### PR TITLE
build(compose): move Redis 7 -> 8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,15 @@ services:
   # config editing; the backend picks it up via REDIS_URL below. Not published on
   # the host — only the backend reaches it over the compose network.
   redis:
-    image: redis:7-alpine
+    # Redis 8 rather than 7: 7.4 is RSALv2/SSPLv1 only, neither of which is open
+    # source, so the bundled container path shipped a non-free component. Redis 8
+    # restores AGPLv3 as a licensing option, matching this project's own licence.
+    #
+    # Upgrading in place is safe — Redis 8 reads the RDB that 7.4 wrote. Rolling
+    # BACK is not: 7.4 cannot read Redis 8's RDB (format v14) and exits on start.
+    # To return to 7.x, delete the `redis_data` volume; only queued jobs and
+    # undelivered activities live here, never user content.
+    image: redis:8-alpine
     restart: unless-stopped
     # Light persistence so the queue survives a restart of Redis itself.
     command: ["redis-server", "--save", "60", "1", "--appendonly", "no"]


### PR DESCRIPTION
Redis 7.4 is licensed RSALv2/SSPLv1 only, neither OSI-approved, so the bundled container path shipped a non-free component to every self-hoster. Redis 8 restores AGPLv3 as an option, matching Omicron's own licence.

Verified the upgrade in place against a real stack: Redis 8.8.1 loads the RDB written by 7.4.9 with keys, TTLs and list order intact, and only the redis container is recreated on `docker compose up -d`. The backend's ioredis client logs connection errors for the few seconds the container is swapping, then reconnects on its own; the Fedify KV, message queue and job-queue worker all come back cleanly.

Rolling back is one-way: 7.4 cannot read Redis 8's RDB (format v14) and exits with "Can't handle RDB format version 14". Recorded inline, since only regenerable queue state lives there — never user content.