### PR TITLE
fix(markdown): keep a footnote star inside bold literal

### DIFF
--- a/apps/backend/src/lib/markdown.ts
+++ b/apps/backend/src/lib/markdown.ts
@@ -179,6 +179,65 @@ md.core.ruler.push("omicron_loose_strong", (state) => {
   }
 });
 
+// A lone `*` written inside a bold span — the footnote star, `**zero* server
+// cost,**` — is a literal asterisk to everyone but the parser.
+//
+// CommonMark pairs delimiters greedily and does not care that the opener is a
+// `**` run: the single `*` closes against half of it, the other half then closes
+// against the trailing `**`, and the reader gets `<em><em>zero</em> server
+// cost,</em>*`. Bold became italic and the star moved from the word it marked to
+// the end of the sentence. Escaping it (`zero\*`) renders correctly, but a body
+// arriving over the content webhook has usually been through a CMS or an
+// HTML-to-Markdown step that dropped the backslash, and the author never sees
+// the source we are handed.
+//
+// So a `*` run of length one that can only close is not allowed to break into a
+// longer opening run: it stays text, and the `**` pair closes with each other as
+// written. The scan tracks the same open/close stack the parser will, which is
+// what keeps genuine nesting intact — in `**a *b* c**` the single closer has a
+// single opener to pair with, and in `**a *b***` the closing run is three long,
+// so neither is touched.
+//
+// It runs before `balance_pairs`, the rule that does the matching, because
+// afterwards the wrong pairing is already tokens.
+
+/** The `*` codepoint, as markdown-it stores a delimiter's marker. */
+const ASTERISK = 0x2a;
+
+/** One entry of markdown-it's delimiter list; `length` is its whole run's. */
+type Delimiter = { marker: number; length: number; open: boolean; close: boolean };
+
+function keepLiteralStars(delimiters: Delimiter[]): void {
+  // Openers still waiting for their closer, innermost last.
+  const open: Delimiter[] = [];
+
+  for (const d of delimiters) {
+    if (d.marker !== ASTERISK) continue; // `_` and `~~` pair among themselves
+
+    if (d.close) {
+      const opener = open[open.length - 1];
+      // The footnote star: one asterisk, usable only as a closer, and the
+      // nearest thing to close is a `**`/`***` run it would have to split.
+      if (!d.open && d.length === 1 && opener && opener.length > 1) {
+        d.open = false;
+        d.close = false;
+        continue; // the opener stays open, for the closer the author wrote
+      }
+      if (opener) open.pop();
+    }
+    if (d.open) open.push(d);
+  }
+}
+
+md.inline.ruler2.before("balance_pairs", "omicron_literal_star", (state) => {
+  keepLiteralStars(state.delimiters as unknown as Delimiter[]);
+  // Inline content nested in a link or an image carries its own list.
+  for (const meta of state.tokens_meta) {
+    if (meta?.delimiters) keepLiteralStars(meta.delimiters as unknown as Delimiter[]);
+  }
+  return false;
+});
+
 // Optional filename on a fence, the way docs sites spell it:
 //
 //     ```ts title="@/lib/name.ts"

--- a/apps/backend/src/lib/markdown_test.ts
+++ b/apps/backend/src/lib/markdown_test.ts
@@ -161,6 +161,46 @@ Deno.test("markdown: code keeps its asterisks", () => {
   assertStringIncludes(renderMarkdown("```\n**not bold **\n```"), "**not bold **");
 });
 
