### PR TITLE
feat(editor): let authors describe their images

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -598,6 +598,31 @@ html {
 .tiptap .img-resizer.is-resizing {
   @apply select-none;
 }
+/* Alt-text control, bottom-left so it never sits under a resize handle. It
+   follows the handles' visibility rule — present on hover or while selected —
+   except when the description is still missing, where it stays visible so the
+   omission is noticed while writing rather than after publishing. */
+.tiptap .img-alt-button {
+  @apply absolute bottom-2 left-2 z-10 rounded-input border border-background/40 bg-dark/75 px-2 py-1 text-xs font-semibold uppercase tracking-wide text-background opacity-0 transition-opacity;
+}
+.tiptap .img-resizer:hover .img-alt-button,
+.tiptap .img-resizer.is-selected .img-alt-button,
+.tiptap .img-alt-button[data-missing="true"] {
+  @apply opacity-100;
+}
+.tiptap .img-alt-button[data-missing="true"] {
+  @apply bg-destructive/85 border-destructive/40;
+}
+.tiptap .img-alt-button:hover {
+  @apply bg-dark;
+}
+.tiptap .img-alt-button[data-missing="true"]:hover {
+  @apply bg-destructive;
+}
+/* A drag shouldn't leave the badge hovering over a moving image. */
+.tiptap .img-resizer.is-resizing .img-alt-button {
+  @apply opacity-0;
+}
 .tiptap .img-resize-handle-nw {
   @apply -left-1.5 -top-1.5 cursor-nwse-resize;
 }

--- a/apps/frontend/src/lib/editor/Editor.svelte
+++ b/apps/frontend/src/lib/editor/Editor.svelte
@@ -8,6 +8,7 @@
   import EmojiTrigger from "$lib/components/EmojiTrigger.svelte";
   import { endpoints, ApiError } from "$lib/api";
   import { isAcceptedImage, prepareImage } from "./image";
+  import { EDIT_ALT_EVENT, type EditAltDetail } from "./resizable-image";
   import { extensions } from "./extensions";
   import { CODE_LANGUAGES, codeLanguageLabel } from "$lib/codeLanguages";
 
@@ -188,6 +189,44 @@
     linkOpen = false;
   }
 
+  // Alt text for an image, collected the same way a link URL is. The node view
+  // is plain DOM (see resizable-image.ts) and cannot open a Svelte component,
+  // so its "Alt" button raises an event carrying the image's position and the
+  // description it already has; this owns the dialog and writes the answer back.
+  let altOpen = $state(false);
+  let altText = $state("");
+  let altPos: number | null = null;
+
+  function openAltDialog(event: Event) {
+    const { pos, alt } = (event as CustomEvent<EditAltDetail>).detail;
+    altPos = pos;
+    altText = alt;
+    altOpen = true;
+  }
+
+  function applyAlt(e: SubmitEvent) {
+    e.preventDefault();
+    altOpen = false;
+    if (altPos === null) return;
+    const node = editor.state.doc.nodeAt(altPos);
+    // The document can move under an open dialog — an undo, or a collaborator's
+    // edit in some future version. Writing to a position that is no longer this
+    // image would relabel the wrong one, so confirm before committing.
+    if (node?.type.name === "image") {
+      editor.view.dispatch(
+        editor.view.state.tr.setNodeMarkup(altPos, undefined, {
+          ...node.attrs,
+          // An empty description is stored as null rather than "", which is how
+          // the node view tells "not described yet" from "deliberately
+          // decorative" — and `alt=""` is the correct markup for the latter.
+          alt: altText.trim() || null,
+        }),
+      );
+    }
+    altPos = null;
+    editor.commands.focus();
+  }
+
   // Emoji picker: inserts the picked Unicode emoji at the cursor. Emoji are
   // stored as plain Unicode (not images) and rendered as Twemoji by the
   // unicode-range font, so federated/exported content stays text.
@@ -300,9 +339,15 @@
       onTransaction: ({ editor }) => refreshActive(editor),
     });
     refreshActive();
+    // The alt-text button lives inside a node view, so its event surfaces on
+    // the editor's own DOM rather than anywhere Svelte can bind to directly.
+    editor.view.dom.addEventListener(EDIT_ALT_EVENT, openAltDialog);
   });
 
-  onDestroy(() => editor?.destroy());
+  onDestroy(() => {
+    editor?.view.dom.removeEventListener(EDIT_ALT_EVENT, openAltDialog);
+    editor?.destroy();
+  });
 
   // `key` (when present) is the active-state flag that highlights the button;
   // `divider` inserts a separator before the button. One-shot actions like the
@@ -535,6 +580,54 @@
             type="text"
             maxlength={MAX_CODE_TITLE}
             placeholder="src/main.ts"
