### PR TITLE
fix(webhook): partial updates, and render description and banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,19 @@ scoped to you, so they never collide with another writer's. The token also
 travels as `Authorization: Bearer <token>`. An unknown credential gets `401`
 and an invalid payload `400` naming the field.
 
+Updates are partial: send only what changed, and everything you leave out keeps
+its current value. Once the post exists, `slug` alone identifies it, so `title`
+and `body` are needed only on the first send.
+
+```bash
+# Unpublish, without resending the article.
+-d '{"slug": "eu-payments", "status": "draft"}'
+# Retitle it.
+-d '{"slug": "eu-payments", "title": "Europe ditches the card networks"}'
+# Drop the cover — `null` clears a field, leaving it out preserves it.
+-d '{"slug": "eu-payments", "banner": null}'
+```
+
 Operators can also set an instance-wide `WEBHOOK_SECRET` (see
 [.env.example](.env.example)) for publishing without a user token — a migration
 script, say. Full reference:

--- a/apps/backend/src/lib/webhook.ts
+++ b/apps/backend/src/lib/webhook.ts
@@ -99,15 +99,25 @@ const httpUrl = z
   .max(2000)
   .refine((u) => /^https?:\/\/\S+$/i.test(u), "must be an absolute http(s) URL");
 
+// Every field is optional at the schema level, because a delivery addressing a
+// post that already exists is a partial update: send `status` alone to unpublish
+// it, `title` alone after a retitle, and everything left out keeps the value it
+// has. Only a *first* delivery — one that creates the post — needs a title and a
+// body, which `requireCreateFields` enforces once the service knows which it is.
+//
+// A field sent as `null` is an explicit clear, distinct from leaving it out:
+// `banner: null` drops the cover, `description: null` returns the summary to the
+// one derived from the body.
 export const contentSchema = z.object({
-  title: z.string().trim().min(1, "is required").max(300),
-  body: z.string().min(1, "is required"),
-  description: z.string().trim().max(500).optional(),
-  banner: httpUrl.optional(),
+  title: z.string().trim().min(1, "must not be empty").max(300).optional(),
+  body: z.string().min(1, "must not be empty").optional(),
+  description: z.string().trim().max(500).nullish(),
+  banner: httpUrl.nullish(),
   // The external system's stable key for this document. Optional: without it we
   // fall back to the title's slug, which means a retitle publishes a new post.
   // Senders that have a document id should send it — it is the only way an
-  // edited title updates the existing post in place.
+  // edited title updates the existing post in place, and the only way to address
+  // a post at all without resending its title.
   slug: z.string().trim().min(1).max(200).optional(),
   // Passthroughs onto the ordinary post fields, so an ingested post is a
   // first-class one rather than a stripped-down import.
@@ -135,6 +145,26 @@ export function parseContent(body: unknown): ContentPayload {
 }
 
 /**
+ * The fields a payload must carry when there is no post behind its key yet.
+ *
+ * A partial update borrows the absent fields from the row it is updating; a
+ * create has nothing to borrow from, so `title` and `body` become required at
+ * exactly that moment. Raised as the same 400 the schema would have, naming the
+ * field, so a sender that has simply forgotten one reads the same error whether
+ * it sent a bad value or none at all.
+ */
+export function requireCreateFields(payload: ContentPayload): void {
+  for (const field of ["title", "body"] as const) {
+    if (!payload[field]) {
+      throw badRequest(
+        `\`${field}\` is required: no post exists under this key yet, so this ` +
+          `request creates one rather than updating one.`,
+      );
+    }
+  }
+}
+
+/**
  * Derive a short preview from a rendered post body — used when the sender
  * supplies no `description`. Flattening the *rendered* HTML rather than
  * stripping Markdown by hand means every syntax markdown-it understands is
@@ -156,12 +186,15 @@ export function summarize(contentHtml: string, limit = SUMMARY_LENGTH): string {
  * from the title. Slugs are ASCII-only, so a title written entirely in a
  * non-Latin script derives to nothing — that has to be an error rather than an
  * empty key, which the unique index would let exactly one post hold.
+ *
+ * A partial update may carry no title at all, in which case `slug` is the only
+ * thing naming the post and is therefore required.
  */
 export function externalKey(payload: Pick<ContentPayload, "slug" | "title">): string {
-  const key = payload.slug?.trim() || slugify(payload.title);
+  const key = payload.slug?.trim() || (payload.title ? slugify(payload.title) : "");
   if (!key) {
     throw badRequest(
-      "`slug` is required: no key could be derived from this title.",
+      "`slug` is required: no key could be derived from this payload.",
     );
   }
   return key;

--- a/apps/backend/src/lib/webhook_test.ts
+++ b/apps/backend/src/lib/webhook_test.ts
@@ -7,6 +7,7 @@ import {
   looksLikeToken,
   parseContent,
   presentedSecret,
+  requireCreateFields,
   secretMatches,
   summarize,
   SUMMARY_LENGTH,
@@ -112,14 +113,51 @@ Deno.test("parseContent: accepts the minimal payload", () => {
   assertEquals(out.banner, undefined);
 });
 
-Deno.test("parseContent: rejects a missing or empty required field", () => {
-  for (const body of [{ body: "x" }, { title: "x" }, { title: "  ", body: "x" }, {}, null]) {
+Deno.test("parseContent: rejects a present-but-empty field", () => {
+  // Absent is legal — that is a partial update. Present and empty is a mistake.
+  for (const body of [{ title: "  ", body: "x" }, { ...valid, body: "" }, null, 7]) {
     assertThrows(() => parseContent(body), HttpError);
   }
   // The error names the offending field so the sender can fix it.
-  const err = assertThrows(() => parseContent({ body: "x" }), HttpError);
+  const err = assertThrows(() => parseContent({ title: "   " }), HttpError);
   assertStringIncludes(err.message, "title");
   assertEquals(err.status, 400);
+});
+
+Deno.test("parseContent: accepts a partial update carrying one field", () => {
+  // The shape a CMS sends when only the status moved: no title, no body.
+  assertEquals(parseContent({ slug: "doc-42", status: "draft" }).status, "draft");
+  assertEquals(parseContent({ slug: "doc-42", title: "Renamed" }).title, "Renamed");
+  // …and the empty payload, which addresses nothing and is caught by
+  // `externalKey` rather than the schema.
+  assertEquals(parseContent({}).title, undefined);
+});
+
+Deno.test("parseContent: keeps an explicit null distinct from an absent field", () => {
+  // `null` clears the stored value; leaving the key out preserves it. The two
+  // must survive parsing as different things or the service cannot tell them
+  // apart.
+  const cleared = parseContent({ slug: "doc-42", banner: null, description: null });
+  assertEquals(cleared.banner, null);
+  assertEquals(cleared.description, null);
+
+  const absent = parseContent({ slug: "doc-42" });
+  assertEquals(absent.banner, undefined);
+  assertEquals(absent.description, undefined);
+});
+
+Deno.test("requireCreateFields: demanded on a create, waived on an update", () => {
+  // A first delivery has no row to merge into, so it must carry both.
+  for (const payload of [{ body: "x" }, { title: "x" }, {}]) {
+    const err = assertThrows(() => requireCreateFields(parseContent(payload)), HttpError);
+    assertEquals(err.status, 400);
+  }
+  assertStringIncludes(
+    assertThrows(() => requireCreateFields(parseContent({ body: "x" })), HttpError).message,
+    "title",
+  );
+  // A full payload passes; an update never reaches this check at all.
+  requireCreateFields(parseContent(valid));
 });
 
 Deno.test("parseContent: rejects a banner that is not an absolute http(s) URL", () => {
@@ -184,6 +222,15 @@ Deno.test("externalKey: demands an explicit slug when the title derives to nothi
   assertStringIncludes(err.message, "slug");
   // …and is satisfied once the sender supplies one.
   assertEquals(externalKey({ title: "日本語", slug: "doc-7" }), "doc-7");
+});
+
+Deno.test("externalKey: a titleless partial update is addressed by its slug alone", () => {
+  assertEquals(externalKey({ title: undefined, slug: "doc-42" }), "doc-42");
+  // With neither, nothing names the post — that has to be a 400, not a write
+  // against an empty key.
+  const err = assertThrows(() => externalKey({ title: undefined, slug: undefined }), HttpError);
+  assertEquals(err.status, 400);
+  assertStringIncludes(err.message, "slug");
 });
 
 // ── Storage safety ──────────────────────────────────────────────────────────

--- a/apps/backend/src/routes/webhooks.ts
+++ b/apps/backend/src/routes/webhooks.ts
@@ -37,6 +37,12 @@ const ingestLimiter = rateLimit({
  * already published under that key (`slug`, or the title's slug when none is
  * sent). 400 names the offending field; 401 means the credential is unknown.
  *
+ * An update is partial: it writes only the fields it carries, so
+ * `{ "slug": "doc-42", "status": "draft" }` unpublishes a post without
+ * resending its body, and `null` clears a field rather than leaving it. `title`
+ * and `body` are required only on the delivery that creates the post — after
+ * that, `slug` alone identifies it.
+ *
  * Errors never carry the credential: the service compares it without ever
  * putting it in a message, and `handleError` (app.ts) is the only thing that
  * logs, so a 500 records the failure and not the token.

--- a/apps/backend/src/services/webhooks.ts
+++ b/apps/backend/src/services/webhooks.ts
@@ -13,12 +13,13 @@ import {
   hashToken,
   looksLikeToken,
   presentedSecret,
+  requireCreateFields,
   secretMatches,
   summarize,
 } from "@/lib/webhook.ts";
 import { queue } from "@/queue/queue.ts";
 import { config } from "@/config.ts";
-import type { User } from "@/db/schema.ts";
+import type { NewPost, User } from "@/db/schema.ts";
 
 // Content ingestion from an external system (Sanity, Contentful, a static-site
 // build hook, …). One endpoint — POST /api/webhooks/content — takes a document
@@ -122,6 +123,16 @@ export type IngestResult = {
  * ingested document, and hand it to the federation queue exactly the way the
  * editor's own create/update path does.
  *
+ * Updates are **partial**. A delivery addressing a post that already exists
+ * changes only the fields it carries, so a CMS that knows a single field moved
+ * sends that field: `{ "slug": "doc-42", "status": "draft" }` unpublishes,
+ * `{ "slug": "doc-42", "title": "…" }` retitles, and neither has to resend a
+ * body it did not touch. A field sent as `null` is an explicit clear
+ * (`banner: null` drops the cover); a field left out is simply not written.
+ *
+ * A first delivery has nothing to merge into, so `title` and `body` are
+ * required there and nowhere else.
+ *
  * On storage: the body is rendered to sanitized HTML on the way in rather than
  * kept as raw Markdown. `contentHtml` is what the reader renders with `{@html}`
  * and what `buildArticle` federates, and `sanitizePostHtml` is the single
@@ -136,27 +147,9 @@ export async function ingestContent(
 ): Promise<IngestResult> {
   const externalId = externalKey(payload);
 
-  const contentHtml = renderMarkdown(payload.body).trim();
-  if (!contentHtml) throw badRequest("`body` contains no renderable content.");
-
-  const status = payload.status ?? "published";
-  const fields = {
-    title: payload.title,
-    contentHtml,
-    // Ingested posts carry no Tiptap document; opening one in the editor
-    // rehydrates from `contentHtml`, the same as a post imported over
-    // federation.
-    contentJson: null,
-    summary: payload.description || summarize(contentHtml),
-    coverUrl: payload.banner ?? null,
-    status,
-    language: normalizeLanguage(payload.language ?? null),
-  };
-
-  // Read the current row first: the write itself is an upsert (delivery is
-  // at-least-once, so a duplicate must not race into a unique violation), but
-  // the ownership check and the create-vs-update answer both need to know what
-  // was there before it.
+  // Read the current row first. It answers create-vs-update, which in turn
+  // decides both which fields this payload is required to carry and which are
+  // left alone; the ownership check needs it too.
   // The lookup is already scoped to this author, so another writer's identical
   // slug is invisible here and cannot be addressed, let alone overwritten.
   const existing = await postsRepo.findByExternalId(author.id, externalId);
@@ -167,11 +160,60 @@ export async function ingestContent(
     throw conflict("That slug belongs to a post this webhook does not own.");
   }
 
-  const post = await postsRepo.upsertByExternalId({
-    ...fields,
-    authorId: author.id,
-    externalId,
-  });
+  if (!existing) requireCreateFields(payload);
+
+  // Only what the payload actually carries goes into the write; anything absent
+  // keeps the value the row already holds.
+  const fields: Partial<NewPost> = {};
+
+  if (payload.body !== undefined) {
+    const contentHtml = renderMarkdown(payload.body).trim();
+    if (!contentHtml) throw badRequest("`body` contains no renderable content.");
+    fields.contentHtml = contentHtml;
+    // Ingested posts carry no Tiptap document; opening one in the editor
+    // rehydrates from `contentHtml`, the same as a post imported over
+    // federation. Re-cleared on every body change, so an edit made in the
+    // editor and then overwritten from the CMS cannot leave a stale document
+    // behind the fresh HTML.
+    fields.contentJson = null;
+  }
+  if (payload.title !== undefined) fields.title = payload.title;
+  if (payload.banner !== undefined) fields.coverUrl = payload.banner;
+  if (payload.language !== undefined) fields.language = normalizeLanguage(payload.language);
+  if (payload.status !== undefined) fields.status = payload.status;
+  else if (!existing) fields.status = "published";
+
+  // The summary follows the description when one is sent, and is re-derived
+  // from the body whenever the body changes or the description is explicitly
+  // cleared. A sender that curates its own description keeps it by sending it
+  // alongside each body it changes.
+  if (payload.description !== undefined) {
+    fields.summary = payload.description || summarize(summarySource(fields, existing));
+  } else if (fields.contentHtml !== undefined) {
+    fields.summary = summarize(fields.contentHtml);
+  }
+
+  // Creating is an upsert rather than an insert because delivery is
+  // at-least-once: two concurrent first deliveries of the same document would
+  // otherwise both miss the lookup above and race into a unique violation.
+  // Updating needs no such guard — concurrent partial updates of one row settle
+  // as last-write-wins instead of colliding.
+  //
+  // A partial update that touches no post column at all is legitimate — `tags`
+  // is the one field that lives elsewhere, so `{ slug, tags }` is a complete
+  // request — and must not reach the writer, which rejects an empty SET.
+  const post = existing
+    ? Object.keys(fields).length > 0 ? await postsRepo.update(existing.id, fields) : existing
+    : await postsRepo.upsertByExternalId({
+      ...fields,
+      // Guaranteed by `requireCreateFields` on this branch.
+      contentHtml: fields.contentHtml!,
+      authorId: author.id,
+      externalId,
+    });
+
+  // Only reachable when the post was deleted between the lookup and the write.
+  if (!post) throw conflict("That post was removed while this update was in flight.");
 
   // Tags are replaced wholesale when the payload carries the field; omitting it
   // leaves whatever the post already has, and `[]` clears them.
@@ -183,11 +225,18 @@ export async function ingestContent(
   // Update when remote instances already hold a copy, otherwise a Create — and
   // unpublishing one tombstones the copies already delivered.
   const wasPublished = existing?.status === "published";
-  if (status === "published") {
+  if (post.status === "published") {
     queue.add("federate_post", { postId: post.id, action: wasPublished ? "update" : "create" });
   } else if (wasPublished) {
     queue.add("federate_post_delete", { postId: post.id, authorId: author.id });
   }
 
   return { id: post.id, slug: externalId, status: post.status, created: !existing };
+}
+
+// The HTML an auto-derived summary is read from: the body this request brings,
+// else the one already stored. One of the two always exists — a create must
+// carry a body, and an update has a row behind it.
+function summarySource(fields: Partial<NewPost>, existing: { contentHtml: string } | undefined) {
+  return fields.contentHtml ?? existing?.contentHtml ?? "";
 }

--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -13,8 +13,19 @@
   let { post }: { post: Post } = $props();
 
   const signedIn = $derived(!!page.data.user);
-  const summary = $derived(excerpt(post.contentHtml));
+  // An ingested post carries its own preview (the CMS's `description`); anything
+  // written in the editor has none, so fall back to clipping the body.
+  const summary = $derived(post.summary?.trim() || excerpt(post.contentHtml));
   const minutes = $derived(readTime(post.contentHtml));
+
+  // The cover is a URL on someone else's host, so a dead link is an ordinary
+  // outcome rather than a bug. Drop the image on error instead of leaving a
+  // broken-image glyph in the card.
+  let coverFailed = $state(false);
+  $effect(() => {
+    void post.coverUrl;
+    coverFailed = false;
+  });
   // Remote authors carry a `user@host` handle; surface the origin instance
   // (the host) rather than a generic "Federated" label.
   const originInstance = $derived(post.author.username.split("@")[1] ?? null);
@@ -34,14 +45,28 @@
   </div>
 
   <Button href={postPath(post)} variant="plain" class="group block w-full text-left">
-    {#if post.title}
-      <h2 class="text-xl font-bold leading-snug text-foreground group-hover:text-foreground-alt sm:text-2xl">
-        {post.title}
-      </h2>
-    {/if}
-    {#if summary}
-      <p class="mt-1.5 line-clamp-3 text-muted-foreground">{summary}</p>
-    {/if}
+    <div class="flex items-start gap-4">
+      <div class="min-w-0 flex-1">
+        {#if post.title}
+          <h2 class="text-xl font-bold leading-snug text-foreground group-hover:text-foreground-alt sm:text-2xl">
+            {post.title}
+          </h2>
+        {/if}
+        {#if summary}
+          <p class="mt-1.5 line-clamp-3 text-muted-foreground">{summary}</p>
+        {/if}
+      </div>
+      {#if post.coverUrl && !coverFailed}
+        <!-- Decorative: the title beside it already names the post. -->
+        <img
+          src={post.coverUrl}
+          alt=""
+          loading="lazy"
+          onerror={() => (coverFailed = true)}
+          class="mt-1 h-20 w-28 shrink-0 rounded-card border border-border object-cover sm:h-24 sm:w-36"
+        />
+      {/if}
+    </div>
   </Button>
 
   {#if post.tags?.length}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -55,6 +55,13 @@ export type Post = {
   // BCP-47 primary language subtag (e.g. "en", "tr"), or null/undefined when the
   // author didn't specify one.
   language?: string | null;
+  // Short plain-text preview, set by an ingesting CMS (`description` on the
+  // content webhook) or derived from the body on ingest. Null for posts written
+  // in the editor, whose preview the card derives itself.
+  summary?: string | null;
+  // Absolute http(s) URL of the banner image, hosted by whoever sent it. Null
+  // unless the post carries one.
+  coverUrl?: string | null;
   createdAt: string;
   author: PostAuthor;
   tags: Tag[];

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -18,6 +18,16 @@
   let { data }: { data: PageData } = $props();
   const post = $derived(data.post);
   const minutes = $derived(readTime(post.contentHtml));
+  // The CMS's `description` on an ingested post, shown as a lede under the
+  // headline. Editor-written posts have none and simply skip it — unlike the
+  // card, an open article needs no clipped stand-in for a body it is showing.
+  const summary = $derived(post.summary?.trim() || "");
+  // A cover lives on whoever sent it; drop it rather than render a broken image.
+  let coverFailed = $state(false);
+  $effect(() => {
+    void post.coverUrl;
+    coverFailed = false;
+  });
   // Origin instance (host) parsed from a remote author's `user@host` handle.
   const originInstance = $derived(post.author.username.split("@")[1] ?? null);
 
@@ -235,7 +245,11 @@
   {/if}
 
   {#if post.title}
-    <h1 class="mb-6 text-3xl font-bold leading-tight tracking-tight text-foreground sm:text-4xl">{post.title}</h1>
+    <h1 class="mb-4 text-3xl font-bold leading-tight tracking-tight text-foreground sm:text-4xl">{post.title}</h1>
+  {/if}
+
+  {#if summary}
+    <p class="mb-6 text-lg leading-relaxed text-muted-foreground">{summary}</p>
   {/if}
 
   <div class="flex items-center gap-3 pb-8">
@@ -300,6 +314,16 @@
       </DropdownMenu.Portal>
     </DropdownMenu.Root>
   </div>
+
+  {#if post.coverUrl && !coverFailed}
+    <!-- Decorative: the headline above it already names the post. -->
+    <img
+      src={post.coverUrl}
+      alt=""
+      onerror={() => (coverFailed = true)}
+      class="mb-8 max-h-[28rem] w-full rounded-card border border-border object-cover"
+    />
+  {/if}
 
   <!-- Content is server-rendered HTML produced by the Tiptap editor. -->
   <div class="prose-omicron" bind:this={contentEl}>


### PR DESCRIPTION
An update addressing an existing post now writes only the fields it carries, so a CMS that knows one field moved sends that field: `status` alone unpublishes, `title` alone retitles, and neither resends a body it did not touch. `null` clears a field where leaving it out preserves it. `title` and `body` are required only on the delivery that creates the post — after that `slug` identifies it, which is also why `externalKey` no longer assumes a title is present.

The reader never showed either of the two fields ingest already accepted. `description` was stored, serialized, and dropped: the frontend Post type did not declare it and the card derived its own excerpt from the body instead. `coverUrl` was stored and federated as the Article image but had no reference anywhere in the frontend. Both now render — on the card and on the article — and both fall back gracefully when the remote image fails to load.