### PR TITLE
feat(posts): banner picker with first-image fallback and free photo search

### DIFF
--- a/apps/backend/drizzle/0027_post_cover_credit.sql
+++ b/apps/backend/drizzle/0027_post_cover_credit.sql
@@ -1,0 +1,21 @@
+-- Attribution for a post's banner image. Additive and idempotent.
+--
+-- `posts.cover_url` has existed since the ingest webhook (0024), but only a CMS
+-- could set it. The editor can now choose a banner too, including a free photo
+-- searched from a stock provider — and those come with conditions. A Creative
+-- Commons image has to carry its creator, the work it came from and the licence
+-- it is under; Unsplash's API terms require the photographer and Unsplash both
+-- be credited with links.
+--
+-- One jsonb column rather than a column per part, because the parts differ by
+-- provider: a CC photo needs a licence, an Unsplash one does not, and a future
+-- provider will want something neither has. Splitting them into text columns
+-- would mean a migration every time that shape moved, and five mostly-null
+-- columns on a table read by every timeline query. Nothing here is ever
+-- filtered or joined on — it is rendered as one line under the banner — so
+-- there is nothing an indexed column would buy.
+--
+-- Null for an uploaded banner or one derived from the body, which need no
+-- attribution. Written as a unit with `cover_url` (see services/posts.ts), so a
+-- row can never carry a credit belonging to a banner it no longer shows.
+ALTER TABLE "posts" ADD COLUMN IF NOT EXISTS "cover_credit" jsonb;

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -190,6 +190,13 @@
       "when": 1786209507619,
       "tag": "0026_post_updated_at",
       "breakpoints": true
