### PR TITLE
fix(posts): typeset bare quantities the backfill mistook for prices

### DIFF
--- a/apps/backend/src/lib/legacyMath.ts
+++ b/apps/backend/src/lib/legacyMath.ts
@@ -22,20 +22,34 @@ const CODE = /<(pre|code)\b[\s\S]*?<\/\1>/gi;
 
 /** `$$…$$` first, so its delimiters are never read as two inline formulas. */
 const DISPLAY = /\$\$([\s\S]+?)\$\$/g;
-/** Inline maths stays within one line, the way every `$…$` dialect has it. */
-const INLINE = /\$([^$\n]+?)\$/g;
+/**
+ * Inline maths stays within one line, the way every `$…$` dialect has it, and
+ * the delimiters must hug their content (`$x$`, never `$ x$`) with no digit
+ * after the closer — the same rule the live renderer uses (see lib/markdown.ts),
+ * and the one that keeps "it costs $5 and $6" a pair of prices.
+ */
+const INLINE = /\$(?!\s)([^$\n]+?)(?<!\s)\$(?!\d)/g;
+
+/**
+ * A bare quantity — `$d$`, `$1/2$`, `$0.4999993$` — carries no command, script
+ * or group, yet it is still a formula an author typed. What it does have is
+ * shape: a single unspaced run of symbols, digits and the operators between
+ * them. Prose that happened to fall between two dollar signs has spaces in it
+ * and fails here.
+ */
+const BARE = /^[A-Za-z0-9]+(?:[./+\-*=][A-Za-z0-9]+)*$/;
 
 /**
  * Does this look like TeX rather than money? A formula worth rendering carries a
- * command, a script or a group; "it costs $5 and $6" carries none of them, and
- * anything that reached storage as plain prose stays prose.
+ * command, a script or a group, or else is a bare quantity; "it costs $5 and $6"
+ * is neither, and anything that reached storage as plain prose stays prose.
  *
- * A bare symbol — `$d$`, `$n$` — has none of those marks either, so it is let
- * through on a second test: one short word, no spaces, and a letter in it. A
- * price is several words ("$5 and $6") or no letters at all, and fails both.
+ * This is the second of two guards. The first is INLINE itself, which already
+ * refuses the delimiter spacing prices are written with — so what reaches here
+ * is a candidate, not a certainty.
  */
 function looksLikeTex(source: string): boolean {
-  return /[\\^_{}]/.test(source) || /^[A-Za-z][A-Za-z0-9]{0,3}$/.test(source);
+  return /[\\^_{}]/.test(source) || BARE.test(source);
 }
 
 /**

--- a/apps/backend/src/lib/legacyMath_test.ts
+++ b/apps/backend/src/lib/legacyMath_test.ts
@@ -92,6 +92,28 @@ Deno.test("legacy maths: a lone symbol is a formula, a price is not", () => {
   assertStringIncludes(out, "costs $5 and $6.");
 });
 
+Deno.test("legacy maths: a bare quantity is a formula too", () => {
+  // The paragraph that prompted this: every one of these stayed literal, so a
+  // rendered post was still speckled with dollar signs.
+  const out = upgradeLegacyMath(
+    "<p>approaches $1/2$ asymptotically (reaching $0.4999993$ at extreme " +
+      "parameters), from $0.05055$ to $0.00341$).</p>",
+  );
+  assertEquals(out.includes("$"), false);
+  assertStringIncludes(out, "<math");
+});
+
+Deno.test("legacy maths: prices sharing a paragraph with a formula stay prices", () => {
+  const html = "<p>Seats are $10 or $20, and shipping is $5 and $6.</p>";
+  assertEquals(upgradeLegacyMath(html), html);
+});
+
+Deno.test("legacy maths: a price the closer does not lead with a digit", () => {
+  // "$5 and $x" hugs no better than "$5 and $6": the closer sits after a space.
+  const html = "<p>It costs $5 and up to $twelve.</p>";
+  assertEquals(upgradeLegacyMath(html), html);
+});
+
 Deno.test("legacy maths: an escape Markdown ate is put back", () => {
   // `\left\{ … \right\}` reached storage as `\left{ … \right}`, which KaTeX
   // cannot parse at all — so restoring the backslash can only help.


### PR DESCRIPTION
`$1/2$` and `$0.05055$` carry no TeX command, script or group, so the backfill's maths-or-money test refused them and the reader kept showing literal dollar signs mid-sentence.

Tell the two apart by shape instead of by content: the inline delimiters now have to hug what they wrap, with no digit after the closer — the rule the live renderer already uses, and the one prices fail. With money ruled out structurally, a bare unspaced quantity can be accepted as the formula it is.