### PR TITLE
feat(frontend): set post content in Source Sans 3

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",
+    "@fontsource-variable/source-sans-3": "^5.3.0",
     "@internationalized/date": "^3.12.2",
     "@lucide/svelte": "^1.27.0",
     "@tiptap/core": "^3.29.2",

--- a/apps/frontend/pnpm-lock.yaml
+++ b/apps/frontend/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@fontsource-variable/inter':
         specifier: ^5.3.0
         version: 5.3.0
+      '@fontsource-variable/source-sans-3':
+        specifier: ^5.3.0
+        version: 5.3.0
       '@internationalized/date':
         specifier: ^3.12.2
         version: 3.12.2
@@ -114,6 +117,9 @@ packages:
 
   '@fontsource-variable/inter@5.3.0':
     resolution: {integrity: sha512-OupL48va4JNofb97w6NYeF9S7W/kHNKM0Er8Dem5nqi4jeOLrVJDoE8tZEpnMJmtkvNbB1EIPPwHcdkF6b1oUA==}
+
+  '@fontsource-variable/source-sans-3@5.3.0':
+    resolution: {integrity: sha512-dpi0GZk7EQe2tYpg6Q0Fx0OmUgnuGu+0rHPgtXqtKhglYmJuP7jZ12Mu1uN+NfRaJRY1Emn8AQJEWzmoZ4wa9g==}
 
   '@internationalized/date@3.12.2':
     resolution: {integrity: sha512-FY1Y+H64NDs+HAF6omlnWxm3mEpfgaCSWtL5l551ZZfImA+kGjPFgrnJrGjH6lfmLL0g8Z/mBu1R3kufeCp6Jw==}
@@ -1448,6 +1454,8 @@ snapshots:
   '@floating-ui/utils@0.2.12': {}
 
   '@fontsource-variable/inter@5.3.0': {}
+
+  '@fontsource-variable/source-sans-3@5.3.0': {}
 
   '@internationalized/date@3.12.2':
     dependencies:

--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -3,11 +3,19 @@
    font's unicode-range and renders with `font-display: swap`. */
 @import "@fontsource-variable/inter/index.css";
 
+/* Self-hosted Source Sans 3 (variable), used only for rendered post content
+   (`.prose-omicron`, see below) — the interface stays on Inter. The italic
+   file is imported as well so emphasis in a post uses the real italic cuts
+   instead of a browser-synthesised oblique. Same unicode-range subsetting and
+   `font-display: swap` as Inter. */
+@import "@fontsource-variable/source-sans-3/index.css";
+@import "@fontsource-variable/source-sans-3/wght-italic.css";
+
 /* Twemoji as a self-hosted COLR colour font (CC-BY 4.0, from
    `twemoji-colr-font`; the .woff2 lives in static/fonts). Scoped with
    `unicode-range` to emoji codepoints only, so Latin/CJK text still renders
-   with Inter/Georgia and the browser fetches this font lazily — only when an
-   emoji actually appears. Listing "Twemoji" first in the sans/serif stacks
+   with Inter/Source Sans 3 and the browser fetches this font lazily — only when
+   an emoji actually appears. Listing "Twemoji" first in each font stack
    (tailwind.config.ts) then makes every user see the same Twemoji artwork
    regardless of their OS, while the document keeps plain Unicode emoji
    (federation-friendly, selectable, copyable). ZWJ (200D), the emoji variation
@@ -175,10 +183,12 @@ html {
   }
 }
 
-/* Rendered post content (the HTML produced by Tiptap). Medium-like serif
-   reading column — generous size, relaxed leading. Extend as the editor grows. */
+/* Rendered post content (the HTML produced by Tiptap). Its own reading face —
+   Source Sans 3, not the interface's Inter — at a generous size with relaxed
+   leading. Code, keys and maths keep their own faces below. Extend as the
+   editor grows. */
 .prose-omicron {
-  @apply font-serif text-[1.125rem] leading-[1.75] text-foreground sm:text-[1.25rem] sm:leading-[1.8];
+  @apply font-content text-[1.125rem] leading-[1.75] text-foreground sm:text-[1.25rem] sm:leading-[1.8];
 }
 /* Media never overflows the reading column on narrow screens. */
 .prose-omicron img,
