### PR TITLE
fix(tags): keep c++ and c# from collapsing onto c

### DIFF
--- a/apps/backend/src/lib/tags.ts
+++ b/apps/backend/src/lib/tags.ts
@@ -7,6 +7,11 @@
 // We keep unicode letters, digits and underscores (so non-Latin hashtags work,
 // matching Mastodon), lowercase everything, strip a leading `#`, and drop any
 // other punctuation/whitespace. Returns "" for anything that normalizes empty.
+//
+// Language names that end in a symbol are spelled out first, so they survive
+// that strip instead of collapsing onto the wrong tag: `c++` would otherwise
+// become `c`, and `c#`/`f#` would become `c`/`f`. Only a symbol attached to a
+// word is spelled out, so a bare `+` still normalizes away.
 
 export const MAX_TAG_LENGTH = 50;
 export const MAX_TAGS_PER_POST = 5;
@@ -17,6 +22,9 @@ export function normalizeTag(raw: string): string {
     .normalize("NFKC")
     .toLowerCase()
     .replace(/^#+/, "")
+    // `c++` → `cpp`, `notepad++` → `notepadpp`, `c#` → `csharp`.
+    .replace(/(?<=[\p{L}\p{M}\p{N}_])\++/gu, (run) => "p".repeat(run.length))
+    .replace(/(?<=[\p{L}\p{M}\p{N}_])#/gu, "sharp")
     // Keep unicode letters/marks/numbers and underscore; drop everything else
     // (spaces, punctuation, emoji). `u` flag enables the \p{...} classes.
     .replace(/[^\p{L}\p{M}\p{N}_]+/gu, "")

--- a/apps/backend/src/lib/tags_test.ts
+++ b/apps/backend/src/lib/tags_test.ts
@@ -21,6 +21,21 @@ Deno.test("normalizeTag: keeps unicode letters and digits and underscore", () =>
   assertEquals(normalizeTag("web_3"), "web_3");
 });
 
+Deno.test("normalizeTag: spells out a symbol that is part of the name", () => {
+  // Without this these collapse onto `c`/`f` — a different, unrelated tag.
+  assertEquals(normalizeTag("c++"), "cpp");
+  assertEquals(normalizeTag("#C++"), "cpp");
+  assertEquals(normalizeTag("notepad++"), "notepadpp");
+  assertEquals(normalizeTag("c#"), "csharp");
+  assertEquals(normalizeTag("F#"), "fsharp");
+});
+
+Deno.test("normalizeTag: a detached symbol still normalizes away", () => {
+  assertEquals(normalizeTag("+"), "");
+  assertEquals(normalizeTag("+rust"), "rust");
+  assertEquals(normalizeTag("go + rust"), "gorust");
+});
+
 Deno.test("normalizeTag: caps length", () => {
   assertEquals(normalizeTag("a".repeat(80)).length, MAX_TAG_LENGTH);
 });

--- a/apps/frontend/src/lib/tags.ts
+++ b/apps/frontend/src/lib/tags.ts
@@ -12,6 +12,9 @@ export function normalizeTag(raw: string): string {
     .normalize("NFKC")
     .toLowerCase()
     .replace(/^#+/, "")
+    // `c++` → `cpp`, `c#` → `csharp`; see the backend copy for why.
+    .replace(/(?<=[\p{L}\p{M}\p{N}_])\++/gu, (run) => "p".repeat(run.length))
+    .replace(/(?<=[\p{L}\p{M}\p{N}_])#/gu, "sharp")
     .replace(/[^\p{L}\p{M}\p{N}_]+/gu, "")
     .slice(0, MAX_TAG_LENGTH);
 }


### PR DESCRIPTION
Tag slugs drop everything outside letters, digits and underscore, so `c++` normalized to `c` and `c#`/`f#` to `c`/`f` — landing the post on a different, unrelated tag rather than rejecting the input.

Spell out a symbol before the strip when it is attached to a word: `c++` -> `cpp`, `notepad++` -> `notepadpp`, `c#` -> `csharp`. A detached `+` still normalizes away, so this adds no junk tags. Slugs stay within Mastodon's hashtag grammar, so they keep matching over federation and stay usable in a URL path.

Mirrored in the frontend copy that drives the tag input's chips.