### PR TITLE
SEO: descriptions, related posts, optional IndexNow

### DIFF
--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -211,6 +211,79 @@ export function listSitemapEntries(page = 1) {
     .offset((Math.max(1, page) - 1) * SITEMAP_PAGE_SIZE);
 }
 
+// Posts related to `postId`, most-related first.
+//
+// A post page used to be a dead end: nothing linked onward from an article
+// except its author's profile. That costs three separate things — a crawler
+// reaches fewer pages, ranking weight collects on individual articles instead
+// of circulating, and a reader who finishes a piece has nowhere to go but away.
+//
+// Relatedness is the number of tags in common, then recency. That is a crude
+// measure and deliberately so: it uses the index that already exists, it is
+// explainable to the author who chose those tags, and it degrades to "recent
+// posts by anyone" rather than to nothing when a post shares no tags — an empty
+// section would leave the dead end exactly as it was.
+export function listRelated(postId: string, limit = 4) {
+  const shared = db
+    .select({
+      id: posts.id,
+      overlap: sql<number>`count(*)::int`.as("overlap"),
+    })
+    .from(postTags)
+    .innerJoin(posts, eq(posts.id, postTags.postId))
+    .where(
+      and(
+        // The tags of the post being read.
+        inArray(
+          postTags.tagId,
+          db.select({ id: postTags.tagId }).from(postTags).where(eq(postTags.postId, postId)),
+        ),
+        sql`${posts.id} <> ${postId}`,
+        eq(posts.status, "published"),
+        // Local posts only. A federated copy is served here as `noindex` (it
+        // reproduces an article published elsewhere), so linking to one adds
+        // nothing to crawl depth and sends a reader to a page we have asked
+        // search engines to ignore. The rail exists to lead further into this
+        // instance's own archive.
+        eq(posts.remote, false),
+      ),
+    )
+    .groupBy(posts.id)
+    .as("shared");
+
+  return selectPosts()
+    .innerJoin(shared, eq(shared.id, posts.id))
+    // A private author's posts are visible only to approved followers; a
+    // suggestion rail has no viewer context to check that against, so they are
+    // left out entirely rather than teased and then 404'd.
+    .where(
+      and(
+        sql`${users.isPrivate} = false`,
+        sql`${users.suspendedAt} is null`,
+      ),
+    )
+    .orderBy(desc(shared.overlap), desc(posts.createdAt))
+    .limit(limit);
+}
+
+// Fallback for a post whose tags nobody else uses (or which has none): the
+// newest published posts, minus the one being read. Keeps the section from
+// disappearing exactly on the posts that most need a way onward.
+export function listRecentExcluding(postId: string, limit = 4) {
+  return selectPosts()
+    .where(
+      and(
+        sql`${posts.id} <> ${postId}`,
+        eq(posts.status, "published"),
+        eq(posts.remote, false),
+        sql`${users.isPrivate} = false`,
+        sql`${users.suspendedAt} is null`,
+      ),
+    )
+    .orderBy(desc(posts.createdAt))
+    .limit(limit);
+}
+
 export async function countSitemapEntries(): Promise<number> {
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })

--- a/apps/backend/src/queue/handlers.ts
+++ b/apps/backend/src/queue/handlers.ts
@@ -14,6 +14,14 @@ export function registerJobHandlers() {
     await deliverPost(postId, action ?? "create");
   });
 