+    },
+    {
+      "idx": 27,
+      "version": "7",
+      "when": 1786209507620,
+      "tag": "0027_post_cover_credit",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -16,6 +16,7 @@ import {
   uniqueIndex,
   uuid,
 } from "drizzle-orm/pg-core";
+import type { CoverCredit } from "@/lib/cover.ts";
 
 // Postgres full-text search vector. Drizzle has no native `tsvector` type, so we
 // declare a minimal custom type purely so the column and its GIN index live in
@@ -156,10 +157,16 @@ export const posts = pgTable("posts", {
   // The post's banner image: the author's explicit choice, and null when they
   // made none — in which case the first image in the body stands in wherever a
   // banner is shown (see lib/cover.ts). Either an absolute http(s) URL (an
-  // ingested post's own) or a root-relative
+  // ingested post's, or a photo picked from Unsplash) or a root-relative
   // `/api/uploads/…` path for one uploaded here. Federates as the Article
   // `image`, and is the post's Open Graph share image.
   coverUrl: text("cover_url"),
+  // Attribution for the banner: the photographer, the page the photo came from
+  // and, for a Creative Commons image, its licence — see lib/cover.ts for the
+  // shape. Required by the terms the stock providers serve photos under, and
+  // null for an uploaded banner, which needs none. Written as a unit with
+  // `cover_url`, so a row never holds a credit for a banner it no longer shows.
+  coverCredit: jsonb("cover_credit").$type<CoverCredit>(),
   // Stable key from the external system that ingested this post (see
   // services/webhooks.ts) — a CMS slug or document id. Present only on
   // machine-ingested posts, and what makes re-delivery of the same content

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -153,8 +153,12 @@ export const posts = pgTable("posts", {
   // Mastodon shows above a long-form link). Null for human-authored posts,
   // whose preview the reader derives from the body at render time.
   summary: text("summary"),
-  // Absolute http(s) URL of the post's banner image, hosted by whoever sent it.
-  // Federates as the Article `image`. Null unless the post carries one.
+  // The post's banner image: the author's explicit choice, and null when they
+  // made none — in which case the first image in the body stands in wherever a
+  // banner is shown (see lib/cover.ts). Either an absolute http(s) URL (an
+  // ingested post's own) or a root-relative
+  // `/api/uploads/…` path for one uploaded here. Federates as the Article
+  // `image`, and is the post's Open Graph share image.
   coverUrl: text("cover_url"),
   // Stable key from the external system that ingested this post (see
   // services/webhooks.ts) — a CMS slug or document id. Present only on

--- a/apps/backend/src/federation/article.ts
+++ b/apps/backend/src/federation/article.ts
@@ -5,13 +5,19 @@ import { origin } from "@/config.ts";
 import type { Post } from "@/db/schema.ts";
 import type { TagSummary } from "@/db/repositories/tags.ts";
 import { normalizeLanguage } from "@/lib/languages.ts";
+import { absoluteBanner, bannerOf } from "@/lib/cover.ts";
 
-// A cover is stored as an absolute URL the sender hosts; anything unparseable
-// is dropped rather than federated as a broken attachment.
+// The post's banner as an ActivityPub Image.
+//
+// A banner uploaded here is stored root-relative (`/api/uploads/…`), which a
+// receiving instance would resolve against its own host, so it is absolutized
+// against ours first. Anything still unparseable is dropped rather than
+// federated as a broken attachment.
 function coverImage(url: string | null): Image | undefined {
-  if (!url) return undefined;
+  const absolute = absoluteBanner(url, origin);
+  if (!absolute) return undefined;
   try {
-    return new Image({ url: new URL(url) });
+    return new Image({ url: new URL(absolute) });
   } catch {
     return undefined;
   }
@@ -25,8 +31,11 @@ function coverImage(url: string | null): Image | undefined {
 // page. A `summary` (short preview) and `image` (banner) ride along when the
 // post carries them — both are what a receiving instance renders in a link
 // card, so a post ingested with a description and a banner looks the same on
-// Mastodon as it does here. Accepts a post without the internal `search_vector`
-// column, which timeline selects omit.
+// Mastodon as it does here. The banner is the resolved one — the author's
+// chosen cover, or the body's first image standing in for it (lib/cover.ts) —
+// so a post that never had a cover set still federates with a picture. Accepts
+// a post without the internal `search_vector` column, which timeline selects
+// omit.
 export function buildArticle(
   ctx: Context<unknown>,
   identifier: string,
@@ -38,7 +47,7 @@ export function buildArticle(
     attribution: ctx.getActorUri(identifier),
     name: post.title ?? undefined,
     summary: post.summary ?? undefined,
-    image: coverImage(post.coverUrl),
+    image: coverImage(bannerOf(post)),
     // When the author declared a language, tag the content with it (rdf:langString)
     // so remote instances can language-filter it; otherwise send a plain string.
     content: post.language ? new LanguageString(post.contentHtml, post.language) : post.contentHtml,

--- a/apps/backend/src/lib/cover.ts
+++ b/apps/backend/src/lib/cover.ts
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { badRequest } from "@/lib/http.ts";
+
+// A post's banner image: what it is, what an author is allowed to store as one,
+// and how it becomes an absolute URL for the places that need one.
+//
+// Two values are in play and they are not the same thing:
+//
+//   `coverUrl`  — the author's explicit choice, null when they made none.
+//   the banner  — what any reader surface actually shows: the chosen cover, or
+//                 failing that the first image in the body.
+//
+// Keeping them apart is what makes the fallback work. Resolving it at write
+// time would mean storing a derived value as if it had been chosen, and an
+// author who then swapped out the opening photo would be left with a banner
+// pointing at an image no longer in their post. Deriving it on read costs one
+// regex over HTML we are already serializing and is always current — the same
+// reasoning as lib/legacyMarkdown and the frontend's body-image deferral.
+
+// The first `<img src="…">` in a post body.
+//
+// Matching attributes with `[^>]*` is only safe because a stored body has been
+// through the sanitizer (lib/sanitize.ts), which re-serializes every attribute
+// double-quoted and entity-encodes any `>` inside a value. `src` is in its img
+// allowlist and is always present on an image the editor produced.
+const IMG_SRC = /<img\b[^>]*?\ssrc="([^"]*)"/i;
+
+export function firstBodyImage(html: string): string | null {
+  const src = html.match(IMG_SRC)?.[1]?.trim();
+  return src ? src : null;
+}
+
+/**
+ * The banner to show for a post: the author's cover, else the first image in
+ * the body, else nothing.
+ */
+export function bannerOf(
+  post: { coverUrl: string | null; contentHtml: string },
+): string | null {
+  return post.coverUrl ?? firstBodyImage(post.contentHtml);
+}
+
+// Where this instance's own uploads live (see routes/media.ts). A banner
+// uploaded in the editor is stored as this root-relative path rather than an
+// absolute URL, so an instance that later changes domain keeps working.
+const UPLOAD_PATH = /^\/api\/uploads\/[A-Za-z0-9-]+\.(?:png|jpe?g|webp|gif)$/;
+const ABSOLUTE_HTTP = /^https?:\/\/\S+$/i;
+const MAX_URL_LENGTH = 2000;
+
+/**
+ * Make a banner URL absolute against this instance's origin.
+ *
+ * A local upload is stored root-relative, but Open Graph scrapers and remote
+ * instances resolve a relative URL against *themselves*, so every context that
+ * publishes the banner outside this document has to absolutize it first.
+ * Returns null for anything unparseable rather than emitting a broken link.
+ */
+export function absoluteBanner(url: string | null, origin: string): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url, origin).href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate an author-supplied banner URL.
+ *
+ * Two shapes are accepted and nothing else: an absolute http(s) URL (an
+ * Unsplash photo, or a banner on an ingesting CMS's own host) and a path into
+ * this instance's uploads. The narrow allowlist is the point — this value is
+ * rendered as an image `src` and published as an OG tag, so `javascript:` and
+ * `data:` must never reach it, and a path that isn't an upload has no business
+ * being fetched as one.
+ *
+ * `null` is a deliberate clear, distinct from the field being absent.
+ */
+export function normalizeCoverUrl(raw: string | null | undefined): string | null {
+  if (raw === null || raw === undefined) return null;
+  const url = raw.trim();
+  if (!url) return null;
+  if (url.length > MAX_URL_LENGTH) throw badRequest("That banner URL is too long.");
+  if (UPLOAD_PATH.test(url) || ABSOLUTE_HTTP.test(url)) return url;
+  throw badRequest("A banner must be an uploaded image or an absolute http(s) URL.");
+}

--- a/apps/backend/src/lib/cover.ts
+++ b/apps/backend/src/lib/cover.ts
@@ -84,3 +84,90 @@ export function normalizeCoverUrl(raw: string | null | undefined): string | null
   if (UPLOAD_PATH.test(url) || ABSOLUTE_HTTP.test(url)) return url;
   throw badRequest("A banner must be an uploaded image or an absolute http(s) URL.");
 }
+
+/**
+ * Attribution for a banner taken from a stock provider.
+ *
+ * One shape covers every provider, because every provider's terms ask for the
+ * same three things in some combination: who made the photo, where it came
+ * from, and what licence it carries.
+ *
+ *   name / nameUrl      the photographer, and a link to them
+ *   source / sourceUrl  where the photo lives ("Unsplash", "Flickr", …)
+ *   license/licenseUrl  the Creative Commons licence, when there is one —
+ *                       absent for Unsplash, which serves photos under its own
+ *                       licence rather than a named public one
+ *
+ * Rendered as a single line under the banner (see the post page).
+ */
+export type CoverCredit = {
+  name: string;
+  nameUrl: string;
+  source: string;
+  sourceUrl: string;
+  license?: string;
+  licenseUrl?: string;
+};
+
+const MAX_CREDIT_TEXT = 120;
+
+function creditText(value: unknown, field: string): string {
+  const text = typeof value === "string" ? value.trim() : "";
+  if (text.length > MAX_CREDIT_TEXT) throw badRequest(`The banner credit's ${field} is too long.`);
+  return text;
+}
+
+function creditUrl(value: unknown, field: string): string {
+  const url = typeof value === "string" ? value.trim() : "";
+  if (!url) return "";
+  if (url.length > MAX_URL_LENGTH || !ABSOLUTE_HTTP.test(url)) {
+    throw badRequest(`The banner credit's ${field} must be an absolute http(s) URL.`);
+  }
+  return url;
+}
+
+/**
+ * Validate the attribution that rides along with a banner.
+ *
+ * The four required parts arrive together or not at all: a name with nowhere to
+ * link is not a credit anyone can follow, and a link with nothing labelling it
+ * credits no one. Every URL is absolute http(s) for the same reason the cover's
+ * is — each becomes an `href` on the post page.
+ *
+ * The licence is optional but paired: a licence name with no link tells a
+ * reader which terms apply without letting them read them, which is exactly
+ * what a Creative Commons attribution is required to provide.
+ */
+export function normalizeCoverCredit(
+  raw: Partial<Record<keyof CoverCredit, unknown>> | null | undefined,
+): CoverCredit | null {
+  if (raw === null || raw === undefined) return null;
+
+  const name = creditText(raw.name, "name");
+  const source = creditText(raw.source, "source");
+  const nameUrl = creditUrl(raw.nameUrl, "creator link");
+  const sourceUrl = creditUrl(raw.sourceUrl, "source link");
+  const license = creditText(raw.license, "licence");
+  const licenseUrl = creditUrl(raw.licenseUrl, "licence link");
+
+  // Nothing supplied at all is "no credit", not a malformed one — an uploaded
+  // banner takes this path.
+  if (!name && !nameUrl && !source && !sourceUrl && !license && !licenseUrl) return null;
+
+  if (!name || !nameUrl || !source || !sourceUrl) {
+    throw badRequest(
+      "A banner credit needs a creator and a source, each with a link.",
+    );
+  }
+  if (Boolean(license) !== Boolean(licenseUrl)) {
+    throw badRequest("A banner credit's licence needs both a name and a link.");
+  }
+
+  return {
+    name,
+    nameUrl,
+    source,
+    sourceUrl,
+    ...(license ? { license, licenseUrl } : {}),
+  };
+}

--- a/apps/backend/src/lib/cover_test.ts
+++ b/apps/backend/src/lib/cover_test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { assertEquals, assertThrows } from "@std/assert";
+import { absoluteBanner, bannerOf, firstBodyImage, normalizeCoverUrl } from "@/lib/cover.ts";
+
+// A banner is rendered as an image `src`, published as an Open Graph tag and
+// federated as the Article `image` — three places an unvalidated URL would be
+// actively harmful. And the fallback to the body's first image is what most
+// posts will actually display, so it has to hold up on real editor output.
+
+Deno.test("firstBodyImage: takes the first image, not a later one", () => {
+  const html = '<p>Hi</p><img src="/api/uploads/a.webp" alt="" /><img src="/api/uploads/b.webp" />';
+  assertEquals(firstBodyImage(html), "/api/uploads/a.webp");
+});
+
+Deno.test("firstBodyImage: finds src after other attributes", () => {
+  // The editor's resizable image writes width/class before src.
+  assertEquals(
+    firstBodyImage('<img class="w-full" width="600" src="https://cdn.test/x.jpg" alt="A cat" />'),
+    "https://cdn.test/x.jpg",
+  );
+});
+
+Deno.test("firstBodyImage: null when the body has no image", () => {
+  assertEquals(firstBodyImage("<p>Just words.</p>"), null);
+  assertEquals(firstBodyImage('<img alt="broken" />'), null);
+});
+
+Deno.test("bannerOf: the chosen cover wins over the body", () => {
+  assertEquals(
+    bannerOf({ coverUrl: "https://cdn.test/chosen.jpg", contentHtml: '<img src="/body.png" />' }),
+    "https://cdn.test/chosen.jpg",
+  );
+});
+
+Deno.test("bannerOf: falls back to the body's first image, then to nothing", () => {
+  assertEquals(bannerOf({ coverUrl: null, contentHtml: '<img src="/body.png" />' }), "/body.png");
+  assertEquals(bannerOf({ coverUrl: null, contentHtml: "<p>Words.</p>" }), null);
+});
+
+Deno.test("absoluteBanner: resolves an upload path against the instance origin", () => {
+  assertEquals(
+    absoluteBanner("/api/uploads/a.webp", "https://blog.test"),
+    "https://blog.test/api/uploads/a.webp",
+  );
+  // An already-absolute URL is left where it is — it is on someone else's host.
+  assertEquals(
+    absoluteBanner("https://images.test/x.jpg", "https://blog.test"),
+    "https://images.test/x.jpg",
+  );
+  assertEquals(absoluteBanner(null, "https://blog.test"), null);
+});
+
+Deno.test("normalizeCoverUrl: accepts an upload path and an absolute URL", () => {
+  assertEquals(normalizeCoverUrl("/api/uploads/9f-2b.webp"), "/api/uploads/9f-2b.webp");
+  assertEquals(
+    normalizeCoverUrl("  https://images.unsplash.com/photo-1?w=1600 "),
+    "https://images.unsplash.com/photo-1?w=1600",
+  );
+});
+
+Deno.test("normalizeCoverUrl: empty and null both clear the banner", () => {
+  assertEquals(normalizeCoverUrl(null), null);
+  assertEquals(normalizeCoverUrl(undefined), null);
+  assertEquals(normalizeCoverUrl("   "), null);
+});
+
+Deno.test("normalizeCoverUrl: rejects anything that isn't one of the two shapes", () => {
+  for (
+    const bad of [
+      "javascript:alert(1)",
+      "data:image/svg+xml;base64,PHN2Zz48L3N2Zz4=",
+      // Not an upload: a path traversal, and a path outside the uploads route.
+      "/api/uploads/../../etc/passwd",
+      "/etc/passwd",
+      "//evil.test/x.jpg",
+    ]
+  ) {
+    assertThrows(() => normalizeCoverUrl(bad), Error);
+  }
+});

--- a/apps/backend/src/lib/cover_test.ts
+++ b/apps/backend/src/lib/cover_test.ts
@@ -1,6 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { assertEquals, assertThrows } from "@std/assert";
-import { absoluteBanner, bannerOf, firstBodyImage, normalizeCoverUrl } from "@/lib/cover.ts";
+import {
+  absoluteBanner,
+  bannerOf,
+  firstBodyImage,
+  normalizeCoverCredit,
+  normalizeCoverUrl,
+} from "@/lib/cover.ts";
 
 // A banner is rendered as an image `src`, published as an Open Graph tag and
 // federated as the Article `image` — three places an unvalidated URL would be
@@ -77,4 +83,59 @@ Deno.test("normalizeCoverUrl: rejects anything that isn't one of the two shapes"
   ) {
     assertThrows(() => normalizeCoverUrl(bad), Error);
   }
+});
+
+Deno.test("normalizeCoverCredit: keeps a complete credit, drops an empty one", () => {
+  assertEquals(
+    normalizeCoverCredit({
+      name: " Ada Lovelace ",
+      nameUrl: "https://unsplash.com/@ada",
+      source: "Unsplash",
+      sourceUrl: "https://unsplash.com/photos/abc",
+    }),
+    {
+      name: "Ada Lovelace",
+      nameUrl: "https://unsplash.com/@ada",
+      source: "Unsplash",
+      sourceUrl: "https://unsplash.com/photos/abc",
+    },
+  );
+  assertEquals(normalizeCoverCredit(null), null);
+  assertEquals(normalizeCoverCredit({}), null);
+});
+
+Deno.test("normalizeCoverCredit: carries a Creative Commons licence through", () => {
+  assertEquals(
+    normalizeCoverCredit({
+      name: "Marufish",
+      nameUrl: "https://www.flickr.com/photos/8819274@N04",
+      source: "Flickr",
+      sourceUrl: "https://www.flickr.com/photos/8819274@N04/8344491578",
+      license: "CC BY-SA 2.0",
+      licenseUrl: "https://creativecommons.org/licenses/by-sa/2.0/",
+    })?.license,
+    "CC BY-SA 2.0",
+  );
+});
+
+Deno.test("normalizeCoverCredit: a partial credit is an error, not a partial credit", () => {
+  const full = {
+    name: "Ada",
+    nameUrl: "https://unsplash.com/@ada",
+    source: "Unsplash",
+    sourceUrl: "https://unsplash.com/photos/abc",
+  };
+  // Each required part missing in turn.
+  for (const key of ["name", "nameUrl", "source", "sourceUrl"] as const) {
+    assertThrows(() => normalizeCoverCredit({ ...full, [key]: "" }), Error, "creator and a source");
+  }
+  // A licence without somewhere to read it states terms it cannot show.
+  assertThrows(
+    () => normalizeCoverCredit({ ...full, license: "CC BY 2.0" }),
+    Error,
+    "licence needs both",
+  );
+  // Every link is an href on the post page, so none of them may be a script URL.
+  assertThrows(() => normalizeCoverCredit({ ...full, nameUrl: "javascript:alert(1)" }), Error);
+  assertThrows(() => normalizeCoverCredit({ ...full, sourceUrl: "/relative" }), Error);
 });

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import * as settings from "@/services/settings.ts";
 import * as anubis from "@/services/anubisProtection.ts";
 import * as seo from "@/services/seo.ts";
+import * as unsplash from "@/services/unsplash.ts";
 import * as moderation from "@/services/moderation.ts";
 import * as emailSettings from "@/services/emailSettings.ts";
 import * as setup from "@/services/instanceSetup.ts";
@@ -96,6 +97,28 @@ adminRoutes.put("/seo", async (c) => {
   if (!parsed.success) throw badRequest("Invalid SEO settings.");
   await seo.setSeoSettings(parsed.data);
   return c.json(await seo.getSeoSettings());
+});
+
+// ── Media (Unsplash banner picker) ──────────────────────────────────────────
+
+// The access key that turns the editor's Unsplash tab on. Only ever reported as
+// configured-or-not: an admin who wants to check the key reads it from their
+// Unsplash dashboard, and echoing a stored credential back over the API is how
+// one ends up in a browser cache or a screenshot.
+adminRoutes.get("/unsplash", async (c) => {
+  requireAdmin(c);
+  return c.json({ configured: await unsplash.configured() });
+});
+
+// A blank (or omitted) key clears it, which is how the feature is turned off.
+const unsplashSchema = z.object({ accessKey: z.string().trim().max(200).nullish() });
+
+adminRoutes.put("/unsplash", async (c) => {
+  requireAdmin(c);
+  const parsed = unsplashSchema.safeParse(await c.req.json().catch(() => null));
+  if (!parsed.success) throw badRequest("Expected { accessKey: string | null }.");
+  await unsplash.setAccessKey(parsed.data.accessKey ?? null);
+  return c.json({ configured: await unsplash.configured() });
 });
 
 // ── Instance identity (runtime config) ──────────────────────────────────────

--- a/apps/backend/src/routes/index.ts
+++ b/apps/backend/src/routes/index.ts
@@ -15,6 +15,7 @@ import { reportRoutes } from "@/routes/reports.ts";
 import { notificationRoutes } from "@/routes/notifications.ts";
 import { instanceRoutes, setupRoutes } from "@/routes/setup.ts";
 import { seoRoutes } from "@/routes/seo.ts";
+import { photoRoutes } from "@/routes/photos.ts";
 import { webhookRoutes } from "@/routes/webhooks.ts";
 import type { AppEnv } from "@/routes/types.ts";
 
@@ -37,4 +38,5 @@ apiRoutes.route("/notifications", notificationRoutes);
 apiRoutes.route("/instance", instanceRoutes);
 apiRoutes.route("/setup", setupRoutes);
 apiRoutes.route("/seo", seoRoutes);
+apiRoutes.route("/photos", photoRoutes);
 apiRoutes.route("/webhooks", webhookRoutes);

--- a/apps/backend/src/routes/photos.ts
+++ b/apps/backend/src/routes/photos.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { Hono } from "hono";
+import * as stockPhotos from "@/services/stockPhotos.ts";
+import { requireUser } from "@/routes/middleware.ts";
+import { rateLimit } from "@/lib/rateLimit.ts";
+import { badRequest } from "@/lib/http.ts";
+import type { AppEnv } from "@/routes/types.ts";
+
+// Free-photo search for the editor's banner picker. Every route is
+// signed-in-only: an anonymous visitor has no post to put a banner on, and one
+// of the providers spends an instance-wide quota that shouldn't be open to the
+// internet.
+export const photoRoutes = new Hono<AppEnv>();
+
+// Search is a GET, so the app-wide write throttle doesn't cover it. Both
+// providers are shared resources — Unsplash bills a per-instance quota (50/hour
+// on their demo tier) and Openverse rate-limits anonymous callers by IP, so
+// this instance is one caller to them however many writers it has. One author
+// refining a search must not be able to exhaust either for everyone else.
+const searchLimiter = rateLimit({
+  name: "photo-search",
+  windowMs: 60_000,
+  max: 20,
+  key: (c) => `u:${c.get("user")?.id ?? "anon"}`,
+});
+
+// Which providers the picker should offer, in order. Never empty: Openverse
+// needs no configuration, so the picker always has something behind it.
+photoRoutes.get("/providers", async (c) => {
+  requireUser(c);
+  return c.json({ providers: await stockPhotos.available() });
+});
+
+photoRoutes.get("/search", searchLimiter, async (c) => {
+  requireUser(c);
+  const provider = stockPhotos.requireProvider(c.req.query("provider"));
+  const page = Number(c.req.query("page") ?? "1");
+  const items = await stockPhotos.search(
+    provider,
+    c.req.query("q") ?? "",
+    Number.isFinite(page) ? page : 1,
+  );
+  return c.json({ items });
+});
+
+// Called once, when an author picks a photo, for providers that ask to be told.
+// Unsplash's API terms require it — it is what keeps a photographer's download
+// count honest when we hotlink their image. Best-effort inside the service, so
+// this always answers ok.
+photoRoutes.post("/use", async (c) => {
+  requireUser(c);
+  const body = await c.req.json().catch(() => null) as
+    | { provider?: unknown; token?: unknown }
+    | null;
+  const provider = stockPhotos.requireProvider(body?.provider);
+  if (typeof body?.token !== "string" || !body.token) {
+    throw badRequest("Expected { provider: string, token: string }.");
+  }
+  await stockPhotos.recordUse(provider, body.token);
+  return c.json({ ok: true });
+});

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -4,6 +4,7 @@ import type { PostWithAuthor } from "@/db/repositories/posts.ts";
 import type { CommentWithAuthor } from "@/db/repositories/comments.ts";
 import type { NotificationRow } from "@/db/repositories/notifications.ts";
 import { htmlToText } from "@/lib/html.ts";
+import { bannerOf } from "@/lib/cover.ts";
 
 // Minimal API payloads — never leak password hashes, keys, or emails publicly.
 
@@ -116,7 +117,12 @@ export function postWithAuthor(
     // Present only on ingested posts (see services/webhooks.ts); null for
     // anything written in the editor, whose preview the reader derives itself.
     summary: row.post.summary,
+    // The author's explicit banner choice (null when they made none) and what
+    // to actually display — see lib/cover.ts. The editor reads the first, so
+    // reopening a post never turns a fallback into a choice; every reader
+    // surface reads the second.
     coverUrl: row.post.coverUrl,
+    bannerUrl: bannerOf(row.post),
     createdAt: row.post.createdAt,
     // When the content itself last changed. The reader's `dateModified` in the
     // page's structured data, so an edited article is re-read rather than left
@@ -273,6 +279,7 @@ export function barePost(p: Omit<Post, "searchVector">) {
     language: p.language,
     summary: p.summary,
     coverUrl: p.coverUrl,
+    bannerUrl: bannerOf(p),
     createdAt: p.createdAt,
   };
 }

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -123,6 +123,7 @@ export function postWithAuthor(
     // surface reads the second.
     coverUrl: row.post.coverUrl,
     bannerUrl: bannerOf(row.post),
+    coverCredit: row.post.coverCredit ?? null,
     createdAt: row.post.createdAt,
     // When the content itself last changed. The reader's `dateModified` in the
     // page's structured data, so an edited article is re-read rather than left
@@ -280,6 +281,7 @@ export function barePost(p: Omit<Post, "searchVector">) {
     summary: p.summary,
     coverUrl: p.coverUrl,
     bannerUrl: bannerOf(p),
+    coverCredit: p.coverCredit ?? null,
     createdAt: p.createdAt,
   };
 }

--- a/apps/backend/src/services/openverse.ts
+++ b/apps/backend/src/services/openverse.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { badRequest } from "@/lib/http.ts";
+import type { StockPhoto } from "@/services/stockPhotos.ts";
+import { APP_VERSION } from "@/version.ts";
+
+// Openverse (openverse.org, run by WordPress) — the banner picker's default
+// photo source, and the reason the picker works on a fresh instance.
+//
+// It indexes openly-licensed images from Flickr, Wikimedia Commons, museums and
+// others, and its API takes anonymous requests: no registration, no key, no
+// admin setup. That is the whole reason it is the default. Unsplash has nicer
+// photographs but cannot be used without an operator going and getting a key,
+// which is exactly the configuration step this feature should not require.
+//
+// The trade is attribution. Most of what Openverse indexes is Creative Commons
+// rather than public domain, so a photo generally has to be credited with its
+// creator, its source and its licence — all of which the API returns and all of
+// which is stored on the post and rendered under the banner (see lib/cover.ts).
+
+const API = "https://api.openverse.org/v1/images/";
+const TIMEOUT_MS = 8000;
+// Openverse's hard ceiling for anonymous callers — asking for more is a 401,
+// not a truncated page. Still a full grid.
+const PER_PAGE = 20;
+
+// Openverse asks anonymous callers to identify themselves so they can tell
+// traffic apart and reach an operator whose instance misbehaves.
+const USER_AGENT = `Omicron/${APP_VERSION} (+https://github.com/the-jk-labs/omicron)`;
+
+// Only photos a blog can actually use: commercially usable (many instances
+// carry ads or sponsorship) and modifiable (a banner is cropped to 16:9 by the
+// layout, which is a derivative work). This excludes ND and NC licences, which
+// a writer would otherwise be offered and quietly breach by publishing.
+const LICENSE_FILTER = "commercial,modification";
+
+/** Human-readable licence name, e.g. "CC BY-SA 2.0" or "Public domain". */
+function licenseLabel(code: string, version: string): string {
+  const slug = code.toUpperCase();
+  // Openverse's two public-domain marks are not "CC …" licences and read
+  // wrongly if formatted as one.
+  if (slug === "CC0") return version ? `CC0 ${version}` : "CC0";
+  if (slug === "PDM") return "Public domain";
+  return version ? `CC ${slug} ${version}` : `CC ${slug}`;
+}
+
+type RawImage = {
+  id?: unknown;
+  title?: unknown;
+  url?: unknown;
+  thumbnail?: unknown;
+  foreign_landing_url?: unknown;
+  creator?: unknown;
+  creator_url?: unknown;
+  license?: unknown;
+  license_version?: unknown;
+  license_url?: unknown;
+  source?: unknown;
+  provider?: unknown;
+};
+
+const str = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+
+// A photo is only usable if it can be shown *and* credited. Anything missing a
+// piece of its attribution is dropped rather than published under an incomplete
+// credit — the licence is the condition of using it at all, so a result we
+// cannot attribute is a result we cannot offer.
+function toPhoto(raw: RawImage): StockPhoto | null {
+  const id = str(raw.id);
+  const bannerUrl = str(raw.url);
+  const thumbUrl = str(raw.thumbnail) || bannerUrl;
+  const name = str(raw.creator);
+  const nameUrl = str(raw.creator_url);
+  const sourceUrl = str(raw.foreign_landing_url);
+  const source = str(raw.source) || str(raw.provider);
+  const license = str(raw.license);
+  const licenseUrl = str(raw.license_url);
+  if (!id || !bannerUrl || !name || !nameUrl || !sourceUrl || !source) return null;
+  if (!license || !licenseUrl) return null;
+
+  return {
+    id,
+    alt: str(raw.title),
+    thumbUrl,
+    bannerUrl,
+    credit: {
+      name,
+      nameUrl,
+      // "flickr" → "Flickr". The API returns a lowercase key, and the credit
+      // line reads as a sentence.
+      source: source.charAt(0).toUpperCase() + source.slice(1),
+      sourceUrl,
+      license: licenseLabel(license, str(raw.license_version)),
+      licenseUrl,
+    },
+    // Openverse asks for no usage ping.
+    useToken: null,
+  };
+}
+
+/**
+ * Search Openverse for photos matching `query`.
+ *
+ * Failures surface as a 400 the editor can print rather than a 500: Openverse
+ * being slow, rate-limiting an anonymous caller, or down is a condition of the
+ * outside world, not a fault in this instance, and the author needs to be told
+ * which so they know whether retrying is worth it.
+ */
+export async function search(query: string, page = 1): Promise<StockPhoto[]> {
+  const params = new URLSearchParams({
+    q: query.slice(0, 100),
+    page: String(page),
+    page_size: String(PER_PAGE),
+    license_type: LICENSE_FILTER,
+    // Openverse flags what its providers marked as sensitive; a banner picker
+    // in a writing tool should not surface it.
+    mature: "false",
+  });
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  let res: Response;
+  try {
+    res = await fetch(`${API}?${params}`, {
+      headers: { accept: "application/json", "user-agent": USER_AGENT },
+      signal: controller.signal,
+    });
+  } catch {
+    throw badRequest("Couldn't reach the photo search. Try again in a moment.");
+  } finally {
+    clearTimeout(timer);
+  }
+
+  // Openverse rate-limits anonymous callers by IP, so this instance is one
+  // caller to them however many writers it has.
+  if (res.status === 429) {
+    throw badRequest("The photo search is busy right now. Try again in a minute.");
+  }
+  if (!res.ok) throw badRequest("Photo search failed. Try again in a moment.");
+
+  const body = await res.json().catch(() => null) as { results?: RawImage[] } | null;
+  return (body?.results ?? []).map(toPhoto).filter((p): p is StockPhoto => p !== null);
+}

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -9,7 +9,7 @@ import { badRequest, forbidden, notFound } from "@/lib/http.ts";
 import { MAX_TAGS_PER_POST, normalizeTags } from "@/lib/tags.ts";
 import { type LanguageFilter, normalizeLanguage } from "@/lib/languages.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
-import { normalizeCoverUrl } from "@/lib/cover.ts";
+import { normalizeCoverCredit, normalizeCoverUrl } from "@/lib/cover.ts";
 import { SUMMARY_LENGTH as MAX_SUMMARY } from "@/lib/webhook.ts";
 import { queue } from "@/queue/queue.ts";
 
@@ -37,6 +37,21 @@ export function normalizeSummary(raw: string | null | undefined): string | null 
   return text;
 }
 
+// The banner columns for a write, from what the author chose in the editor.
+//
+// The credit belongs to the image, so the two always move together: clearing
+// the banner clears the credit, and replacing an Unsplash photo with an upload
+// (which needs no attribution) drops the photographer's name with it. Sending
+// one without the other could otherwise leave a post crediting someone for a
+// picture it no longer shows.
+function coverFields(
+  coverUrl: string | null | undefined,
+  coverCredit: Record<string, unknown> | null | undefined,
+) {
+  const url = normalizeCoverUrl(coverUrl);
+  return { coverUrl: url, coverCredit: url ? normalizeCoverCredit(coverCredit) : null };
+}
+
 // Normalizes and validates author-supplied tags, capping the count per post.
 // Exported so every write path that accepts tags — the editor here, ingested
 // content in services/webhooks.ts — enforces the same cap.
@@ -56,6 +71,7 @@ export async function createPost(authorId: string, input: {
   language?: string | null;
   summary?: string | null;
   coverUrl?: string | null;
+  coverCredit?: Record<string, unknown> | null;
   tags?: string[];
 }) {
   const status = input.status === "draft" ? "draft" : "published";
@@ -80,7 +96,7 @@ export async function createPost(authorId: string, input: {
     status,
     language: normalizeLanguage(input.language),
     summary: normalizeSummary(input.summary),
-    coverUrl: normalizeCoverUrl(input.coverUrl),
+    ...coverFields(input.coverUrl, input.coverCredit),
   });
 
   if (tags !== undefined) await tagsRepo.setPostTags(post.id, tags);
@@ -161,6 +177,7 @@ export async function updatePost(authorId: string, id: string, input: {
   language?: string | null;
   summary?: string | null;
   coverUrl?: string | null;
+  coverCredit?: Record<string, unknown> | null;
   tags?: string[];
 }) {
   const row = await postsRepo.findById(id);
@@ -194,7 +211,10 @@ export async function updatePost(authorId: string, id: string, input: {
     ...(input.status !== undefined ? { status } : {}),
     ...(input.language !== undefined ? { language: normalizeLanguage(input.language) } : {}),
     ...(input.summary !== undefined ? { summary: normalizeSummary(input.summary) } : {}),
-    ...(input.coverUrl !== undefined ? { coverUrl: normalizeCoverUrl(input.coverUrl) } : {}),
+    // `coverUrl` present is the whole banner decision, credit included — an
+    // editor that sends the field always sends both, and one that sends
+    // neither (the ingest webhook's partial updates) leaves the row alone.
+    ...(input.coverUrl !== undefined ? coverFields(input.coverUrl, input.coverCredit) : {}),
   };
 
   // A tags-only edit touches no post columns; skip the update (drizzle rejects

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -9,6 +9,7 @@ import { badRequest, forbidden, notFound } from "@/lib/http.ts";
 import { MAX_TAGS_PER_POST, normalizeTags } from "@/lib/tags.ts";
 import { type LanguageFilter, normalizeLanguage } from "@/lib/languages.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
+import { normalizeCoverUrl } from "@/lib/cover.ts";
 import { SUMMARY_LENGTH as MAX_SUMMARY } from "@/lib/webhook.ts";
 import { queue } from "@/queue/queue.ts";
 
@@ -54,6 +55,7 @@ export async function createPost(authorId: string, input: {
   status?: string;
   language?: string | null;
   summary?: string | null;
+  coverUrl?: string | null;
   tags?: string[];
 }) {
   const status = input.status === "draft" ? "draft" : "published";
@@ -78,6 +80,7 @@ export async function createPost(authorId: string, input: {
     status,
     language: normalizeLanguage(input.language),
     summary: normalizeSummary(input.summary),
+    coverUrl: normalizeCoverUrl(input.coverUrl),
   });
 
   if (tags !== undefined) await tagsRepo.setPostTags(post.id, tags);
@@ -157,6 +160,7 @@ export async function updatePost(authorId: string, id: string, input: {
   status?: string;
   language?: string | null;
   summary?: string | null;
+  coverUrl?: string | null;
   tags?: string[];
 }) {
   const row = await postsRepo.findById(id);
@@ -190,6 +194,7 @@ export async function updatePost(authorId: string, id: string, input: {
     ...(input.status !== undefined ? { status } : {}),
     ...(input.language !== undefined ? { language: normalizeLanguage(input.language) } : {}),
     ...(input.summary !== undefined ? { summary: normalizeSummary(input.summary) } : {}),
+    ...(input.coverUrl !== undefined ? { coverUrl: normalizeCoverUrl(input.coverUrl) } : {}),
   };
 
   // A tags-only edit touches no post columns; skip the update (drizzle rejects

--- a/apps/backend/src/services/stockPhotos.ts
+++ b/apps/backend/src/services/stockPhotos.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { CoverCredit } from "@/lib/cover.ts";
+import { badRequest } from "@/lib/http.ts";
+import * as openverse from "@/services/openverse.ts";
+import * as unsplash from "@/services/unsplash.ts";
+
+// Free-photo search for the editor's banner picker, so a writer can put a
+// decent, properly-licensed photo at the top of a post without leaving the page
+// or working out for themselves whether they are allowed to use it.
+//
+// Two providers, deliberately:
+//
+//   Openverse  needs no credentials and is therefore always on. It is the
+//              reason this feature works on a fresh instance with nothing
+//              configured, which is the whole point — an operator should not
+//              have to register with a third party to get a working editor.
+//
+//   Unsplash   has better-curated photography but issues a per-application key
+//              and has no anonymous mode, so it can only ever be an opt-in an
+//              operator enables (see services/unsplash.ts). No key, no tab.
+//
+// Both normalize to `StockPhoto` below, so the picker renders one grid and the
+// post stores one credit shape whichever tab the author used.
+
+/** One photo, reduced to what the picker and the post actually need. */
+export type StockPhoto = {
+  /** Unique within a provider's results; used as the grid's key. */
+  id: string;
+  /** The provider's own description, for the grid's alt text. */
+  alt: string;
+  /** Small, for the results grid. */
+  thumbUrl: string;
+  /** Full-width, what gets stored as the post's banner. */
+  bannerUrl: string;
+  /** Attribution to store alongside the banner, already assembled. */
+  credit: CoverCredit;
+  /**
+   * Provider-specific token identifying this photo for `recordUse`, or null
+   * when the provider asks for nothing. Opaque to the client, which passes it
+   * back untouched.
+   */
+  useToken: string | null;
+};
+
+export const PROVIDERS = ["openverse", "unsplash"] as const;
+export type Provider = typeof PROVIDERS[number];
+
+export function isProvider(value: unknown): value is Provider {
+  return typeof value === "string" && (PROVIDERS as readonly string[]).includes(value);
+}
+
+/**
+ * The providers this instance can actually search right now, in the order the
+ * picker should offer them. Openverse is always present, so the list is never
+ * empty and the picker is never offered with nothing behind it.
+ */
+export async function available(): Promise<Provider[]> {
+  return await unsplash.configured() ? ["openverse", "unsplash"] : ["openverse"];
+}
+
+export async function search(
+  provider: Provider,
+  query: string,
+  page = 1,
+): Promise<StockPhoto[]> {
+  const q = query.trim();
+  if (!q) return [];
+  // Clamped here rather than in each provider: they agree on 1-based paging,
+  // and a caller walking to page 10,000 is spending someone else's quota.
+  const p = Math.min(Math.max(Math.trunc(page) || 1, 1), 20);
+  return provider === "unsplash" ? await unsplash.search(q, p) : await openverse.search(q, p);
+}
+
+/**
+ * Tell a provider one of its photos was actually used.
+ *
+ * Unsplash's API terms require this — it is how a photographer's download count
+ * stays honest when we hotlink their image. Openverse asks for nothing, so this
+ * is a no-op there. Best-effort in both cases: choosing a banner must not fail
+ * because a third party's counter was unreachable.
+ */
+export async function recordUse(provider: Provider, token: string): Promise<void> {
+  if (provider === "unsplash") await unsplash.trackDownload(token);
+}
+
+/** Rejects an unknown provider before it reaches a service. */
+export function requireProvider(value: unknown): Provider {
+  if (!isProvider(value)) throw badRequest("Unknown photo provider.");
+  return value;
+}

--- a/apps/backend/src/services/unsplash.ts
+++ b/apps/backend/src/services/unsplash.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import * as settingsRepo from "@/db/repositories/instanceSettings.ts";
+import { badRequest } from "@/lib/http.ts";
+import type { StockPhoto } from "@/services/stockPhotos.ts";
+
+// Unsplash — the banner picker's optional second source, alongside the
+// always-available Openverse (see services/stockPhotos.ts).
+//
+// Optional because it cannot be anything else: Unsplash issues a key per
+// registered application and has no anonymous mode, so there is no version of
+// this that works on a fresh instance. Shipping one shared key would put it in
+// a public repository, spend a single quota across every instance in the world,
+// and breach the terms it was issued under. So an operator pastes their own key
+// in the admin panel, or this provider simply isn't offered.
+//
+// The key never leaves the server. Searches are proxied through this instance
+// rather than called from the browser, which is also what Unsplash's terms
+// require (a public key would be anyone's to spend).
+
+const KEYS = {
+  accessKey: "media.unsplashAccessKey",
+} as const;
+
+const API = "https://api.unsplash.com";
+// Unsplash pins its response shape to a dated API version; sending it means a
+// later default on their side can't silently change what we parse.
+const API_VERSION = "v1";
+// A slow third party must not hold an editor request open indefinitely.
+const TIMEOUT_MS = 8000;
+// One screenful. Unsplash's demo tier allows 50 requests an hour, so the picker
+// asks for a usable page rather than paging aggressively.
+const PER_PAGE = 24;
+
+/**
+ * Attribution query string required by the Unsplash API guidelines: every link
+ * back to a photographer or to Unsplash has to identify the referring app.
+ */
+const UTM = "utm_source=omicron&utm_medium=referral";
+
+export function withUtm(url: string): string {
+  return `${url}${url.includes("?") ? "&" : "?"}${UTM}`;
+}
+
+export async function accessKey(): Promise<string | null> {
+  const key = await settingsRepo.get<string>(KEYS.accessKey);
+  return key?.trim() || null;
+}
+
+/** Whether the picker should be offered at all. */
+export async function configured(): Promise<boolean> {
+  return (await accessKey()) !== null;
+}
+
+/**
+ * Store or clear the access key. Passing null (or a blank string) removes it,
+ * which is how an operator turns the feature back off.
+ *
+ * Cleared as an empty string rather than a JSON null: `instance_settings.value`
+ * is NOT NULL, and every reader here already treats blank as absent — so this
+ * keeps the store's invariant instead of loosening a column for one setting.
+ */
+export function setAccessKey(key: string | null): Promise<void> {
+  return settingsRepo.set(KEYS.accessKey, key?.trim() || "");
+}
+
+type RawPhoto = {
+  id?: unknown;
+  alt_description?: unknown;
+  description?: unknown;
+  urls?: { small?: unknown; regular?: unknown };
+  links?: { download_location?: unknown };
+  user?: { name?: unknown; username?: unknown; links?: { html?: unknown } };
+};
+
+const str = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+
+// Skips anything missing a piece we cannot do without: an image to show, a
+// photographer to credit, and the download endpoint their terms oblige us to
+// call. A partial result is dropped rather than rendered as a photo we would be
+// using without attribution.
+function toPhoto(raw: RawPhoto): StockPhoto | null {
+  const id = str(raw.id);
+  const thumbUrl = str(raw.urls?.small);
+  const bannerUrl = str(raw.urls?.regular);
+  const name = str(raw.user?.name) || str(raw.user?.username);
+  const profile = str(raw.user?.links?.html);
+  const useToken = str(raw.links?.download_location);
+  if (!id || !thumbUrl || !bannerUrl || !name || !profile || !useToken) return null;
+  return {
+    id,
+    alt: str(raw.alt_description) || str(raw.description) || "",
+    thumbUrl,
+    bannerUrl,
+    // No licence: Unsplash serves photos under its own licence rather than a
+    // named public one, so there is nothing to link a reader to. Their terms
+    // ask for the photographer and Unsplash itself, both with UTM-tagged links.
+    credit: {
+      name,
+      nameUrl: withUtm(profile),
+      source: "Unsplash",
+      sourceUrl: withUtm(`https://unsplash.com/photos/${id}`),
+    },
+    useToken,
+  };
+}
+
+async function call(url: string, key: string): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    return await fetch(url, {
+      headers: {
+        authorization: `Client-ID ${key}`,
+        "accept-version": API_VERSION,
+      },
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Search Unsplash for photos matching `query`.
+ *
+ * Failures are reported as a 400 the editor can print, never as a 500: an
+ * expired key or a rate limit is a condition of the operator's account, not a
+ * fault in this instance, and the author needs to be told which.
+ */
+export async function search(query: string, page = 1): Promise<StockPhoto[]> {
+  const key = await accessKey();
+  if (!key) throw badRequest("Unsplash search isn't set up on this instance.");
+
+  const params = new URLSearchParams({
+    query: query.slice(0, 100),
+    page: String(page),
+    per_page: String(PER_PAGE),
+    // Photos only — an illustration or a vector makes a poor 16:9 banner.
+    content_filter: "high",
+    orientation: "landscape",
+  });
+
+  let res: Response;
+  try {
+    res = await call(`${API}/search/photos?${params}`, key);
+  } catch {
+    throw badRequest("Couldn't reach Unsplash. Try again in a moment.");
+  }
+
+  if (res.status === 401) throw badRequest("Unsplash rejected this instance's access key.");
+  if (res.status === 403) {
+    throw badRequest("This instance has hit its Unsplash rate limit. Try again later.");
+  }
+  if (!res.ok) throw badRequest("Unsplash search failed. Try again in a moment.");
+
+  const body = await res.json().catch(() => null) as { results?: RawPhoto[] } | null;
+  return (body?.results ?? []).map(toPhoto).filter((p): p is StockPhoto => p !== null);
+}
+
+/**
+ * Ping the download endpoint for a photo the author actually chose.
+ *
+ * Required by the Unsplash API guidelines — it is how a photographer's download
+ * count stays truthful, and hotlinking their image without it is a term of use
+ * we would be breaking. Best-effort: nothing about saving a post should fail
+ * because a third-party counter was unreachable.
+ *
+ * The URL comes back from the browser, so it is checked against Unsplash's own
+ * host before being fetched — otherwise this endpoint would forward an
+ * authenticated request anywhere a caller named (an SSRF hole with our key
+ * attached).
+ */
+export async function trackDownload(downloadLocation: string): Promise<void> {
+  const key = await accessKey();
+  if (!key) return;
+
+  let url: URL;
+  try {
+    url = new URL(downloadLocation);
+  } catch {
+    throw badRequest("That isn't an Unsplash download link.");
+  }
+  if (url.protocol !== "https:" || url.host !== "api.unsplash.com") {
+    throw badRequest("That isn't an Unsplash download link.");
+  }
+
+  try {
+    await call(url.href, key);
+  } catch {
+    // Deliberately silent: the author's banner is chosen either way.
+  }
+}

--- a/apps/backend/src/services/webhooks.ts
+++ b/apps/backend/src/services/webhooks.ts
@@ -178,7 +178,14 @@ export async function ingestContent(
     fields.contentJson = null;
   }
   if (payload.title !== undefined) fields.title = payload.title;
-  if (payload.banner !== undefined) fields.coverUrl = payload.banner;
+  if (payload.banner !== undefined) {
+    fields.coverUrl = payload.banner;
+    // The credit belongs to the image, so it goes when the image does. A CMS
+    // never sends one, but a post whose banner was picked from a stock provider
+    // in the editor and later replaced from the CMS would otherwise keep
+    // crediting a photographer for a picture it no longer shows.
+    fields.coverCredit = null;
+  }
   if (payload.language !== undefined) fields.language = normalizeLanguage(payload.language);
   if (payload.status !== undefined) fields.status = payload.status;
   else if (!existing) fields.status = "published";

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -5,6 +5,7 @@ import type {
   AdminUser,
   BlockedDomain,
   Comment,
+  CoverCredit,
   DashboardSummary,
   DkimGenerateResult,
   EmailDnsResult,
@@ -30,6 +31,8 @@ import type {
   SuggestedUser,
   TagDetail,
   TagWithCount,
+  PhotoProvider,
+  StockPhoto,
   User,
   WebhookToken,
 } from "$lib/types";
@@ -128,6 +131,10 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     sitemapPosts: (page: number) => api.get<SitemapEntry[]>(`/seo/sitemap-posts?page=${page}`),
     adminSeo: () => api.get<SeoSettings>("/admin/seo"),
     setAdminSeo: (body: Partial<SeoSettings>) => api.put<SeoSettings>("/admin/seo", body),
+    // The Unsplash access key. Never read back — only whether one is set.
+    adminUnsplash: () => api.get<{ configured: boolean }>("/admin/unsplash"),
+    setAdminUnsplash: (accessKey: string | null) =>
+      api.put<{ configured: boolean }>("/admin/unsplash", { accessKey }),
 
     // admin email settings (runtime-configurable delivery)
     adminEmail: () => api.get<EmailSettings>("/admin/email"),
@@ -210,11 +217,11 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     drafts: (cursor?: string | null) =>
       api.get<Page<Post>>(`/posts/drafts${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""}`),
     createPost: (
-      body: { title?: string; contentHtml: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; coverUrl?: string | null; tags?: string[] },
+      body: { title?: string; contentHtml: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; coverUrl?: string | null; coverCredit?: CoverCredit | null; tags?: string[] },
     ) => api.post<{ post: { id: string } }>("/posts", body),
     updatePost: (
       id: string,
-      body: { title?: string; contentHtml?: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; coverUrl?: string | null; tags?: string[] },
+      body: { title?: string; contentHtml?: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; coverUrl?: string | null; coverCredit?: CoverCredit | null; tags?: string[] },
     ) => api.patch<{ post: { id: string } }>(`/posts/${id}`, body),
     deletePost: (id: string) => api.del<{ ok: true }>(`/posts/${id}`),
     // Posts to read next, shown under an article (see relatedPosts service).
@@ -286,6 +293,17 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     uploadImage: (blob: Blob, contentType: string) =>
       api.postRaw<{ url: string }>("/uploads", blob, contentType),
 
+    // Free-photo search for the banner picker. `photoProviders` says which
+    // tabs to offer — never empty, since Openverse needs no configuration.
+    photoProviders: () => api.get<{ providers: PhotoProvider[] }>("/photos/providers"),
+    searchPhotos: (provider: PhotoProvider, q: string, page = 1) =>
+      api.get<{ items: StockPhoto[] }>(
+        `/photos/search?provider=${provider}&q=${encodeURIComponent(q)}&page=${page}`,
+      ),
+    // Tells a provider one of its photos was used — required by Unsplash's API
+    // terms so a photographer's download count reflects reality.
+    recordPhotoUse: (provider: PhotoProvider, token: string) =>
+      api.post<{ ok: true }>("/photos/use", { provider, token }),
 
     // users + follows
     suggestedUsers: () => api.get<{ items: SuggestedUser[] }>("/users/suggested"),

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -210,11 +210,11 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     drafts: (cursor?: string | null) =>
       api.get<Page<Post>>(`/posts/drafts${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""}`),
     createPost: (
-      body: { title?: string; contentHtml: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; tags?: string[] },
+      body: { title?: string; contentHtml: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; coverUrl?: string | null; tags?: string[] },
     ) => api.post<{ post: { id: string } }>("/posts", body),
     updatePost: (
       id: string,
-      body: { title?: string; contentHtml?: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; tags?: string[] },
+      body: { title?: string; contentHtml?: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; coverUrl?: string | null; tags?: string[] },
     ) => api.patch<{ post: { id: string } }>(`/posts/${id}`, body),
     deletePost: (id: string) => api.del<{ ok: true }>(`/posts/${id}`),
     // Posts to read next, shown under an article (see relatedPosts service).
@@ -285,6 +285,7 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     // Post-body image upload. The blob is already resized/compressed client-side.
     uploadImage: (blob: Blob, contentType: string) =>
       api.postRaw<{ url: string }>("/uploads", blob, contentType),
+
 
     // users + follows
     suggestedUsers: () => api.get<{ items: SuggestedUser[] }>("/users/suggested"),

--- a/apps/frontend/src/lib/components/AdminUnsplash.svelte
+++ b/apps/frontend/src/lib/components/AdminUnsplash.svelte
@@ -1,0 +1,109 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { Label } from "bits-ui";
+  import { endpoints, ApiError } from "$lib/api";
+  import Button from "$lib/components/ui/Button.svelte";
+
+  // The Unsplash access key, which adds Unsplash as a second source in the
+  // editor's banner picker. Optional, and optional by necessity: Unsplash
+  // issues a key per registered application and has no anonymous mode, so
+  // unlike Openverse it cannot work out of the box. The picker is useful
+  // without it.
+  //
+  // The key is write-only over the API — the server reports whether one is set
+  // and nothing more, so it can't come back through a browser cache or land in
+  // a screenshot of this page. Re-entering it is the way to change it.
+  let configured = $state(false);
+  let accessKey = $state("");
+  let loading = $state(true);
+  let saving = $state(false);
+  let error = $state("");
+  let saved = $state("");
+
+  const field =
+    "h-11 rounded-input border border-input bg-background shadow-btn px-3.5 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-foreground";
+
+  $effect(() => {
+    endpoints()
+      .adminUnsplash()
+      .then((r) => (configured = r.configured))
+      .catch((e) => (error = e instanceof ApiError ? e.message : "Failed to load settings."))
+      .finally(() => (loading = false));
+  });
+
+  async function save(key: string | null) {
+    saving = true;
+    error = "";
+    saved = "";
+    try {
+      configured = (await endpoints().setAdminUnsplash(key)).configured;
+      accessKey = "";
+      saved = key
+        ? "Unsplash added to the banner picker."
+        : "Unsplash removed. Openverse is still available.";
+    } catch (e) {
+      error = e instanceof ApiError ? e.message : "Failed to save.";
+    } finally {
+      saving = false;
+    }
+  }
+</script>
+
+<div class="flex flex-col gap-4">
+  <p class="max-w-prose text-sm text-muted-foreground">
+    Photo search already works with no setup: the banner picker searches
+    <strong class="text-foreground">Openverse</strong>, which needs no account. Adding a key here
+    puts <strong class="text-foreground">Unsplash</strong> beside it as a second tab. Either way
+    the creator is credited under the banner automatically, as both providers' terms require.
+    Create a free app at
+    <a
+      href="https://unsplash.com/oauth/applications"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-foreground underline">unsplash.com/oauth/applications</a
+    >
+    and paste its <em>Access Key</em> below. Their demo tier allows 50 searches an hour across the
+    whole instance.
+  </p>
+
+  {#if loading}
+    <p class="text-sm text-muted-foreground">Loading…</p>
+  {:else}
+    <p class="text-sm text-foreground">
+      Status:
+      <span class={configured ? "text-foreground" : "text-muted-foreground"}>
+        {configured
+          ? "configured — writers see an Unsplash tab in the picker"
+          : "not configured — the picker searches Openverse only"}
+      </span>
+    </p>
+
+    <div class="flex flex-col gap-1.5">
+      <Label.Root for="unsplash-key" class="text-sm font-medium leading-none text-foreground">
+        Access key
+      </Label.Root>
+      <input
+        id="unsplash-key"
+        bind:value={accessKey}
+        type="password"
+        autocomplete="off"
+        placeholder={configured ? "Enter a new key to replace the current one" : "Your Unsplash Access Key"}
+        class={field}
+      />
+    </div>
+
+    {#if error}<p class="text-sm text-destructive">{error}</p>{/if}
+    {#if saved}<p class="text-sm text-muted-foreground">{saved}</p>{/if}
+
+    <div class="flex items-center gap-2">
+      <Button variant="solid" size="sm" disabled={saving || !accessKey.trim()} onclick={() => save(accessKey.trim())}>
+        {saving ? "Saving…" : "Save key"}
+      </Button>
+      {#if configured}
+        <Button variant="outline" size="sm" disabled={saving} onclick={() => save(null)}>
+          Remove key
+        </Button>
+      {/if}
+    </div>
+  {/if}
+</div>

--- a/apps/frontend/src/lib/components/BannerPicker.svelte
+++ b/apps/frontend/src/lib/components/BannerPicker.svelte
@@ -3,8 +3,10 @@
   import { endpoints, ApiError } from "$lib/api";
   import Button from "$lib/components/ui/Button.svelte";
   import Icon from "$lib/components/Icon.svelte";
+  import StockPhotoPicker from "$lib/components/StockPhotoPicker.svelte";
   import { firstBodyImage } from "$lib/cover";
   import { isAcceptedImage, prepareImage } from "$lib/editor/image";
+  import type { CoverCredit, StockPhoto } from "$lib/types";
 
   // The post's banner: what a reader sees at the top of the article, what a
   // link preview (Open Graph) shows when the post is shared, and what a remote
@@ -18,10 +20,12 @@
   // opening picture, not the one that happened to be first when they published.
   let {
     coverUrl = $bindable(null),
+    coverCredit = $bindable(null),
     contentHtml = "",
     onChange,
   }: {
     coverUrl?: string | null;
+    coverCredit?: CoverCredit | null;
     /** Live editor output, for the fallback preview. */
     contentHtml?: string;
     /** Called on any change, so the page can mark itself dirty. */
@@ -29,22 +33,23 @@
   } = $props();
 
   let fileInput = $state<HTMLInputElement | null>(null);
+  let photosOpen = $state(false);
   let uploading = $state(false);
   let error = $state("");
 
   const fallback = $derived(coverUrl ? null : firstBodyImage(contentHtml));
   const preview = $derived(coverUrl ?? fallback);
 
-  function set(url: string | null) {
+  function set(url: string | null, credit: CoverCredit | null) {
     coverUrl = url;
+    coverCredit = credit;
     onChange?.();
   }
 
   async function onFile(e: Event) {
-    const input = e.target as HTMLInputElement;
-    const file = input.files?.[0];
+    const file = (e.target as HTMLInputElement).files?.[0];
     // Reset the input so re-picking the same file fires `change` again.
-    input.value = "";
+    (e.target as HTMLInputElement).value = "";
     if (!file) return;
     if (!isAcceptedImage(file)) {
       error = "Unsupported image type. Use PNG, JPEG, WebP, or GIF.";
@@ -55,12 +60,19 @@
     try {
       const { blob, type } = await prepareImage(file);
       const { url } = await endpoints().uploadImage(blob, type);
-      set(url);
+      // An upload is the author's own image: nobody to credit, so any credit
+      // left over from a previously chosen stock photo goes with it.
+      set(url, null);
     } catch (err) {
       error = err instanceof ApiError ? err.message : "Failed to upload the banner.";
     } finally {
       uploading = false;
     }
+  }
+
+  function onPhotoPick(photo: StockPhoto) {
+    error = "";
+    set(photo.bannerUrl, photo.credit);
   }
 </script>
 
@@ -93,15 +105,36 @@
       </div>
     {/if}
 
+    {#if coverCredit}
+      <p class="mt-2 text-xs text-muted-foreground">
+        Photo by
+        <a href={coverCredit.nameUrl} target="_blank" rel="noopener noreferrer nofollow" class="hover:text-foreground underline">
+          {coverCredit.name}
+        </a>
+        on
+        <a href={coverCredit.sourceUrl} target="_blank" rel="noopener noreferrer nofollow" class="hover:text-foreground underline">
+          {coverCredit.source}
+        </a>{#if coverCredit.license && coverCredit.licenseUrl}
+          ·
+          <a href={coverCredit.licenseUrl} target="_blank" rel="noopener noreferrer nofollow" class="hover:text-foreground underline">
+            {coverCredit.license}
+          </a>
+        {/if}
+      </p>
+    {/if}
+
     <div class="mt-3 flex flex-wrap items-center gap-2">
       <Button variant="outline" size="sm" onclick={() => fileInput?.click()} disabled={uploading}>
         <Icon name="image" size={15} />
         {uploading ? "Uploading…" : "Upload"}
       </Button>
+      <Button variant="outline" size="sm" onclick={() => (photosOpen = true)} disabled={uploading}>
+        <Icon name="search" size={15} /> Free photos
+      </Button>
       {#if coverUrl}
         <!-- Removes the *choice*, not the banner: the body's first image takes
              over again, which the preview above updates to show. -->
-        <Button variant="ghost" size="sm" onclick={() => set(null)} disabled={uploading}>
+        <Button variant="ghost" size="sm" onclick={() => set(null, null)} disabled={uploading}>
           <Icon name="close" size={15} /> Remove
         </Button>
       {/if}
@@ -118,3 +151,5 @@
     class="hidden"
   />
 </div>
+
+<StockPhotoPicker bind:open={photosOpen} onPick={onPhotoPick} />

--- a/apps/frontend/src/lib/components/BannerPicker.svelte
+++ b/apps/frontend/src/lib/components/BannerPicker.svelte
@@ -1,0 +1,120 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { endpoints, ApiError } from "$lib/api";
+  import Button from "$lib/components/ui/Button.svelte";
+  import Icon from "$lib/components/Icon.svelte";
+  import { firstBodyImage } from "$lib/cover";
+  import { isAcceptedImage, prepareImage } from "$lib/editor/image";
+
+  // The post's banner: what a reader sees at the top of the article, what a
+  // link preview (Open Graph) shows when the post is shared, and what a remote
+  // instance renders in its card for it.
+  //
+  // Choosing one is optional. Left unset, the first image in the body stands in
+  // — which is what most posts want and nobody should have to configure — so
+  // this control shows that fallback as a live preview rather than an empty
+  // box. `coverUrl` stays null in that case: only a deliberate choice is a
+  // choice, and an author who later reorders their images should get the new
+  // opening picture, not the one that happened to be first when they published.
+  let {
+    coverUrl = $bindable(null),
+    contentHtml = "",
+    onChange,
+  }: {
+    coverUrl?: string | null;
+    /** Live editor output, for the fallback preview. */
+    contentHtml?: string;
+    /** Called on any change, so the page can mark itself dirty. */
+    onChange?: () => void;
+  } = $props();
+
+  let fileInput = $state<HTMLInputElement | null>(null);
+  let uploading = $state(false);
+  let error = $state("");
+
+  const fallback = $derived(coverUrl ? null : firstBodyImage(contentHtml));
+  const preview = $derived(coverUrl ?? fallback);
+
+  function set(url: string | null) {
+    coverUrl = url;
+    onChange?.();
+  }
+
+  async function onFile(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const file = input.files?.[0];
+    // Reset the input so re-picking the same file fires `change` again.
+    input.value = "";
+    if (!file) return;
+    if (!isAcceptedImage(file)) {
+      error = "Unsupported image type. Use PNG, JPEG, WebP, or GIF.";
+      return;
+    }
+    error = "";
+    uploading = true;
+    try {
+      const { blob, type } = await prepareImage(file);
+      const { url } = await endpoints().uploadImage(blob, type);
+      set(url);
+    } catch (err) {
+      error = err instanceof ApiError ? err.message : "Failed to upload the banner.";
+    } finally {
+      uploading = false;
+    }
+  }
+</script>
+
+<div class="mb-6">
+  <p class="text-muted-foreground mb-1.5 text-xs font-medium">
+    Banner — shown at the top of the post and in link previews. Optional; the first image in
+    your post is used when you don't pick one.
+  </p>
+
+  <div class="rounded-card border border-border bg-background-alt p-3">
+    {#if preview}
+      <div class="rounded-card border border-border relative aspect-[16/9] max-h-64 w-full overflow-hidden">
+        <!-- Decorative here: this is a control, and the banner is labelled by
+             the text above it. -->
+        <img src={preview} alt="" class="h-full w-full object-cover" />
+        {#if fallback}
+          <span
+            class="rounded-button bg-dark/80 absolute bottom-2 left-2 px-2 py-1 text-xs font-medium text-background"
+          >
+            From your post
+          </span>
+        {/if}
+      </div>
+    {:else}
+      <div
+        class="rounded-card border border-dashed border-border flex aspect-[16/9] max-h-64 w-full flex-col items-center justify-center gap-1.5 text-muted-foreground"
+      >
+        <Icon name="image" size={22} />
+        <span class="text-sm">No banner yet</span>
+      </div>
+    {/if}
+
+    <div class="mt-3 flex flex-wrap items-center gap-2">
+      <Button variant="outline" size="sm" onclick={() => fileInput?.click()} disabled={uploading}>
+        <Icon name="image" size={15} />
+        {uploading ? "Uploading…" : "Upload"}
+      </Button>
+      {#if coverUrl}
+        <!-- Removes the *choice*, not the banner: the body's first image takes
+             over again, which the preview above updates to show. -->
+        <Button variant="ghost" size="sm" onclick={() => set(null)} disabled={uploading}>
+          <Icon name="close" size={15} /> Remove
+        </Button>
+      {/if}
+    </div>
+
+    {#if error}<p class="mt-2 text-sm text-destructive">{error}</p>{/if}
+  </div>
+
+  <input
+    bind:this={fileInput}
+    type="file"
+    accept="image/png,image/jpeg,image/webp,image/gif"
+    onchange={onFile}
+    class="hidden"
+  />
+</div>

--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -19,12 +19,12 @@
   const summary = $derived(post.summary?.trim() || excerpt(post.contentHtml));
   const minutes = $derived(readTime(post.contentHtml));
 
-  // The cover is a URL on someone else's host, so a dead link is an ordinary
-  // outcome rather than a bug. Drop the image on error instead of leaving a
+  // The banner may be a URL on someone else's host, so a dead link is an
+  // ordinary outcome rather than a bug. Drop the image on error instead of leaving a
   // broken-image glyph in the card.
   let coverFailed = $state(false);
   $effect(() => {
-    void post.coverUrl;
+    void post.bannerUrl;
     coverFailed = false;
   });
   // Remote authors carry a `user@host` handle; surface the origin instance
@@ -57,14 +57,14 @@
           <p class="mt-1.5 line-clamp-3 text-muted-foreground">{summary}</p>
         {/if}
       </div>
-      {#if post.coverUrl && !coverFailed}
+      {#if post.bannerUrl && !coverFailed}
         <!-- Decorative: the title beside it already names the post. -->
         <!-- The CSS box is already fixed, so this thumbnail cannot shift the
              layout; `width`/`height` are set anyway so the space is reserved
              even before the stylesheet applies. `decoding="async"` keeps a
              long feed of these off the main thread. -->
         <img
-          src={post.coverUrl}
+          src={post.bannerUrl}
           alt=""
           width="144"
           height="96"

--- a/apps/frontend/src/lib/components/StockPhotoPicker.svelte
+++ b/apps/frontend/src/lib/components/StockPhotoPicker.svelte
@@ -1,0 +1,209 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { Dialog, Tabs } from "bits-ui";
+  import { endpoints, ApiError } from "$lib/api";
+  import Button from "$lib/components/ui/Button.svelte";
+  import Icon from "$lib/components/Icon.svelte";
+  import type { PhotoProvider, StockPhoto } from "$lib/types";
+
+  // Search for a free, properly-licensed banner photo.
+  //
+  // Openverse needs no credentials, so this is always available. Unsplash is
+  // offered as a second tab only when an operator has configured a key — the
+  // provider list comes from the server, so the tab bar is simply absent when
+  // there is nothing to switch between.
+  let {
+    open = $bindable(false),
+    onPick,
+  }: {
+    open?: boolean;
+    onPick: (photo: StockPhoto) => void;
+  } = $props();
+
+  const LABELS: Record<PhotoProvider, string> = {
+    openverse: "Openverse",
+    unsplash: "Unsplash",
+  };
+
+  let providers = $state<PhotoProvider[]>(["openverse"]);
+  let provider = $state<PhotoProvider>("openverse");
+  let query = $state("");
+  let photos = $state<StockPhoto[]>([]);
+  let searching = $state(false);
+  let error = $state("");
+  // Distinguishes "nothing found" from "nothing searched for yet", so the empty
+  // grid says the right thing.
+  let searched = $state(false);
+
+  $effect(() => {
+    endpoints()
+      .photoProviders()
+      .then((r) => {
+        if (r.providers.length) providers = r.providers;
+      })
+      .catch(() => {});
+  });
+
+  async function run(p: PhotoProvider, q: string) {
+    if (!q || searching) return;
+    searching = true;
+    error = "";
+    try {
+      photos = (await endpoints().searchPhotos(p, q)).items;
+      searched = true;
+    } catch (err) {
+      error = err instanceof ApiError ? err.message : "Photo search failed.";
+      photos = [];
+    } finally {
+      searching = false;
+    }
+  }
+
+  function search(e?: SubmitEvent) {
+    e?.preventDefault();
+    void run(provider, query.trim());
+  }
+
+  // Switching tabs re-runs the current search against the other provider, which
+  // is what "the same thing, from somewhere else" should do — retyping the
+  // query to compare sources would be busywork.
+  function switchTo(next: string | undefined) {
+    if (!next || next === provider) return;
+    provider = next as PhotoProvider;
+    photos = [];
+    searched = false;
+    error = "";
+    void run(provider, query.trim());
+  }
+
+  // Choosing a photo is what a provider counts as using it, so the usage ping
+  // goes out here. Deliberately not awaited: the author's choice is theirs
+  // whether or not a third-party counter answers.
+  function pick(photo: StockPhoto) {
+    if (photo.useToken) {
+      endpoints().recordPhotoUse(provider, photo.useToken).catch(() => {});
+    }
+    onPick(photo);
+    open = false;
+  }
+
+  // Each open starts clean rather than showing the last search's results, which
+  // would look like a response to a query the author hasn't typed yet.
+  function onOpenChange(next: boolean) {
+    open = next;
+    if (next) return;
+    query = "";
+    photos = [];
+    error = "";
+    searched = false;
+  }
+</script>
+
+<Dialog.Root bind:open {onOpenChange}>
+  <Dialog.Portal>
+    <Dialog.Overlay
+      class="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+    />
+    <Dialog.Content
+      class="rounded-card bg-background shadow-popover fixed left-1/2 top-1/2 z-50 flex max-h-[85vh] w-full max-w-[94%] -translate-x-1/2 -translate-y-1/2 flex-col border border-border sm:max-w-[720px]"
+    >
+      <div class="flex items-center justify-between border-b border-border px-5 py-4">
+        <Dialog.Title class="text-foreground text-base font-semibold tracking-tight">
+          Choose a photo
+        </Dialog.Title>
+        <Dialog.Close
+          class="text-muted-foreground hover:text-foreground focus-visible:outline-none"
+          aria-label="Close"
+        >
+          <Icon name="close" size={18} />
+        </Dialog.Close>
+      </div>
+
+      <Dialog.Description class="sr-only">
+        Search for a free, openly-licensed photo to use as this post's banner.
+      </Dialog.Description>
+
+      <div class="flex flex-col gap-3 border-b border-border px-5 py-4">
+        {#if providers.length > 1}
+          <Tabs.Root value={provider} onValueChange={switchTo}>
+            <Tabs.List
+              class="inline-flex items-center gap-1 rounded-input border border-input bg-background-alt p-1 shadow-btn"
+            >
+              {#each providers as p (p)}
+                <Tabs.Trigger
+                  value={p}
+                  class="data-[state=active]:bg-background data-[state=active]:shadow-mini text-muted-foreground data-[state=active]:text-foreground inline-flex h-8 items-center rounded-button px-3 text-sm font-medium"
+                >
+                  {LABELS[p]}
+                </Tabs.Trigger>
+              {/each}
+            </Tabs.List>
+          </Tabs.Root>
+        {/if}
+
+        <form onsubmit={search} class="flex items-center gap-2">
+          <input
+            bind:value={query}
+            placeholder="Search free photos — mountains, desk, coffee…"
+            aria-label="Search photos"
+            class="rounded-input border border-input bg-background shadow-btn h-10 min-w-0 flex-1 px-3.5 text-sm outline-none transition-colors placeholder:text-muted-foreground focus:border-foreground"
+          />
+          <Button type="submit" variant="solid" size="sm" disabled={searching || !query.trim()}>
+            {searching ? "Searching…" : "Search"}
+          </Button>
+        </form>
+      </div>
+
+      <div class="min-h-0 flex-1 overflow-y-auto px-5 py-4">
+        {#if error}
+          <p class="text-sm text-destructive">{error}</p>
+        {:else if searching}
+          <p class="text-sm text-muted-foreground">Searching…</p>
+        {:else if photos.length}
+          <div class="grid grid-cols-2 gap-3 sm:grid-cols-3">
+            {#each photos as photo (photo.id)}
+              <figure class="flex flex-col gap-1">
+                <button
+                  type="button"
+                  onclick={() => pick(photo)}
+                  class="rounded-card border border-border focus-visible:ring-foreground group aspect-[4/3] overflow-hidden focus-visible:outline-none focus-visible:ring-2"
+                >
+                  <img
+                    src={photo.thumbUrl}
+                    alt={photo.alt || "Photo"}
+                    loading="lazy"
+                    decoding="async"
+                    class="h-full w-full object-cover transition-opacity group-hover:opacity-80"
+                  />
+                </button>
+                <!-- These photos are licensed on condition of attribution, so
+                     the creator is named in the grid too, not only once one is
+                     chosen. -->
+                <figcaption class="truncate text-xs text-muted-foreground">
+                  <a
+                    href={photo.credit.nameUrl}
+                    target="_blank"
+                    rel="noopener noreferrer nofollow"
+                    class="hover:text-foreground hover:underline"
+                  >
+                    {photo.credit.name}
+                  </a>
+                  {#if photo.credit.license}
+                    <span class="text-muted-foreground/70">· {photo.credit.license}</span>
+                  {/if}
+                </figcaption>
+              </figure>
+            {/each}
+          </div>
+        {:else if searched}
+          <p class="text-sm text-muted-foreground">No photos matched that search.</p>
+        {:else}
+          <p class="text-sm text-muted-foreground">
+            Search for a photo you're free to publish. The creator and licence are credited under
+            your banner automatically.
+          </p>
+        {/if}
+      </div>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>

--- a/apps/frontend/src/lib/cover.ts
+++ b/apps/frontend/src/lib/cover.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// The banner fallback, mirrored client-side for the editor.
+//
+// A post's banner is resolved on the server (backend lib/cover.ts) and arrives
+// as `post.bannerUrl`, which is what every reader surface renders. The editor
+// is the one place that cannot wait for a round trip: it has to show the author
+// what their banner will be while they are still typing, before anything has
+// been saved. So the same rule — the chosen cover, else the body's first image
+// — is repeated here, over the HTML Tiptap is currently producing.
+//
+// Keep it in step with the backend's `firstBodyImage`. A divergence would show
+// an author one banner in the editor and publish another, which is worse than
+// having no preview at all.
+
+const IMG_SRC = /<img\b[^>]*?\ssrc="([^"]*)"/i;
+
+/**
+ * The first image in a post body, or null when it has none.
+ *
+ * The body here is live editor output rather than sanitized storage, so the
+ * `[^>]*` attribute match is doing less work than its backend twin: Tiptap
+ * serializes double-quoted attributes, and anything it produces has been
+ * through the same sanitizer by the time it is read back.
+ */
+export function firstBodyImage(html: string): string | null {
+  const src = html.match(IMG_SRC)?.[1]?.trim();
+  return src ? src : null;
+}
+
+// A path served by this instance's own uploads route — the only relative form
+// that is ours to resolve. Mirrors the backend's UPLOAD_PATH (lib/cover.ts).
+const UPLOAD_PATH = /^\/api\/uploads\/[A-Za-z0-9-]+\.(?:png|jpe?g|webp|gif)$/;
+
+/**
+ * A banner URL in the absolute form an Open Graph scraper needs.
+ *
+ * A banner uploaded here is stored root-relative (`/api/uploads/…`), which is
+ * fine inside the page but useless to a scraper — it would resolve the path
+ * against itself — so those are joined to our canonical origin. Anything
+ * already absolute is on someone else's host and is left alone.
+ *
+ * Every other shape returns undefined so the caller falls back to the brand
+ * image. That case is real rather than theoretical: a federated post's banner
+ * can be the first image of a body written on another instance, and if that
+ * instance used a relative `src`, resolving it here would point the tag at a
+ * path on *our* domain that has nothing behind it. No image beats a broken one.
+ */
+export function absoluteBanner(
+  url: string | null | undefined,
+  origin: string,
+): string | undefined {
+  if (!url) return undefined;
+  if (UPLOAD_PATH.test(url)) return `${origin}${url}`;
+  if (!/^https?:\/\//i.test(url)) return undefined;
+  try {
+    return new URL(url).href;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -45,6 +45,21 @@ export type PostAuthor = {
 export type Tag = { slug: string; name: string };
 export type TagWithCount = Tag & { postCount: number };
 
+// Attribution for a post's banner image, as one line under the banner: the
+// photographer, where the photo came from, and — for a Creative Commons image
+// — the licence it carries. Null for an uploaded banner, which needs none.
+// Mirrors the backend's CoverCredit (lib/cover.ts).
+export type CoverCredit = {
+  name: string;
+  nameUrl: string;
+  source: string;
+  sourceUrl: string;
+  // Absent for Unsplash, which serves photos under its own licence rather than
+  // a named public one, so there is nothing to link a reader to.
+  license?: string;
+  licenseUrl?: string;
+};
+
 export type Post = {
   id: string;
   title: string | null;
@@ -59,8 +74,8 @@ export type Post = {
   // content webhook) or derived from the body on ingest. Null for posts written
   // in the editor, whose preview the card derives itself.
   summary?: string | null;
-  // The banner the author explicitly chose — an uploaded `/api/uploads/…` path
-  // or a CMS's own URL. Null when they chose none, which is
+  // The banner the author explicitly chose — an uploaded `/api/uploads/…` path,
+  // a stock photo, or a CMS's own URL. Null when they chose none, which is
   // what the editor seeds its picker from: only an explicit choice is one.
   coverUrl?: string | null;
   // The banner to actually show: `coverUrl`, or the first image in the body
@@ -68,6 +83,9 @@ export type Post = {
   // page, the cards, the share tags and the federated Article all agree on
   // one answer. Every reader surface should use this, never `coverUrl`.
   bannerUrl?: string | null;
+  // Who to credit for the banner — present on a photo picked from a stock
+  // provider, whose terms require it, and null otherwise.
+  coverCredit?: CoverCredit | null;
   createdAt: string;
   // When the post's own content last changed (body, title, tags, cover,
   // language) — not engagement. Drives `dateModified` in the page's structured
@@ -279,6 +297,24 @@ export type SeoSettings = {
   indexNowEnabled: boolean;
   // Present only on the admin payload — the public /seo endpoint withholds it.
   indexNowKey?: string | null;
+};
+
+// Free-photo search for the editor's banner picker. Openverse needs no
+// credentials and is always available; Unsplash appears only when an operator
+// has configured a key, which never reaches the browser — searches are proxied
+// through /api/photos either way.
+export type PhotoProvider = "openverse" | "unsplash";
+
+export type StockPhoto = {
+  id: string;
+  alt: string;
+  thumbUrl: string;
+  bannerUrl: string;
+  credit: CoverCredit;
+  // Passed back to /photos/use when this photo is chosen, for providers that
+  // ask to be told (Unsplash's download count). Null when the provider asks for
+  // nothing; opaque to us either way.
+  useToken: string | null;
 };
 
 // Everything the instance publishes that belongs in the sitemap, in the raw

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -59,9 +59,15 @@ export type Post = {
   // content webhook) or derived from the body on ingest. Null for posts written
   // in the editor, whose preview the card derives itself.
   summary?: string | null;
-  // Absolute http(s) URL of the banner image, hosted by whoever sent it. Null
-  // unless the post carries one.
+  // The banner the author explicitly chose — an uploaded `/api/uploads/…` path
+  // or a CMS's own URL. Null when they chose none, which is
+  // what the editor seeds its picker from: only an explicit choice is one.
   coverUrl?: string | null;
+  // The banner to actually show: `coverUrl`, or the first image in the body
+  // standing in for it. Resolved server-side (backend lib/cover.ts) so the
+  // page, the cards, the share tags and the federated Article all agree on
+  // one answer. Every reader surface should use this, never `coverUrl`.
+  bannerUrl?: string | null;
   createdAt: string;
   // When the post's own content last changed (body, title, tags, cover,
   // language) — not engagement. Drives `dateModified` in the page's structured

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -8,6 +8,7 @@
   import MobileNav from "$lib/components/MobileNav.svelte";
   import Discover from "$lib/components/Discover.svelte";
   import { canonicalOrigin } from "$lib/canonical";
+  import { absoluteBanner } from "$lib/cover";
   import {
     blogPostingLd,
     breadcrumbLd,
@@ -78,13 +79,15 @@
   );
   const ogType = $derived(post ? "article" : "website");
   // A post's banner becomes its share image, falling back to the instance's
-  // brand image. The URL is on whatever host sent it, so it is published only
-  // when absolute — a relative one would resolve against the scraper, not us.
-  // (The ingest schema already enforces this; the check costs nothing and keeps
-  // the guarantee local to where it matters.)
-  const shareImage = $derived(
-    post?.coverUrl && /^https?:\/\//i.test(post.coverUrl) ? post.coverUrl : ogImage,
-  );
+  // brand image. `bannerUrl` rather than `coverUrl`, so a post whose banner is
+  // simply its first picture still gets a picture on the link card instead of
+  // the generic brand tile.
+  //
+  // Resolved against the canonical origin because a banner uploaded here is
+  // stored root-relative (`/api/uploads/…`) and a scraper would resolve that
+  // against itself. An unparseable URL falls back rather than emitting a broken
+  // og:image.
+  const shareImage = $derived(absoluteBanner(post?.bannerUrl, origin) ?? ogImage);
 
   // RSS auto-discovery: a reader pointed at a profile or reading-list page finds
   // the feed from this tag alone. Local profiles only (a remote actor's posts are

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -24,7 +24,7 @@
   // A cover lives on whoever sent it; drop it rather than render a broken image.
   let coverFailed = $state(false);
   $effect(() => {
-    void post.coverUrl;
+    void post.bannerUrl;
     coverFailed = false;
   });
   // Origin instance (host) parsed from a remote author's `user@host` handle.
@@ -317,7 +317,7 @@
     </DropdownMenu.Root>
   </div>
 
-  {#if post.coverUrl && !coverFailed}
+  {#if post.bannerUrl && !coverFailed}
     <!-- The cover is almost always this page's largest element, so it is what
          the browser (and Google's Core Web Vitals) times the load by.
 
@@ -337,7 +337,7 @@
     >
       <!-- Decorative: the headline above it already names the post. -->
       <img
-        src={post.coverUrl}
+        src={post.bannerUrl}
         alt=""
         fetchpriority="high"
         decoding="async"

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -345,6 +345,43 @@
         class="h-full w-full object-cover"
       />
     </div>
+    {#if post.coverCredit}
+      <!-- Attribution for the banner. The licences these photos are offered
+           under require the creator, the source and (for Creative Commons) the
+           licence itself to be named with links wherever the photo appears —
+           which is why the credit is stored on the post rather than guessed at
+           from the image URL. -->
+      <p class="-mt-6 mb-8 text-xs text-muted-foreground">
+        Photo by
+        <a
+          href={post.coverCredit.nameUrl}
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+          class="hover:text-foreground underline"
+        >
+          {post.coverCredit.name}
+        </a>
+        on
+        <a
+          href={post.coverCredit.sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer nofollow"
+          class="hover:text-foreground underline"
+        >
+          {post.coverCredit.source}
+        </a>{#if post.coverCredit.license && post.coverCredit.licenseUrl}
+          ·
+          <a
+            href={post.coverCredit.licenseUrl}
+            target="_blank"
+            rel="noopener noreferrer nofollow"
+            class="hover:text-foreground underline"
+          >
+            {post.coverCredit.license}
+          </a>
+        {/if}
+      </p>
+    {/if}
   {/if}
 
   <!-- Content is server-rendered HTML produced by the Tiptap editor. -->

--- a/apps/frontend/src/routes/admin/+page.svelte
+++ b/apps/frontend/src/routes/admin/+page.svelte
@@ -9,6 +9,7 @@
   import AdminDomains from "$lib/components/AdminDomains.svelte";
   import AdminSecurity from "$lib/components/AdminSecurity.svelte";
   import AdminSeo from "$lib/components/AdminSeo.svelte";
+  import AdminUnsplash from "$lib/components/AdminUnsplash.svelte";
   import Icon, { type IconName } from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import type { PageData } from "./$types";
@@ -22,6 +23,7 @@
     { value: "email", label: "Email", icon: "mail" },
     { value: "security", label: "Security", icon: "lock" },
     { value: "discoverability", label: "Discoverability", icon: "globe" },
+    { value: "media", label: "Media", icon: "image" },
     { value: "settings", label: "Instance", icon: "settings" },
   ];
 
@@ -121,6 +123,19 @@
       </p>
       <div class="mt-5">
         <AdminSeo />
+      </div>
+    </section>
+  </Tabs.Content>
+
+  <Tabs.Content value="media" class="mt-6">
+    <section class="rounded-card border border-border bg-background p-6">
+      <h2 class="text-lg font-semibold tracking-tight text-foreground">Photo search</h2>
+      <p class="mt-1 text-sm text-muted-foreground">
+        Writers can already search free, openly-licensed photos for a post banner — Openverse
+        needs no setup. Add an Unsplash key here to offer their library as a second source.
+      </p>
+      <div class="mt-5">
+        <AdminUnsplash />
       </div>
     </section>
   </Tabs.Content>

--- a/apps/frontend/src/routes/compose/+page.svelte
+++ b/apps/frontend/src/routes/compose/+page.svelte
@@ -10,6 +10,7 @@
   import Icon from "$lib/components/Icon.svelte";
   import TagInput from "$lib/components/TagInput.svelte";
   import LanguageSelect from "$lib/components/LanguageSelect.svelte";
+  import BannerPicker from "$lib/components/BannerPicker.svelte";
   import { reading } from "$lib/prefs.svelte";
 
   // Matches SUMMARY_LENGTH in the backend (lib/webhook.ts), which caps the
@@ -43,6 +44,11 @@
   // previews show. Left empty it falls back to a truncation of the opening
   // paragraph — which is what every post used to get, often cut mid-clause.
   let summary = $state(draft?.summary ?? "");
+  // The banner the author picked, if any. Null means "use the first image in
+  // the post", which the picker previews and the server resolves on read — so
+  // a draft saved without one is not silently committed to whatever image
+  // happened to be first at the time.
+  let coverUrl = $state<string | null>(draft?.coverUrl ?? null);
   let html = $state(draft?.contentHtml ?? "");
   let json = $state<unknown>(draft?.contentJson ?? null);
   let error = $state("");
@@ -80,6 +86,7 @@
     return (
       title.trim().length > 0 ||
       tags.length > 0 ||
+      coverUrl !== null ||
       (html.trim().length > 0 && html !== "<p></p>")
     );
   }
@@ -116,6 +123,7 @@
         // Null, not "", so the reader falls back to the derived excerpt
         // rather than showing an empty description.
         summary: summary.trim() || null,
+        coverUrl,
         tags,
       };
       if (postId) {
@@ -219,6 +227,8 @@
   </div>
   <LanguageSelect bind:value={language} />
 </div>
+
+<BannerPicker bind:coverUrl contentHtml={html} onChange={() => (touched = true)} />
 
 {#if EditorComponent}
   <EditorComponent {onUpdate} content={(draft?.contentJson as Content) ?? draft?.contentHtml} />

--- a/apps/frontend/src/routes/compose/+page.svelte
+++ b/apps/frontend/src/routes/compose/+page.svelte
@@ -17,6 +17,7 @@
   // same column on the ingest path — so neither way of writing a post can
   // store a description the other would reject.
   const MAX_SUMMARY = 150;
+  import type { CoverCredit } from "$lib/types";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -49,6 +50,7 @@
   // a draft saved without one is not silently committed to whatever image
   // happened to be first at the time.
   let coverUrl = $state<string | null>(draft?.coverUrl ?? null);
+  let coverCredit = $state<CoverCredit | null>(draft?.coverCredit ?? null);
   let html = $state(draft?.contentHtml ?? "");
   let json = $state<unknown>(draft?.contentJson ?? null);
   let error = $state("");
@@ -124,6 +126,7 @@
         // rather than showing an empty description.
         summary: summary.trim() || null,
         coverUrl,
+        coverCredit,
         tags,
       };
       if (postId) {
@@ -228,7 +231,12 @@
   <LanguageSelect bind:value={language} />
 </div>
 
-<BannerPicker bind:coverUrl contentHtml={html} onChange={() => (touched = true)} />
+<BannerPicker
+  bind:coverUrl
+  bind:coverCredit
+  contentHtml={html}
+  onChange={() => (touched = true)}
+/>
 
 {#if EditorComponent}
   <EditorComponent {onUpdate} content={(draft?.contentJson as Content) ?? draft?.contentHtml} />

--- a/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
+++ b/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
@@ -12,6 +12,7 @@
   import Icon from "$lib/components/Icon.svelte";
   import TagInput from "$lib/components/TagInput.svelte";
   import LanguageSelect from "$lib/components/LanguageSelect.svelte";
+  import BannerPicker from "$lib/components/BannerPicker.svelte";
   import { postPath } from "$lib/links";
   import type { PageData } from "./$types";
 
@@ -33,6 +34,10 @@
   // would leave it untouched, but an author who cleared it here must have the
   // clearing saved, and one who never touches it must not lose what they wrote.
   let summary = $state(post.summary ?? "");
+  // Seeded from the *chosen* banner, never the resolved one — a post that has
+  // been showing its first body image must not have that turned into an
+  // explicit choice just because someone opened the editor.
+  let coverUrl = $state<string | null>(post.coverUrl ?? null);
   let html = $state(post.contentHtml);
   let json = $state<unknown>(post.contentJson ?? null);
   let error = $state("");
@@ -61,6 +66,7 @@
         contentJson: json,
         language,
         summary: summary.trim() || null,
+        coverUrl,
         tags,
       });
       // Title may have changed, so navigate to the freshly-built canonical path.
@@ -117,6 +123,8 @@
   </div>
   <LanguageSelect bind:value={language} />
 </div>
+
+<BannerPicker bind:coverUrl contentHtml={html} />
 
 {#if EditorComponent}
   <EditorComponent {onUpdate} content={(post.contentJson as Content) ?? post.contentHtml} />

--- a/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
+++ b/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
@@ -14,6 +14,7 @@
   import LanguageSelect from "$lib/components/LanguageSelect.svelte";
   import BannerPicker from "$lib/components/BannerPicker.svelte";
   import { postPath } from "$lib/links";
+  import type { CoverCredit } from "$lib/types";
   import type { PageData } from "./$types";
 
   let { data }: { data: PageData } = $props();
@@ -38,6 +39,7 @@
   // been showing its first body image must not have that turned into an
   // explicit choice just because someone opened the editor.
   let coverUrl = $state<string | null>(post.coverUrl ?? null);
+  let coverCredit = $state<CoverCredit | null>(post.coverCredit ?? null);
   let html = $state(post.contentHtml);
   let json = $state<unknown>(post.contentJson ?? null);
   let error = $state("");
@@ -67,6 +69,7 @@
         language,
         summary: summary.trim() || null,
         coverUrl,
+        coverCredit,
         tags,
       });
       // Title may have changed, so navigate to the freshly-built canonical path.
@@ -124,7 +127,7 @@
   <LanguageSelect bind:value={language} />
 </div>
 
-<BannerPicker bind:coverUrl contentHtml={html} />
+<BannerPicker bind:coverUrl bind:coverCredit contentHtml={html} />
 
 {#if EditorComponent}
   <EditorComponent {onUpdate} content={(post.contentJson as Content) ?? post.contentHtml} />


### PR DESCRIPTION
## The gap

A post's banner is what a reader sees above the article, what a link preview shows when the post is shared, and what a remote instance renders in its card. `posts.cover_url` has existed since the ingest webhook (0024), but **only a CMS could ever set it** — anything written in the editor had no banner at all, so every share of a hand-written post fell back to the instance's brand tile.

## What this adds

**A banner control in the editor** (compose and edit both): upload an image, or search free, openly-licensed photos without leaving the page.

**A fallback, so most posts need no decision at all.** Left unset, the first image in the body is used.

## The design decision worth reviewing

Two values are deliberately kept apart:

| | meaning |
|---|---|
| `coverUrl` | the author's explicit choice — null when they made none |
| `bannerUrl` | what readers actually see: the cover, else the body's first image |

Resolving the fallback **at write time** would store a derived value as if it had been chosen, and an author who later swapped out their opening photo would be left with a banner pointing at an image no longer in the post. Deriving it on read costs one regex over HTML we are already serializing and is always current.

The API therefore serves both. The editor seeds from `coverUrl`, so opening a post can never silently turn a fallback into a choice; every reader surface uses `bannerUrl`.

## Photo search: why Openverse is the default

**Openverse** (WordPress's index of openly-licensed images — Flickr, Wikimedia, museums) takes anonymous API requests. That is the whole reason it is the default: photo search works on a fresh instance with nothing configured. An operator should not have to register with a third party to get a working editor.

**Unsplash** has better-curated photography but issues a key per registered application and has no anonymous mode, so it can only ever be opt-in. Shipping one shared key would put it in a public repository, spend a single quota across every instance in the world, and breach the terms it was issued under. An admin pastes their own key and gets a second tab; without one, the picker searches Openverse alone.

Both normalise to one photo shape, so the picker renders one grid and a post stores one credit whichever tab was used.

## Attribution

These photos are licensed *on condition of* attribution, so it is stored rather than guessed at from the image URL: creator, the page the photo came from, and — for Creative Commons — the licence, each with a link, rendered as one line under the banner.

- A result missing any part of its attribution is **dropped** rather than offered as something we could not credit.
- Openverse is filtered to **commercially-usable, modifiable** licences: an instance may carry sponsorship, and the layout crops every banner to 16:9 (a derivative work). Offering ND or NC photos would invite a writer to breach a licence by publishing. This narrows results — a deliberate trade.
- The credit is written as a unit with the cover and cleared whenever the cover changes, on the editor path **and** the ingest path, so a post can never keep crediting a photographer for a picture it no longer shows.

Stored as one `jsonb` column rather than a column per part: the parts differ by provider (a CC photo needs a licence, an Unsplash one does not), and nothing here is ever filtered or joined on.

## Open Graph

`og:image`, `twitter:image` and the JSON-LD `image` now use the resolved banner, absolutized. Uploads are stored root-relative (`/api/uploads/…`) so an instance that changes domain keeps working — which means a scraper would otherwise resolve the path against itself. The federated Article `image` gets the same treatment.

The frontend helper only resolves paths that are **ours** and requires everything else to be absolute already. A federated post whose body used a relative `src` therefore falls back to the brand image rather than emitting a link into our own domain with nothing behind it.

## Security

- Accepted banner URLs are an uploads path or an absolute `http(s)` URL and nothing else — the value becomes an image `src` and a meta tag, so `javascript:` and `data:` must not reach it.
- Every credit link is validated absolute `http(s)`; each becomes an `href` on the post page.
- Unsplash's usage ping takes a URL from the browser, so it is checked against `api.unsplash.com` before being fetched — otherwise it would forward an authenticated request anywhere a caller named.
- Search is a GET and so escapes the app-wide write throttle. Both providers are shared resources (Unsplash bills a per-instance quota, Openverse rate-limits anonymous callers by IP), so it carries a per-user limiter.
- The Unsplash key is write-only over the API: the server reports whether one is set and never echoes it back.

## Verified

- **131 backend tests** (13 new in `cover_test.ts`), `deno lint`, `deno fmt`, `svelte-check`, production build — all clean, and checked on **each commit independently**.
- Migration applied and re-applied against a real Postgres 16; idempotent.
- Ran the stack end to end: the fallback, explicit choice, and clear-reverts-to-fallback paths all returned the right `coverUrl`/`bannerUrl`/`coverCredit`.
- Rejected as expected: `javascript:`, `data:`, `/etc/passwd`, path traversal, a partial credit, an unknown provider, and a link-local URL to the usage ping.
- **Real Openverse search with no key** returned 20 results with complete CC attribution; saving one rendered `Photo by Timitrius on Flickr · CC BY-SA 2.0` with all three links, and the banner as `og:image`.
- Adding an Unsplash key made the second tab appear; removing it made it vanish.
- Federated Article `image` confirmed absolutized, including the body-image fallback.

**Not verified:** Unsplash's response parsing against a genuine result set — I have no key. A bogus key correctly surfaced their 401 as a readable error, but `toPhoto` has not seen real Unsplash JSON.

**Found and fixed during testing:** Openverse caps `page_size` at 20 for anonymous callers and 401s above it, so the initial 24 made search silently return nothing. Caught only by running the real API.

## Deploy notes

Migration `0027_post_cover_credit` adds one nullable `jsonb` column; it applies on a plain `docker compose up -d` via the normal migration runner. Nothing else to do — Openverse needs no configuration. Unsplash is optional, under **Admin → Media**.

## Docs

This changes what users and admins see (a new editor control, a new admin tab and setting, a new `/api/photos` route group). `omicron-docs` is not updated here — happy to open a PR there separately.