@@ -186,22 +196,22 @@ html {
   @apply mx-auto my-6 h-auto max-w-full rounded-card;
 }
 .prose-omicron h1 {
-  @apply mt-10 mb-4 font-sans text-3xl font-bold tracking-tight text-foreground;
+  @apply mt-10 mb-4 font-content text-3xl font-bold tracking-tight text-foreground;
 }
 .prose-omicron h2 {
-  @apply mt-8 mb-3 font-sans text-2xl font-bold tracking-tight text-foreground;
+  @apply mt-8 mb-3 font-content text-2xl font-bold tracking-tight text-foreground;
 }
 .prose-omicron h3 {
-  @apply mt-7 mb-2 font-sans text-xl font-bold tracking-tight text-foreground;
+  @apply mt-7 mb-2 font-content text-xl font-bold tracking-tight text-foreground;
 }
 .prose-omicron h4 {
-  @apply mt-6 mb-2 font-sans text-lg font-semibold tracking-tight text-foreground;
+  @apply mt-6 mb-2 font-content text-lg font-semibold tracking-tight text-foreground;
 }
 .prose-omicron h5 {
-  @apply mt-6 mb-2 font-sans text-base font-semibold tracking-tight text-foreground;
+  @apply mt-6 mb-2 font-content text-base font-semibold tracking-tight text-foreground;
 }
 .prose-omicron h6 {
-  @apply mt-6 mb-2 font-sans text-sm font-semibold uppercase tracking-wide text-muted-foreground;
+  @apply mt-6 mb-2 font-content text-sm font-semibold uppercase tracking-wide text-muted-foreground;
 }
 .prose-omicron p {
   @apply my-5;
@@ -248,7 +258,7 @@ html {
   @apply border border-border px-3 py-2 text-left align-top;
 }
 .prose-omicron th {
-  @apply bg-muted font-sans text-sm font-semibold text-foreground;
+  @apply bg-muted font-content text-sm font-semibold text-foreground;
 }
 /* A cell written in the editor holds a paragraph, not bare text (ProseMirror
    tables are block content), and a paragraph's own margins inside a cell would
@@ -269,7 +279,7 @@ html {
   @apply my-5 rounded-card border border-border bg-background px-4 py-3;
 }
 .prose-omicron summary {
-  @apply cursor-pointer font-sans text-base font-medium text-foreground marker:text-muted-foreground;
+  @apply cursor-pointer font-content text-base font-medium text-foreground marker:text-muted-foreground;
 }
 .prose-omicron kbd {
   @apply rounded border border-border bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-foreground;

--- a/apps/frontend/tailwind.config.ts
+++ b/apps/frontend/tailwind.config.ts
@@ -58,7 +58,17 @@ export default {
         // glyphs — text still renders with Inter/Georgia. This gives consistent
         // Twemoji artwork across every OS without touching stored content.
         sans: ["Twemoji", "Inter Variable", "Inter", "ui-sans-serif", "system-ui", "sans-serif"],
-        // Medium-like reading typography for rendered post content.
+        // Reading typography for rendered post content (`.prose-omicron`).
+        content: [
+          "Twemoji",
+          "Source Sans 3 Variable",
+          "Source Sans 3",
+          "ui-sans-serif",
+          "system-ui",
+          "sans-serif",
+        ],
+        // Kept for maths (MathML renders best with a serif) and anything else
+        // that asks for a serif explicitly.
         serif: ["Twemoji", "Georgia", "Cambria", "Times New Roman", "serif"],
       },
     },


### PR DESCRIPTION
## Symptom

Post bodies render in Georgia, a serif that sits oddly next to the rest of the
product and that resolves to a different face on every OS that lacks it. The
reading column and the interface look like they came from two different eras.

## Change

Rendered post content now uses **Source Sans 3**, self-hosted as a variable font
via `@fontsource-variable/source-sans-3` — no third-party request, the browser
fetches only the unicode-range subsets it needs, `font-display: swap`, same setup
as the existing Inter import.

The switch is scoped to `.prose-omicron`, which covers the rendered article and
the Tiptap editing surface that shares the class (`Editor.svelte:295`), so the
editor shows what the reader gets. A new `font-content` family in
`tailwind.config.ts` carries the stack; `font-serif` stays for maths.

Deliberately unchanged:

- the interface — still Inter (`font-sans`)
- `pre` / `code` / `kbd` — still monospace
- `math` — still the serif stack, which is what the browser's own MathML layout
  expects
- the code-block language badge, which is chrome rather than content

Headings, table headers and `<summary>` **inside** the content did move with the
body. They were on Inter to contrast with the serif; against Source Sans 3 a
second sans reads as an inconsistency rather than a contrast.

The italic file is imported alongside the normal one so emphasis in a post uses
the real italic cuts instead of a browser-synthesised oblique.

## Verified

- `pnpm build` succeeds.
- Compiled CSS contains
  `.prose-omicron{font-family:Twemoji, Source Sans 3 Variable, Source Sans 3, ui-sans-serif, system-ui, sans-serif; …}`.
- Both the normal and italic woff2 subsets are emitted into the client build.

Not verified: I have not looked at a rendered post in a browser. Whether Source
Sans 3 at the current 1.125/1.25rem and 1.75/1.8 leading reads as well as Georgia
did is a judgement call best made on screen — the metrics were tuned for a serif
and may want a nudge.

## Deploy notes

None beyond a normal rebuild; the fonts ship as build assets.