+            class="rounded-input border border-input bg-background shadow-btn px-3.5 py-2.5 text-sm outline-none placeholder:text-muted-foreground focus:border-foreground"
+          />
+        </div>
+        <div class="flex justify-end gap-2">
+          <Dialog.Close
+            class="text-foreground hover:bg-muted inline-flex h-10 items-center justify-center rounded-input px-4 text-sm font-medium active:scale-[0.98]"
+          >
+            Cancel
+          </Dialog.Close>
+          <button
+            type="submit"
+            class="rounded-input bg-dark text-background shadow-mini hover:bg-dark/95 inline-flex h-10 items-center justify-center px-5 text-sm font-semibold active:scale-[0.98]"
+          >
+            Save
+          </button>
+        </div>
+      </form>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>
+
+<Dialog.Root bind:open={altOpen}>
+  <Dialog.Portal>
+    <Dialog.Overlay
+      class="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+    />
+    <Dialog.Content
+      class="rounded-card bg-background shadow-popover fixed left-1/2 top-1/2 z-50 w-full max-w-[94%] -translate-x-1/2 -translate-y-1/2 border border-border p-6 sm:max-w-[420px]"
+    >
+      <Dialog.Title class="text-foreground text-lg font-semibold tracking-tight">
+        Describe this image
+      </Dialog.Title>
+      <Dialog.Description class="text-muted-foreground mt-1 text-sm">
+        Read aloud to people using a screen reader, and shown if the image fails to
+        load. Leave it empty if the image is purely decorative.
+      </Dialog.Description>
+      <form onsubmit={applyAlt} class="mt-4 flex flex-col gap-4">
+        <div class="flex flex-col gap-1.5">
+          <Label.Root for="image-alt" class="text-sm font-medium leading-none">
+            Alt text
+          </Label.Root>
+          <!-- svelte-ignore a11y_autofocus -->
+          <input
+            id="image-alt"
+            bind:value={altText}
+            type="text"
+            placeholder="A rabbit peering out of its burrow"
+            autofocus
             class="rounded-input border border-input bg-background shadow-btn px-3.5 py-2.5 text-sm outline-none placeholder:text-muted-foreground focus:border-foreground"
           />
         </div>

--- a/apps/frontend/src/lib/editor/resizable-image.ts
+++ b/apps/frontend/src/lib/editor/resizable-image.ts
@@ -14,6 +14,14 @@ import Image from "@tiptap/extension-image";
 // Height is never stored: the image keeps its own aspect ratio (`h-auto` in
 // app.css), so dragging a corner scales both edges together.
 
+// Alt text is edited through a dialog owned by Editor.svelte rather than a
+// browser prompt, so it looks like the rest of the app. The node view is plain
+// DOM and cannot open a Svelte component itself, so it raises this event and
+// the editor component listens for it. `detail.pos` identifies which image, so
+// the answer can be written straight back with a transaction.
+export const EDIT_ALT_EVENT = "omicron:edit-image-alt";
+export type EditAltDetail = { pos: number; alt: string };
+
 // Never let an image shrink to something unclickable, and never past the column.
 const MIN_PERCENT = 10;
 const MAX_PERCENT = 100;
@@ -51,6 +59,20 @@ export const ResizableImage = Image.extend({
 
       // Mirrors the node's attributes onto the DOM. Called on creation and on
       // every `update`, so an undo of a resize snaps the frame back.
+      // Alt-text control. An image with no description is invisible to a screen
+      // reader and mute to a search engine, and until now the editor offered no
+      // way to give it one — the attribute existed on the node and nothing
+      // could ever set it. The button doubles as the indicator: it reads "Alt"
+      // and is marked incomplete while the description is empty, so the gap is
+      // visible while writing rather than discovered by someone who cannot see
+      // the picture.
+      const altButton = document.createElement("button");
+      altButton.type = "button";
+      altButton.className = "img-alt-button";
+      altButton.draggable = false;
+      altButton.addEventListener("dragstart", (event) => event.preventDefault());
+      frame.appendChild(altButton);
+
       let current = node;
       function render() {
         img.src = current.attrs.src ?? "";
@@ -58,8 +80,36 @@ export const ResizableImage = Image.extend({
         if (current.attrs.title) img.title = current.attrs.title;
         else img.removeAttribute("title");
         frame.style.width = (current.attrs.width as string | null) ?? "100%";
+
+        const alt = (current.attrs.alt as string | null)?.trim() ?? "";
+        altButton.textContent = "Alt";
+        altButton.dataset.missing = alt ? "false" : "true";
+        altButton.title = alt ? `Alt text: ${alt}` : "Add alt text";
+        altButton.setAttribute(
+          "aria-label",
+          alt ? `Edit alt text: ${alt}` : "Add alt text for this image",
+        );
       }
       render();
+
+      altButton.addEventListener("pointerdown", (event) => {
+        // Stop ProseMirror turning the press into a node drag or selection.
+        event.preventDefault();
+        event.stopPropagation();
+      });
+      altButton.addEventListener("click", (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        if (!editor.isEditable) return;
+        const pos = typeof getPos === "function" ? getPos() : null;
+        if (pos === null || pos === undefined) return;
+        editor.view.dom.dispatchEvent(
+          new CustomEvent<EditAltDetail>(EDIT_ALT_EVENT, {
+            bubbles: true,
+            detail: { pos, alt: (current.attrs.alt as string | null) ?? "" },
+          }),
+        );
+      });
 
       // Live width during a drag, committed to the document on pointer-up.
       let dragging: { startX: number; startWidth: number; columnWidth: number; grow: number } | null = null;


### PR DESCRIPTION
The image node has always carried an `alt` attribute, the sanitizer has always allowed it through, and the reader has always rendered it — but nothing in the editor could ever set one. Every image in every post was published undescribed, which is silence for anyone using a screen reader and, to a search engine, an image with nothing to say about it.

Selecting an image now offers an "Alt" button that opens a dialog, built from the same Bits UI Dialog as the link and code-block ones. The button is also the indicator: while a description is missing it stays visible and marked, rather than fading with the resize handles, so the gap is noticed while writing instead of after publishing.

An empty answer is stored as null, not "", so the node view can still tell "not described yet" from an author's deliberate "this is decorative" — and `alt=""` is the correct markup for the latter.

The node view is plain DOM and cannot open a Svelte component, so it raises an event carrying the image's position and current text; the editor component owns the dialog and writes the answer back. The position is re-checked against the document before committing, since an undo can move the node while the dialog is open and writing blind would relabel a different image.