+// ── The footnote star inside bold ───────────────────────────────────────────
+
+Deno.test("markdown: a footnote star inside bold stays where it was typed", () => {
+  // CommonMark closes the `**` opener against the single `*`, which turns the
+  // bold into nested italics and drops the star at the end of the sentence:
+  // `<em><em>zero</em> server cost,</em>*`.
+  const out = renderMarkdown("It also means **zero* server cost,** the server just returns.");
+  assertStringIncludes(out, "<strong>zero* server cost,</strong>");
+  assertEquals(out.includes("<em>"), false);
+});
+
+Deno.test("markdown: an escaped star renders the same as a bare one", () => {
+  // The escaped form is what an author writes; the bare one is what survives a
+  // CMS. Both are the same sentence, so both must read the same.
+  const escaped = renderMarkdown(String.raw`**zero\* server cost,**`);
+  assertEquals(escaped, renderMarkdown("**zero* server cost,**"));
+  assertStringIncludes(escaped, "<strong>zero* server cost,</strong>");
+});
+
+Deno.test("markdown: genuine italics inside bold still nest", () => {
+  // The single closer has a single opener to pair with here, so nothing is
+  // reinterpreted — this is the case the rule must not break.
+  assertStringIncludes(renderMarkdown("**a *b* c**"), "<strong>a <em>b</em> c</strong>");
+  // And the same with the two closers written as one `***` run.
+  assertStringIncludes(renderMarkdown("**a *b***"), "<strong>a <em>b</em></strong>");
+  assertStringIncludes(renderMarkdown("*a **b** c*"), "<em>a <strong>b</strong> c</em>");
+});
+
+Deno.test("markdown: an ordinary star outside bold is untouched", () => {
+  assertStringIncludes(renderMarkdown("**bold** and a star* here"), "and a star* here");
+  assertStringIncludes(renderMarkdown("2 * 3 * 4"), "2 * 3 * 4");
+  assertStringIncludes(renderMarkdown("*italic* alone"), "<em>italic</em> alone");
+});
+
+Deno.test("markdown: the star is repaired inside a link's own inline run", () => {
+  // Link content carries its own delimiter list, which the rule has to walk too.
+  const out = renderMarkdown("[**zero* cost**](https://kofe.al)");
+  assertStringIncludes(out, "<strong>zero* cost</strong>");
+});
+
 // ── Fence titles ────────────────────────────────────────────────────────────
 
 Deno.test("markdown: a fence carries its optional filename", () => {


### PR DESCRIPTION
## Symptom

A post ingested over the content webhook rendered this sentence

> It also means **zero\* server cost,** the server just returns the same file again and again, like a CDN.

as *zero server cost,\** — italic instead of bold, and the footnote star moved off the word it marks to the end of the phrase. The same sentence on the author's own site is bold, with the star still on "zero".

## Root cause

The body that reaches Omicron carries the star unescaped: `**zero* server cost,**`. That is enough on its own. CommonMark matches emphasis delimiters greedily and does not care that the opener is a `**` run, so the lone `*` closes against half of it and the trailing `**` closes against the rest:

```
**zero* server cost,**   ->   <em><em>zero</em> server cost,</em>*
```

which is exactly what the screenshot shows. Reproduced against `renderMarkdown` directly; stock markdown-it with no Omicron rules loaded produces the same thing, so neither the KaTeX plugin nor the existing `omicron_loose_strong` rule is involved — this is the spec behaving as written.

The author's site is fine because the source there escapes the star (`zero\*`), and Omicron renders that form correctly too. What gets lost is the backslash: a body arriving over the webhook has usually been through a CMS or an HTML-to-Markdown step, and by then nobody is looking at the Markdown we are handed. Where exactly the backslash goes is outside this repo and is *not* proven here — the fix deliberately does not depend on knowing.

## The fix

A new inline rule, `omicron_literal_star`, in the same spirit as the loose-bold rule next to it: a `*` run of length one that can only close is not allowed to break into a longer opening run. It stays text, and the `**` pair closes with itself as written.

It runs before `balance_pairs` — the rule that does the matching — because afterwards the wrong pairing is already tokens. The scan tracks the same open/close stack the parser will, which is what leaves genuine nesting alone: in `**a *b* c**` the single closer has a single opener to pair with, and in `**a *b***` the closing run is three long, so neither is touched.

The alternative — repairing the `<em><em>…</em>…</em>*` tokens afterwards — would mean moving the star back across the text it was displaced from, on the strength of a pattern match. Refusing the bad pairing in the first place is smaller and does not have to guess.

## Verified

`deno test -A src/` — 116 passed, 0 failed. `deno check`, `deno lint`, `deno fmt --check` clean. Six new tests in `markdown_test.ts`.

Checked by hand, before and after:

| input | output |
| --- | --- |
| `**zero* server cost,**` | `<strong>zero* server cost,</strong>` |
| `**zero\* server cost,**` | identical to the line above |
| `**a *b* c**` | `<strong>a <em>b</em> c</strong>` |
| `**a *b***` | `<strong>a <em>b</em></strong>` |
| `*a **b** c*` | `<em>a <strong>b</strong> c</em>` |
| `***all three***` | `<em><strong>all three</strong></em>` |
| `**bold** and a star* here` | star stays literal, as before |
| `2 * 3 * 4` | unchanged |
| `[**zero* cost**](…)` | repaired inside the link's own delimiter list |

Not verified: no rendered post was checked in a browser, and no other ingested post was re-rendered to see whether this rule changes anything else in the existing corpus.

## Deploy notes

Nothing beyond a normal backend deploy. But note that rendering happens **on write**: posts already stored keep their broken HTML. The post that surfaced this needs redelivering through the webhook to be re-rendered.