+  // Tell IndexNow-participating engines a post appeared or changed. Queued
+  // rather than awaited inline so a slow third party never delays a publish,
+  // and no-ops unless an admin enabled it (see services/indexNow.ts).
+  registerHandler("indexnow_submit", async ({ postId }) => {
+    const { submitPost } = await import("@/services/indexNow.ts");
+    await submitPost(postId);
+  });
+
   // A local post was deleted; tombstone it on remote followers' instances. The
   // row is already gone, so the payload carries the former author id.
   registerHandler("federate_post_delete", async ({ postId, authorId }) => {

--- a/apps/backend/src/queue/queue.ts
+++ b/apps/backend/src/queue/queue.ts
@@ -11,6 +11,7 @@ import { newRedis, redisEnabled } from "@/lib/redis.ts";
 
 export type JobName =
   | "federate_post"
+  | "indexnow_submit"
   | "federate_post_delete"
   | "federate_actor_update"
   | "federate_list_item"
@@ -26,6 +27,7 @@ export type JobName =
 
 export type JobPayloads = {
   federate_post: { postId: string; action?: "create" | "update" };
+  indexnow_submit: { postId: string };
   federate_post_delete: { postId: string; authorId: string };
   federate_actor_update: { userId: string };
   federate_list_item: { listId: string; postId: string; action: "add" | "remove" };

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -87,6 +87,7 @@ adminRoutes.get("/seo", async (c) => {
 const seoSchema = z.object({
   indexingEnabled: z.boolean().optional(),
   verification: z.record(z.string(), z.string()).optional(),
+  indexNowEnabled: z.boolean().optional(),
 });
 
 adminRoutes.put("/seo", async (c) => {

--- a/apps/backend/src/routes/posts.ts
+++ b/apps/backend/src/routes/posts.ts
@@ -91,6 +91,15 @@ postRoutes.get("/:id", async (c) => {
   return c.json({ post: await enrichPost(row, viewer?.id ?? null) });
 });
 
+// Posts to read next (public). Sits under the article and is what stops a post
+// page being a dead end for readers and crawlers alike.
+postRoutes.get("/:id/related", async (c) => {
+  const viewer = c.get("user");
+  const row = await postsService.getPost(c.req.param("id"), viewer?.id ?? null);
+  const items = await postsService.relatedPosts(row.post.id);
+  return c.json({ items: await enrichPosts(items, viewer?.id ?? null) });
+});
+
 // Edit a post (auth required; author only, local posts only).
 postRoutes.patch("/:id", async (c) => {
   const user = requireUser(c);

--- a/apps/backend/src/routes/seo.ts
+++ b/apps/backend/src/routes/seo.ts
@@ -14,8 +14,24 @@ export const seoRoutes = new Hono<AppEnv>();
 
 // Indexing flag + verification tokens. Public by design: the tokens are meant to
 // appear in the page's HTML anyway.
+//
+// The IndexNow key is withheld. It is what authorises submissions for this
+// host, and while IndexNow treats it as semi-public — the engines fetch it from
+// a file on the domain — handing it to every caller would let anyone submit
+// this instance's URLs at will. The app never needs it; only the key-file route
+// does, and that confirms a guess rather than being told (see below).
 seoRoutes.get("/", async (c) => {
-  return c.json(await seo.getSeoSettings());
+  const { indexNowKey: _withheld, ...settings } = await seo.getSeoSettings();
+  return c.json(settings);
+});
+
+// Confirms whether `key` is this instance's IndexNow key, so the app can serve
+// the key file the engines fetch to verify domain ownership. Answers only yes
+// or no, so a caller learns nothing it did not already have to supply.
+seoRoutes.get("/indexnow-key/:key", async (c) => {
+  const { indexNowEnabled, indexNowKey } = await seo.getSeoSettings();
+  const ok = indexNowEnabled && !!indexNowKey && c.req.param("key") === indexNowKey;
+  return c.json({ ok });
 });
 
 // The instance's index pages — author profiles, tag indexes, public reading

--- a/apps/backend/src/services/indexNow.ts
+++ b/apps/backend/src/services/indexNow.ts
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { config } from "@/config.ts";
+import * as postsRepo from "@/db/repositories/posts.ts";
+import * as usersRepo from "@/db/repositories/users.ts";
+import { slugify } from "@/lib/slug.ts";
+import { getSeoSettings } from "@/services/seo.ts";
+
+// IndexNow: tell participating search engines that a URL changed, instead of
+// waiting for them to come and find out.
+//
+// A sitemap says "here is everything, come back sometime". This says "this one
+// page, now". Bing, Yandex, Seznam and Naver honour it and share submissions
+// between themselves, so one call reaches all of them. Google does not
+// participate — their Indexing API is restricted to job postings and
+// livestreams, and using it for blog posts is against its terms, so nothing
+// here tries to.
+//
+// Off unless an admin turns it on (see services/seo.ts). Enabling it means this
+// instance sends its URLs to third-party servers on every publish; that is a
+// fair trade for an operator who wants it, and not something to do on their
+// behalf uninvited.
+
+const ENDPOINT = "https://api.indexnow.org/IndexNow";
+
+// A publish should never be held up, or failed, by a third party being slow or
+// down. Everything below is best-effort: a rejected or timed-out submission
+// costs nothing but the next crawl arriving on its own schedule.
+const TIMEOUT_MS = 5000;
+
+/** Canonical public path for a post — mirrors the frontend's `postPath`. */
+export function postPath(post: { id: string; title: string | null }, username: string): string {
+  const slug = post.title ? slugify(post.title) : "";
+  const shortId = post.id.slice(0, 8);
+  return `/@${username}/${slug ? `${slug}-${shortId}` : shortId}`;
+}
+
+/** Where the engines fetch the key from to confirm we own this host. */
+export function keyLocation(origin: string, key: string): string {
+  return `${origin}/indexnow-${key}.txt`;
+}
+
+function origin(): string | null {
+  const host = config.APP_DOMAIN?.trim();
+  if (!host || host.startsWith("localhost")) return null;
+  return `https://${host}`;
+}
+
+/**
+ * Submit one post's canonical URL. Safe to call for anything: it resolves
+ * whether it should do nothing at all — protection off, indexing off, a draft,
+ * a federated post that belongs to another instance, or a local dev host with
+ * no public URL for an engine to fetch.
+ */
+export async function submitPost(postId: string): Promise<void> {
+  const site = origin();
+  if (!site) return;
+
+  const seo = await getSeoSettings();
+  // Indexing being off is the stronger statement of the two: an instance that
+  // asks not to be indexed must not then push its URLs at anyone.
+  if (!seo.indexNowEnabled || !seo.indexingEnabled || !seo.indexNowKey) return;
+
+  const row = await postsRepo.findById(postId);
+  if (!row?.post || row.post.remote || row.post.status !== "published") return;
+  if (!row.post.authorId) return;
+
+  const author = await usersRepo.findById(row.post.authorId);
+  if (!author || author.suspendedAt || author.isPrivate) return;
+
+  await submit([`${site}${postPath(row.post, author.username)}`], site, seo.indexNowKey);
+}
+
+async function submit(urlList: string[], site: string, key: string): Promise<void> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(ENDPOINT, {
+      method: "POST",
+      headers: { "content-type": "application/json; charset=utf-8" },
+      signal: controller.signal,
+      body: JSON.stringify({
+        host: new URL(site).host,
+        key,
+        keyLocation: keyLocation(site, key),
+        urlList,
+      }),
+    });
+    // 200 and 202 are both success; anything else is worth a line in the log,
+    // since a persistently rejected key is invisible otherwise.
+    if (!res.ok && res.status !== 202) {
+      console.warn(`IndexNow submission rejected (${res.status}) for ${urlList.join(", ")}`);
+    }
+  } catch (err) {
+    console.warn(`IndexNow submission failed: ${err instanceof Error ? err.message : err}`);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -9,9 +9,32 @@ import { badRequest, forbidden, notFound } from "@/lib/http.ts";
 import { MAX_TAGS_PER_POST, normalizeTags } from "@/lib/tags.ts";
 import { type LanguageFilter, normalizeLanguage } from "@/lib/languages.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
+import { SUMMARY_LENGTH as MAX_SUMMARY } from "@/lib/webhook.ts";
 import { queue } from "@/queue/queue.ts";
 
 // Business logic for posts. Creating a local post enqueues federation delivery.
+
+// The author's own one-line description of a post.
+//
+// This is what a search engine prints under the title in results, and what a
+// link preview shows — the sentence that decides whether anyone clicks. Until
+// now only the ingest webhook could set it, so a post written in the editor
+// fell back to a mechanical truncation of its opening paragraph, frequently
+// cut mid-clause.
+//
+// Capped at the same length the ingest path derives to, so both routes into the
+// database agree and neither can store a "description" long enough to be
+// clipped by every engine that shows it. Empty is stored as null, which is the
+// reader's signal to fall back to the derived excerpt.
+export function normalizeSummary(raw: string | null | undefined): string | null {
+  if (raw === null || raw === undefined) return null;
+  const text = raw.replace(/\s+/g, " ").trim();
+  if (!text) return null;
+  if (text.length > MAX_SUMMARY) {
+    throw badRequest(`A description can be at most ${MAX_SUMMARY} characters.`);
+  }
+  return text;
+}
 
 // Normalizes and validates author-supplied tags, capping the count per post.
 // Exported so every write path that accepts tags — the editor here, ingested
@@ -30,6 +53,7 @@ export async function createPost(authorId: string, input: {
   contentJson?: unknown;
   status?: string;
   language?: string | null;
+  summary?: string | null;
   tags?: string[];
 }) {
   const status = input.status === "draft" ? "draft" : "published";
@@ -53,6 +77,7 @@ export async function createPost(authorId: string, input: {
     contentJson: input.contentJson ?? null,
     status,
     language: normalizeLanguage(input.language),
+    summary: normalizeSummary(input.summary),
   });
 
   if (tags !== undefined) await tagsRepo.setPostTags(post.id, tags);
@@ -109,6 +134,7 @@ export async function updatePost(authorId: string, id: string, input: {
   contentJson?: unknown;
   status?: string;
   language?: string | null;
+  summary?: string | null;
   tags?: string[];
 }) {
   const row = await postsRepo.findById(id);
@@ -141,6 +167,7 @@ export async function updatePost(authorId: string, id: string, input: {
     ...(html ? { contentHtml: html, contentJson: input.contentJson ?? null } : {}),
     ...(input.status !== undefined ? { status } : {}),
     ...(input.language !== undefined ? { language: normalizeLanguage(input.language) } : {}),
+    ...(input.summary !== undefined ? { summary: normalizeSummary(input.summary) } : {}),
   };
 
   // A tags-only edit touches no post columns; skip the update (drizzle rejects

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -121,6 +121,25 @@ export async function getPost(id: string, viewerId: string | null = null) {
   return row;
 }
 
+// Posts to offer at the end of an article. Tag overlap first; when a post
+// shares tags with nothing (or carries none), the newest posts stand in, so the
+// reader is never left at a dead end. Deduplicated by id because the fallback
+// is only topped up when the related set comes back short.
+export async function relatedPosts(postId: string, limit = 4) {
+  const related = await postsRepo.listRelated(postId, limit);
+  if (related.length >= limit) return related;
+
+  const seen = new Set(related.map((r) => r.post.id));
+  const filler = await postsRepo.listRecentExcluding(postId, limit + related.length);
+  for (const row of filler) {
+    if (related.length >= limit) break;
+    if (seen.has(row.post.id)) continue;
+    seen.add(row.post.id);
+    related.push(row);
+  }
+  return related;
+}
+
 export async function listDrafts(authorId: string, cursor: Cursor | null) {
   const rows = await postsRepo.listDraftsByAuthor(authorId, cursor, DEFAULT_PAGE_SIZE);
   return pageOf(rows, DEFAULT_PAGE_SIZE);

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -83,7 +83,10 @@ export async function createPost(authorId: string, input: {
   if (tags !== undefined) await tagsRepo.setPostTags(post.id, tags);
 
   // Only published posts fan out to remote followers; drafts stay private.
-  if (status === "published") queue.add("federate_post", { postId: post.id });
+  if (status === "published") {
+    queue.add("federate_post", { postId: post.id });
+    queue.add("indexnow_submit", { postId: post.id });
+  }
   return post;
 }
 
@@ -209,6 +212,9 @@ export async function updatePost(authorId: string, id: string, input: {
   if (post.status === "published") {
     const action = row.post.status === "published" ? "update" : "create";
     queue.add("federate_post", { postId: post.id, action });
+    // Resubmit on edit as well as on publish: an engine holding the old copy is
+    // exactly the case IndexNow exists to shorten.
+    queue.add("indexnow_submit", { postId: post.id });
   } else if (row.post.status === "published" && post.authorId) {
     // Unpublishing (published → draft) makes the post private again; tombstone
     // the copies already delivered to remote followers.

--- a/apps/backend/src/services/seo.ts
+++ b/apps/backend/src/services/seo.ts
@@ -15,6 +15,8 @@ import * as settingsRepo from "@/db/repositories/instanceSettings.ts";
 const KEYS = {
   indexingEnabled: "seo.indexingEnabled",
   verification: "seo.verification",
+  indexNowEnabled: "seo.indexNowEnabled",
+  indexNowKey: "seo.indexNowKey",
 } as const;
 
 // Supported verification engines → the `<meta name>` each search console expects.
@@ -32,6 +34,18 @@ export type SeoVerification = Partial<Record<VerificationEngine, string>>;
 export interface SeoSettings {
   indexingEnabled: boolean;
   verification: SeoVerification;
+  // IndexNow: ping participating engines the moment a post is published or
+  // edited, instead of waiting to be crawled. Bing, Yandex, Seznam and others
+  // honour it; Google does not participate.
+  //
+  // Off by default, and deliberately so. Turning it on makes this instance send
+  // its URLs to third-party servers on every publish — a reasonable trade for
+  // an operator who wants faster indexing, but not a thing self-hosted software
+  // should start doing on someone's behalf without being asked. The key is
+  // generated on first enable and served from a well-known path so the engines
+  // can verify the sender owns the domain.
+  indexNowEnabled: boolean;
+  indexNowKey: string | null;
 }
 
 const ENGINE_KEYS = Object.keys(VERIFICATION_ENGINES) as VerificationEngine[];
@@ -50,25 +64,42 @@ function cleanVerification(input: unknown): SeoVerification {
 }
 
 export async function getSeoSettings(): Promise<SeoSettings> {
-  const [indexing, verification] = await Promise.all([
+  const [indexing, verification, indexNow, key] = await Promise.all([
     settingsRepo.get<boolean>(KEYS.indexingEnabled),
     settingsRepo.get<SeoVerification>(KEYS.verification),
+    settingsRepo.get<boolean>(KEYS.indexNowEnabled),
+    settingsRepo.get<string>(KEYS.indexNowKey),
   ]);
   return {
     indexingEnabled: indexing ?? true,
     verification: cleanVerification(verification),
+    indexNowEnabled: indexNow ?? false,
+    indexNowKey: key ?? null,
   };
 }
 
 // Partial update: only the keys present in `patch` are written, so toggling
 // indexing never clobbers the verification tokens and vice versa.
 export async function setSeoSettings(
-  patch: { indexingEnabled?: boolean; verification?: SeoVerification },
+  patch: {
+    indexingEnabled?: boolean;
+    verification?: SeoVerification;
+    indexNowEnabled?: boolean;
+  },
 ): Promise<void> {
   if (patch.indexingEnabled !== undefined) {
     await settingsRepo.set(KEYS.indexingEnabled, patch.indexingEnabled);
   }
   if (patch.verification !== undefined) {
     await settingsRepo.set(KEYS.verification, cleanVerification(patch.verification));
+  }
+  if (patch.indexNowEnabled !== undefined) {
+    await settingsRepo.set(KEYS.indexNowEnabled, patch.indexNowEnabled);
+    // Mint the key the first time it is switched on, and keep it thereafter —
+    // rotating it would invalidate the key file the engines have already
+    // fetched, and every URL submitted under the old one.
+    if (patch.indexNowEnabled && !(await settingsRepo.get<string>(KEYS.indexNowKey))) {
+      await settingsRepo.set(KEYS.indexNowKey, crypto.randomUUID().replaceAll("-", ""));
+    }
   }
 }

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -121,6 +121,9 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     // discoverability / SEO: public read (layout, robots.txt, sitemap.xml) + the
     // moderator-only write side.
     seo: () => api.get<SeoSettings>("/seo"),
+    // Yes/no check backing the IndexNow key file; never returns the key.
+    verifyIndexNowKey: (key: string) =>
+      api.get<{ ok: boolean }>(`/seo/indexnow-key/${encodeURIComponent(key)}`),
     sitemapEntries: () => api.get<SitemapContents>("/seo/sitemap-entries"),
     sitemapPosts: (page: number) => api.get<SitemapEntry[]>(`/seo/sitemap-posts?page=${page}`),
     adminSeo: () => api.get<SeoSettings>("/admin/seo"),

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -207,11 +207,11 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     drafts: (cursor?: string | null) =>
       api.get<Page<Post>>(`/posts/drafts${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""}`),
     createPost: (
-      body: { title?: string; contentHtml: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; tags?: string[] },
+      body: { title?: string; contentHtml: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; tags?: string[] },
     ) => api.post<{ post: { id: string } }>("/posts", body),
     updatePost: (
       id: string,
-      body: { title?: string; contentHtml?: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; tags?: string[] },
+      body: { title?: string; contentHtml?: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; tags?: string[] },
     ) => api.patch<{ post: { id: string } }>(`/posts/${id}`, body),
     deletePost: (id: string) => api.del<{ ok: true }>(`/posts/${id}`),
 

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -214,6 +214,8 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
       body: { title?: string; contentHtml?: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; tags?: string[] },
     ) => api.patch<{ post: { id: string } }>(`/posts/${id}`, body),
     deletePost: (id: string) => api.del<{ ok: true }>(`/posts/${id}`),
+    // Posts to read next, shown under an article (see relatedPosts service).
+    relatedPosts: (id: string) => api.get<{ items: Post[] }>(`/posts/${id}/related`),
 
     // likes + comments
     likePost: (id: string) => api.post<LikeState>(`/posts/${id}/like`),

--- a/apps/frontend/src/lib/components/AdminSeo.svelte
+++ b/apps/frontend/src/lib/components/AdminSeo.svelte
@@ -10,6 +10,11 @@
   // site-verification tokens rendered as <meta> tags in the app's <head>.
   let indexingEnabled = $state(true);
   let verification = $state<SeoVerification>({});
+  // IndexNow. Off by default: enabling it makes this instance send its post URLs
+  // to third-party search engines on every publish, which is the operator's call
+  // to make rather than a default to inherit.
+  let indexNowEnabled = $state(false);
+  let indexNowKey = $state<string | null>(null);
   let loading = $state(true);
   let saving = $state(false);
   let error = $state("");
@@ -45,6 +50,8 @@
   function apply(s: SeoSettings) {
     indexingEnabled = s.indexingEnabled;
     verification = { ...s.verification };
+    indexNowEnabled = s.indexNowEnabled;
+    indexNowKey = s.indexNowKey ?? null;
   }
 
   $effect(() => {
@@ -60,7 +67,7 @@
     error = "";
     saved = false;
     try {
-      apply(await endpoints().setAdminSeo({ indexingEnabled, verification }));
+      apply(await endpoints().setAdminSeo({ indexingEnabled, verification, indexNowEnabled }));
       saved = true;
     } catch (e) {
       error = e instanceof ApiError ? e.message : "Failed to save.";
@@ -89,6 +96,47 @@
       id="seo-indexing"
       bind:checked={indexingEnabled}
       disabled={loading || saving}
+      class="peer inline-flex h-[36px] min-h-[36px] w-[60px] shrink-0 cursor-pointer items-center rounded-full px-[3px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-foreground data-[state=unchecked]:bg-dark-10 data-[state=unchecked]:shadow-mini-inset"
+    >
+      <Switch.Thumb
+        class="pointer-events-none block size-[30px] shrink-0 rounded-full bg-background transition-transform data-[state=checked]:translate-x-[24px] data-[state=unchecked]:translate-x-0 data-[state=unchecked]:shadow-mini"
+      />
+    </Switch.Root>
+  </div>
+
+  <!-- IndexNow -->
+  <div class="flex items-start justify-between gap-4 border-t border-border pt-5">
+    <div class="flex flex-col gap-1">
+      <Label.Root for="seo-indexnow" class="text-sm font-medium text-foreground">
+        Notify search engines instantly (IndexNow)
+      </Label.Root>
+      <p class="max-w-prose text-sm text-muted-foreground">
+        Tells participating engines the moment a post is published or edited, instead of
+        waiting for them to crawl. Supported by Bing, Yandex, Seznam and Naver, which share
+        submissions between them; <strong class="text-foreground-alt">Google does not
+        participate</strong> and is unaffected.
+      </p>
+      <p class="max-w-prose text-sm text-muted-foreground">
+        Off by default because it sends this instance's post URLs to those companies' servers
+        on every publish. Nothing else is sent, and only public posts by public accounts —
+        never drafts, private accounts, or posts from other instances.
+      </p>
+      {#if indexNowEnabled && indexNowKey}
+        <p class="text-xs text-muted-foreground">
+          Verified with a key file at
+          <a
+            href={`/indexnow-${indexNowKey}.txt`}
+            target="_blank"
+            rel="noreferrer"
+            class="text-foreground underline underline-offset-2"
+          >/indexnow-{indexNowKey}.txt</a>, generated when you first switched this on.
+        </p>
+      {/if}
+    </div>
+    <Switch.Root
+      id="seo-indexnow"
+      bind:checked={indexNowEnabled}
+      disabled={loading || saving || !indexingEnabled}
       class="peer inline-flex h-[36px] min-h-[36px] w-[60px] shrink-0 cursor-pointer items-center rounded-full px-[3px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-foreground focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-foreground data-[state=unchecked]:bg-dark-10 data-[state=unchecked]:shadow-mini-inset"
     >
       <Switch.Thumb

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -264,7 +264,16 @@ export type SecuritySettings = { anubisProtection: boolean; anubisManaged: boole
 // `noindex`; `verification` holds per-engine site-verification tokens (the meta
 // `content` value only), keyed by engine (google/bing/yandex).
 export type SeoVerification = { google?: string; bing?: string; yandex?: string };
-export type SeoSettings = { indexingEnabled: boolean; verification: SeoVerification };
+export type SeoSettings = {
+  indexingEnabled: boolean;
+  verification: SeoVerification;
+  // IndexNow: push new and edited post URLs to participating engines (Bing,
+  // Yandex, Seznam — not Google) instead of waiting to be crawled. Off unless
+  // an admin turns it on, since it sends this instance's URLs to third parties.
+  indexNowEnabled: boolean;
+  // Present only on the admin payload — the public /seo endpoint withholds it.
+  indexNowKey?: string | null;
+};
 
 // Everything the instance publishes that belongs in the sitemap, in the raw
 // form /sitemap.xml needs to build URLs from (the permalink logic lives in

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.server.ts
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.server.ts
@@ -19,14 +19,20 @@ export const load: PageServerLoad = async ({ fetch, locals, params, url }) => {
     // Resolve the post first (id may be a short prefix), then load its comments
     // by the full id.
     const { post } = await api.post(id);
-    const comments = await api.comments(post.id);
+    // Comments and the read-next rail are independent of each other, so they go
+    // out together. A failure in the rail must not cost the reader the article,
+    // so it degrades to an empty list rather than propagating.
+    const [comments, related] = await Promise.all([
+      api.comments(post.id),
+      api.relatedPosts(post.id).then((r) => r.items).catch(() => []),
+    ]);
     // Highlighting is a read-time concern (see lib/highlight.ts): the stored
     // body stays the author's, and this decorates the copy on its way to the
     // reader. `post` is this request's own deserialized response, so writing to
     // it changes nothing but what this page renders. Only this page renders a
     // full body, so only this load pays for the work.
     post.contentHtml = deferBodyImages(highlightCodeBlocks(post.contentHtml));
-    data = { post, comments };
+    data = { post, comments, related };
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) error(404, "Post not found");
     throw err;

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -10,6 +10,7 @@
   import { confirm } from "$lib/components/ui/confirm";
   import Comments from "$lib/components/Comments.svelte";
   import TagList from "$lib/components/TagList.svelte";
+  import PostCard from "$lib/components/PostCard.svelte";
   import SaveToListButton from "$lib/components/SaveToListButton.svelte";
   import { formatDateTime, readTime } from "$lib/format";
   import { timeZone } from "$lib/timezone";
@@ -376,6 +377,21 @@
     </div>
   </div>
 </article>
+
+{#if data.related?.length}
+  <!-- Where to go next. A post page linked onward to nothing but its author,
+       which left readers with only the back button and left crawlers unable to
+       reach the rest of the archive from an article. Real <a> links, rendered
+       server-side, so both audiences follow the same ones. -->
+  <section aria-labelledby="read-next" class="mt-12 border-t border-border pt-8">
+    <h2 id="read-next" class="text-foreground mb-4 text-lg font-bold tracking-tight">
+      Read next
+    </h2>
+    {#each data.related as related (related.id)}
+      <PostCard post={related} />
+    {/each}
+  </section>
+{/if}
 
 <div id="responses" class="mt-12">
   <Comments

--- a/apps/frontend/src/routes/compose/+page.svelte
+++ b/apps/frontend/src/routes/compose/+page.svelte
@@ -11,6 +11,11 @@
   import TagInput from "$lib/components/TagInput.svelte";
   import LanguageSelect from "$lib/components/LanguageSelect.svelte";
   import { reading } from "$lib/prefs.svelte";
+
+  // Matches SUMMARY_LENGTH in the backend (lib/webhook.ts), which caps the
+  // same column on the ingest path — so neither way of writing a post can
+  // store a description the other would reject.
+  const MAX_SUMMARY = 150;
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -34,6 +39,10 @@
   // deliberate blank. Only a genuinely new post takes the remembered default,
   // so revisiting a draft never silently relabels it.
   let language = $state<string | null>(draft ? draft.language ?? null : reading.composeLang);
+  // The one-line description search engines print under the title, and link
+  // previews show. Left empty it falls back to a truncation of the opening
+  // paragraph — which is what every post used to get, often cut mid-clause.
+  let summary = $state(draft?.summary ?? "");
   let html = $state(draft?.contentHtml ?? "");
   let json = $state<unknown>(draft?.contentJson ?? null);
   let error = $state("");
@@ -58,8 +67,10 @@
   // mark the page dirty the instant it opened, so simply looking at the
   // composer and leaving would raise the unsaved-changes prompt.
   const initialLanguage = draft ? draft.language ?? null : reading.composeLang;
+  const initialSummary = draft?.summary ?? "";
   $effect(() => {
     if (tags.join(",") !== initialTags || language !== initialLanguage) touched = true;
+    if (summary !== initialSummary) touched = true;
   });
 
   // There's unsaved work worth keeping if the author has edited and there's
@@ -96,7 +107,17 @@
     if (status === "published") busy = true;
     else savingDraft = true;
     try {
-      const body = { title: title.trim(), contentHtml: html, contentJson: json, status, language, tags };
+      const body = {
+        title: title.trim(),
+        contentHtml: html,
+        contentJson: json,
+        status,
+        language,
+        // Null, not "", so the reader falls back to the derived excerpt
+        // rather than showing an empty description.
+        summary: summary.trim() || null,
+        tags,
+      };
       if (postId) {
         await endpoints().updatePost(postId, body);
       } else {
@@ -172,6 +193,25 @@
   oninput={() => (touched = true)}
   class="mb-6 w-full border-none bg-transparent text-3xl font-bold tracking-tight text-foreground placeholder:text-muted-foreground focus:outline-none sm:text-4xl"
 />
+
+<div class="mb-6">
+  <label for="post-summary" class="text-muted-foreground mb-1.5 block text-xs font-medium">
+    Description — shown in search results and link previews. Optional; the opening
+    lines are used when it's blank.
+  </label>
+  <div class="flex items-center gap-3">
+    <input
+      id="post-summary"
+      bind:value={summary}
+      maxlength={MAX_SUMMARY}
+      placeholder="One sentence on what this post is about"
+      class="rounded-input border border-input bg-background shadow-btn min-w-0 flex-1 px-3.5 py-2.5 text-sm outline-none placeholder:text-muted-foreground focus:border-foreground"
+    />
+    <span class="text-muted-foreground shrink-0 text-xs tabular-nums">
+      {summary.length}/{MAX_SUMMARY}
+    </span>
+  </div>
+</div>
 
 <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start">
   <div class="min-w-0 flex-1">

--- a/apps/frontend/src/routes/indexnow-[key].txt/+server.ts
+++ b/apps/frontend/src/routes/indexnow-[key].txt/+server.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { error } from "@sveltejs/kit";
+import { endpoints } from "$lib/api";
+import type { RequestHandler } from "./$types";
+
+// The IndexNow key file.
+//
+// When this instance submits a URL, it names this file. The engine fetches it
+// and checks the contents match the key that came with the submission — which
+// is how it knows the sender controls the domain rather than someone else
+// pushing URLs for a site they do not own.
+//
+// Served from the app origin because that is the host the engines were told
+// about, and it must be a plain-text body containing the key and nothing else.
+//
+// The backend is asked to confirm the key rather than to hand it over, so this
+// route never has a copy to leak: a request for the wrong filename learns only
+// that it was wrong. 404 when IndexNow is switched off, so a disabled instance
+// exposes no key file at all.
+
+export const GET: RequestHandler = async ({ fetch, params }) => {
+  const { ok } = await endpoints(fetch).verifyIndexNowKey(params.key).catch(() => ({ ok: false }));
+  if (!ok) error(404, "Not found");
+
+  return new Response(`${params.key}\n`, {
+    headers: {
+      "content-type": "text/plain; charset=utf-8",
+      // The key is stable once minted, but an engine re-checking it after the
+      // admin switched IndexNow off must see the 404 rather than a cached copy.
+      "cache-control": "public, max-age=300",
+    },
+  });
+};

--- a/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
+++ b/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
@@ -2,6 +2,9 @@
 <script lang="ts">
   import { onMount, untrack } from "svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
+
+  // Matches SUMMARY_LENGTH in the backend (lib/webhook.ts).
+  const MAX_SUMMARY = 150;
   import type { Content } from "@tiptap/core";
   import { goto } from "$app/navigation";
   import { endpoints, ApiError } from "$lib/api";
@@ -26,6 +29,10 @@
   let title = $state(post.title ?? "");
   let tags = $state<string[]>(post.tags?.map((t) => t.name) ?? []);
   let language = $state<string | null>(post.language ?? null);
+  // Seeded from the stored value, and always sent back — omitting the field
+  // would leave it untouched, but an author who cleared it here must have the
+  // clearing saved, and one who never touches it must not lose what they wrote.
+  let summary = $state(post.summary ?? "");
   let html = $state(post.contentHtml);
   let json = $state<unknown>(post.contentJson ?? null);
   let error = $state("");
@@ -53,6 +60,7 @@
         contentHtml: html,
         contentJson: json,
         language,
+        summary: summary.trim() || null,
         tags,
       });
       // Title may have changed, so navigate to the freshly-built canonical path.
@@ -83,6 +91,25 @@
   bind:value={title}
   class="mb-6 w-full border-none bg-transparent text-3xl font-bold tracking-tight text-foreground placeholder:text-muted-foreground focus:outline-none sm:text-4xl"
 />
+
+<div class="mb-6">
+  <label for="post-summary" class="text-muted-foreground mb-1.5 block text-xs font-medium">
+    Description — shown in search results and link previews. Optional; the opening
+    lines are used when it's blank.
+  </label>
+  <div class="flex items-center gap-3">
+    <input
+      id="post-summary"
+      bind:value={summary}
+      maxlength={MAX_SUMMARY}
+      placeholder="One sentence on what this post is about"
+      class="rounded-input border border-input bg-background shadow-btn min-w-0 flex-1 px-3.5 py-2.5 text-sm outline-none placeholder:text-muted-foreground focus:border-foreground"
+    />
+    <span class="text-muted-foreground shrink-0 text-xs tabular-nums">
+      {summary.length}/{MAX_SUMMARY}
+    </span>
+  </div>
+</div>
 
 <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start">
   <div class="min-w-0 flex-1">


### PR DESCRIPTION
Three separable features aimed at posts being found and clicked, rather than merely indexed. Each commit type-checks independently. No migration.

---

## 1. `feat(compose)` — authors can write their post's description

**Symptom.** The sentence a search engine prints under the title — and that a link preview shows — was a mechanical truncation of the opening paragraph, frequently cut mid-clause. That sentence is what decides whether anyone clicks a result.

**Root cause.** The `summary` column has existed all along and already federates as the Article summary, but only the ingest webhook (`services/webhooks.ts`) could set it. A post written in the editor had no way to.

**Fix.** The composer and the edit page both offer the field, with a character count against `SUMMARY_LENGTH`, the same cap the ingest path derives to — so the two routes into the column agree and neither can store a description long enough to be clipped by every engine that shows it.

Empty is stored as `null` rather than `""`, which is what tells the reader to fall back to the derived excerpt instead of rendering an empty description.

The edit page always sends the field rather than omitting it when untouched: an author who deliberately clears a description must have that saved, and one who never touches it must not lose what they wrote.

---

## 2. `feat(posts)` — related posts at the end of an article

**Symptom.** A post page linked onward to nothing but its author's profile.

That costs three separate things: a crawler reaching an article could go no deeper into the archive (the feeds load older entries with JavaScript, so there was nothing to follow), ranking weight collected on individual posts instead of circulating between them, and a reader who finished a piece had nowhere to go but away.

**Fix.** A "Read next" section under the article — real server-rendered `<a>` links, so readers and crawlers follow the same ones.

Relatedness is tag overlap, then recency. Crude on purpose: it uses the join-table index that already exists, it is explainable to the author who chose those tags, and when a post shares tags with nothing — or carries none — it falls back to recent posts rather than rendering nothing, which would leave the dead end exactly as it was on the posts that most need a way out.

**Local posts only.** This was changed during verification: the rail was initially pulling in federated posts. Those pages are served `noindex` here (they reproduce an article published elsewhere), so linking to one adds nothing to crawl depth and sends a reader to a page we have asked search engines to ignore.

Private and suspended authors are excluded too — the rail has no viewer context to evaluate follow-approval against, so their posts are left out rather than teased and then 404'd. A failure loading the rail degrades to an empty section rather than costing the reader the article.

---

## 3. `feat(seo)` — optional IndexNow submission

**What it does.** A sitemap says "here is everything, come back sometime". IndexNow says "this page, now" — participating engines are told the moment a post is published or edited. Bing, Yandex, Seznam and Naver honour it and share submissions between themselves, so one call reaches all of them.

**Google does not participate.** Their Indexing API is restricted to `JobPosting` and `BroadcastEvent`, and using it for blog posts breaches its terms, so nothing here attempts it. Enabling this changes nothing about how Google sees an instance — worth saying plainly, since that is the engine most operators will assume it affects.

**Off by default, admin toggle.** Turning it on makes the instance send its post URLs to third-party servers on every publish. That is a fair trade for an operator who wants faster indexing, and not something self-hostable software should start doing on someone's behalf uninvited.

**Key handling.** Minted on first enable and then kept — rotating it would invalidate the file the engines have already fetched, and every URL submitted under the old one. It is withheld from the public `/api/seo` response: IndexNow treats the key as semi-public (the engines fetch it from a file on the domain), but handing it to every caller would let anyone submit this instance's URLs at will. The key-file route asks the backend to *confirm a guess* rather than being given the value, so it holds no copy to leak, and 404s entirely while the feature is off.

**Failure and scope.** Submission is a queued job, so a slow or unreachable third party never delays a publish; every failure is logged and swallowed. Nothing is submitted when indexing is switched off (an instance asking not to be indexed must not then push its URLs at anyone), nor for drafts, federated posts belonging to another instance, private or suspended authors, or when `APP_DOMAIN` is a localhost dev host with no URL an engine could fetch.

---

## What was verified

Run against a real stack with the existing 50-post database.

**Descriptions.** A post created with `"  A hand-written   description.  "` stored as `A hand-written description.` (whitespace normalised) and surfaced identically in `<meta name="description">`, `og:description` and the JSON-LD `description`. A 151-character description was rejected with `400 A description can be at most 150 characters.`

**Related posts.** The section renders with real links, and tag matching works — a post tagged `fediverse`/`seo` pulled the two existing fediverse-tagged articles ahead of unrelated ones. After the local-only fix, a federated post that had been appearing no longer does.

**IndexNow**, end to end:

| Check | Result |
|---|---|
| Public `/api/seo`, feature off | `indexNowEnabled: false`, no key |
| Key file while disabled | 404 |
| Admin enable | key minted, returned on the admin payload only |
| Public `/api/seo`, feature on | key still withheld |
| Correct key file | 200, serves the key |
| Wrong key file | 404 |
| Publish with `APP_DOMAIN=localhost` | no outbound call, no submission |

All three commits type-check independently on both apps. Test data (one user, two posts, the IndexNow settings rows) was removed afterwards.

**Not verified:** the composer and edit-page UI. Both need a browser and a login, which I can't drive here — the storage and render paths are proven, the form itself is not. Worth one check after deploy: publish something with a description and confirm it appears in the page source. The same caveat applied to the alt-text button in the previous PR.

## Deploy notes

`git pull && docker compose up -d --build`. No migration, no config change, no Anubis restart.

IndexNow stays off until an admin enables it on the Discoverability page, so this deploy sends nothing anywhere by itself.

## Honest scope note

This makes posts more findable and more clickable. It does not make them rank first — that comes from what is written and who links to it. The technical work is a floor, not a lever.
