### PR TITLE
Fix/anubis challenge hang

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -104,6 +104,13 @@
 # the API are never challenged. The backend toggles it through Caddy's internal
 # admin API; override only if you run Caddy elsewhere.
 #CADDY_ADMIN_URL=http://caddy:2019
+# Hostnames a solved challenge is allowed to send a visitor back to, comma
+# separated. Unset, Anubis will honour any domain — fine for a private or local
+# instance, but on a public one it is an open redirect someone can point at their
+# own site. List every hostname this instance actually answers on, not just the
+# canonical one: a reader who arrived on `www.` solves the challenge on `www.`
+# and is refused the redirect if it is missing here.
+#ANUBIS_REDIRECT_DOMAINS=example.com,www.example.com
 
 # ── Networking / storage (usually leave as-is) ──
 #PORT=8000

--- a/Caddyfile
+++ b/Caddyfile
@@ -42,6 +42,35 @@
 	# it — is also what Anubis's install docs ask a reverse proxy to do.
 	request_header X-Real-IP {remote_host}
 
+	# Anubis's challenge page is a race waiting to happen, and these two files are
+	# the trigger. The page loads its script as `<script async type="module">`, so
+	# it runs the moment it is *available* rather than after the document is
+	# parsed — but the `#progress` element it dereferences is declared ~3 KB
+	# further down the HTML. Anubis serves both this script and its locale JSON
+	# with `Cache-Control: public, max-age=31536000` and no ETag, so from the
+	# second visit onwards both resolve straight out of disk cache with no network
+	# delay, the script wins the race, `getElementById("progress")` returns null,
+	# and the TypeError lands outside the page's own try/catch: the visitor is
+	# stuck on "Calculating… Difficulty: 4," forever. (Anubis's built-in reload
+	# watchdog can't help — the script had already set `window.__anubisBooted`
+	# before it threw.) Pressing reload revalidates the subresources, which is
+	# exactly why a refresh "fixes" it.
+	#
+	# Forcing revalidation on just these two puts a round trip back in front of
+	# the script, so the parser always reaches `#progress` first. Anubis sends no
+	# validator, so this costs a full re-fetch (~11 KB) — but only on challenge
+	# pages, and only while the shield is on. Everything else Anubis serves (CSS,
+	# mascot images, the PoW worker) keeps its long cache lifetime.
+	#
+	# Upstream bug, not ours: drop this block once Anubis ships the script as
+	# deferred or moves `#progress` above it.
+	#
+	# `>` defers the set until the response is being written. Without it this runs
+	# before the proxy and Anubis's own header is *added* alongside ours, leaving
+	# the response with two conflicting Cache-Control values.
+	@anubis_boot path /.within.website/x/cmd/anubis/static/js/main.mjs /.within.website/x/cmd/anubis/static/locales/*
+	header @anubis_boot >Cache-Control "no-cache"
+
 	@federation path /.well-known/* /users/* /inbox /nodeinfo /nodeinfo/*
 	handle @federation {
 		reverse_proxy backend:8000

--- a/Caddyfile
+++ b/Caddyfile
@@ -32,6 +32,16 @@
 		X-Content-Type-Options nosniff
 	}
 
+	# Anubis reads the client IP from X-Real-IP and refuses the request outright
+	# ("[misconfiguration] X-Real-Ip header is not set") when it can't determine
+	# one — Caddy sends X-Forwarded-For but never X-Real-IP. The fallback to XFF
+	# is not enough here: XFF_STRIP_PRIVATE drops private hops, so any client on
+	# a private network (localhost, LAN, a CGNAT/VPN edge, a Docker bridge in dev)
+	# leaves Anubis with an empty XFF and every request 500s. Setting it here —
+	# unconditionally, from the connection's real peer, so a client can't spoof
+	# it — is also what Anubis's install docs ask a reverse proxy to do.
+	request_header X-Real-IP {remote_host}
+
 	@federation path /.well-known/* /users/* /inbox /nodeinfo /nodeinfo/*
 	handle @federation {
 		reverse_proxy backend:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -193,6 +193,18 @@ services:
       # (including a routine upgrade) silently invalidates every visitor's proof
       # of work and walls the whole readership behind a fresh challenge.
       ED25519_PRIVATE_KEY_HEX_FILE: /run/secrets/anubis_ed25519_key
+      # Hostnames a solved challenge may bounce back to. Left empty Anubis will
+      # redirect to whatever domain the `redir` parameter names — an open
+      # redirect worth closing on a public instance.
+      #
+      # Not derived from APP_DOMAIN, deliberately: this instance answers on every
+      # hostname pointed at it (apex, `www.`, a bare IP) and only canonicalises
+      # later, in the app — which sits *behind* Anubis. Narrowing this to the one
+      # canonical domain would let a visitor who arrived on any other hostname
+      # solve the challenge and then be refused the redirect. So it stays opt-in,
+      # and the operator lists every hostname they actually serve. See
+      # ANUBIS_REDIRECT_DOMAINS in .env.example.
+      REDIRECT_DOMAINS: ${ANUBIS_REDIRECT_DOMAINS:-}
       METRICS_BIND: ":9090"
       POLICY_FNAME: "/data/cfg/botPolicy.yaml"
       # PoW cost. 4 is Anubis's default — light on real browsers.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,10 @@
 # volume and secrets in the `secrets` volume, so upgrades never lose content.
 
 services:
-  # Generates any missing secrets once, then exits. Both postgres and backend
-  # depend on it completing, so the files always exist before they start.
+  # Generates any missing secrets once, then exits. Postgres, the backend and
+  # Anubis depend on it completing, so the files always exist before they start.
+  # Each is 32 random bytes as 64 hex characters — which is also exactly the
+  # Ed25519 seed length Anubis wants for anubis_ed25519_key.
   init-secrets:
     image: alpine:3
     command:
@@ -25,7 +27,7 @@ services:
       - -c
       - |
         set -e
-        for name in db_password session_secret; do
+        for name in db_password session_secret anubis_ed25519_key; do
           f="/secrets/$$name"
           if [ ! -s "$$f" ]; then
             head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$$f"
@@ -33,6 +35,11 @@ services:
             echo "generated $$name"
           fi
         done
+        # Anubis runs unprivileged (uid 1000) from a distroless image and cannot
+        # read a root-owned 0600 file, so hand it ownership of its own key —
+        # only that one, and every boot rather than only at generation, so an
+        # instance upgrading into this also gets fixed.
+        chown 1000 /secrets/anubis_ed25519_key
     volumes:
       - secrets:/secrets
 
@@ -164,8 +171,9 @@ services:
   # can't pass but real browsers solve in ~1s. It always runs but only sits in
   # the request path when an admin enables protection (Admin → Security), which
   # makes Caddy route the app branch here instead of straight to the frontend.
-  # Federation and the API never pass through it. Its signing key is ephemeral,
-  # so a restart re-challenges readers once — a fine trade for zero config.
+  # Federation and the API never pass through it. Its signing key is generated
+  # once into the `secrets` volume, so restarts and upgrades don't re-challenge
+  # readers who have already solved a proof of work.
   anubis:
     # Pinned to a specific release so an upgrade is a deliberate bump, never a
     # silent breaking change on the next pull. Check for newer stable tags at
@@ -173,10 +181,18 @@ services:
     image: ghcr.io/techarohq/anubis:v1.26.2
     restart: unless-stopped
     depends_on:
-      - frontend
+      init-secrets:
+        condition: service_completed_successfully
+      frontend:
+        condition: service_started
     environment:
       BIND: ":8080"
       TARGET: "http://frontend:3000"
+      # Sign challenge cookies with a key that persists across restarts. Without
+      # it Anubis generates a random key at boot, so every `docker compose up`
+      # (including a routine upgrade) silently invalidates every visitor's proof
+      # of work and walls the whole readership behind a fresh challenge.
+      ED25519_PRIVATE_KEY_HEX_FILE: /run/secrets/anubis_ed25519_key
       METRICS_BIND: ":9090"
       POLICY_FNAME: "/data/cfg/botPolicy.yaml"
       # PoW cost. 4 is Anubis's default — light on real browsers.
@@ -199,6 +215,7 @@ services:
       OG_EXPIRY_TIME: "24h"
     volumes:
       - ./botPolicy.yaml:/data/cfg/botPolicy.yaml:ro
+      - secrets:/run/secrets:ro
 
   # Public entrypoint: terminates TLS and reverse-proxies to frontend/backend.
   # Obtains Let's Encrypt certificates on demand for the instance's own domain


### PR DESCRIPTION
With the AI-scraper shield on, opening the site leaves the reader on a frozen challenge page. Refreshing loads it normally.

Anubis loads its script as `<script async type="module">` but declares the `#progress` element that script uses further down the HTML, and serves the script with a one-year cache and no ETag. From the second visit it runs from cache before the parser reaches `#progress` and throws outside its own `try/catch`. Forcing revalidation on that script makes the parser win. Upstream bug.

Three other Anubis defects fixed while reproducing it:

- Caddy never sent `X-Real-IP` and `XFF_STRIP_PRIVATE` empties the fallback, so requests from a private client IP 500'd.
- A random signing key per boot re-challenged every reader on each restart and upgrade. Now persisted in the `secrets` volume.
- Added `ANUBIS_REDIRECT_DOMAINS` to close the post-challenge open redirect. Opt-in, empty by default.

Deploy needs `--force-recreate` (the Caddyfile is a bind mount). New env var, so omicron-docs needs a follow-up.