### PR TITLE
build(ci): update GitHub Actions and the pnpm pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       run:
         working-directory: apps/backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: denoland/setup-deno@v2
         with:
           deno-version: v2.x
@@ -39,12 +39,12 @@ jobs:
       run:
         working-directory: apps/frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
+      - uses: actions/checkout@v7
+      - uses: pnpm/action-setup@v6
         with:
           # Version comes from package.json's "packageManager" field.
           package_json_file: apps/frontend/package.json
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           # Keep in step with apps/frontend/Dockerfile, so CI checks the same
           # Node major that the runtime image ships.
@@ -60,7 +60,7 @@ jobs:
     name: Docker images build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       # The compose stack builds both images from source (no prebuilt images
       # yet), so a broken Dockerfile breaks `install.sh` for everyone. Build both
       # here to catch it before release.

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -4,7 +4,7 @@
   "version": "0.1.0",
   "license": "AGPL-3.0-or-later",
   "type": "module",
-  "packageManager": "pnpm@11.2.2",
+  "packageManager": "pnpm@11.18.0",
   "scripts": {
     "dev": "vite dev",
     "build": "vite build",


### PR DESCRIPTION
actions/checkout v4 -> v7, actions/setup-node v4 -> v7, pnpm/action-setup v4 -> v6, and pnpm 11.2.2 -> 11.18.0.

Old action majors run on Node runtimes GitHub eventually retires, so these were the stalest thing in the repo. setup-node v6 narrowed *automatic* caching to npm, but the explicit `cache: pnpm` input is still supported in v7, so the frontend cache config is unchanged.

denoland/setup-deno stays at v2 — already the current major.