### PR TITLE
feat(languages): offer Azerbaijani when tagging a post

### DIFF
--- a/apps/frontend/src/lib/languages.ts
+++ b/apps/frontend/src/lib/languages.ts
@@ -10,6 +10,7 @@ export type Language = { code: string; name: string; native: string };
 
 export const LANGUAGES: Language[] = [
   { code: "ar", name: "Arabic", native: "العربية" },
+  { code: "az", name: "Azerbaijani", native: "Azərbaycan dili" },
   { code: "bn", name: "Bengali", native: "বাংলা" },
   { code: "bg", name: "Bulgarian", native: "Български" },
   { code: "ca", name: "Catalan", native: "Català" },


### PR DESCRIPTION
Adds `az` to the curated language list, alphabetized by English name and carrying its endonym alongside like every other entry:

```ts
{ code: "az", name: "Azerbaijani", native: "Azərbaycan dili" },
```

`LANGUAGES` is the single source for all four places a language appears, so the one entry covers them all:

- the compose/edit language picker
- the reader's per-language feed filter in settings
- the label under a published post
- the default guessed from the browser's language

**No backend change needed.** `normalizeLanguage` accepts any well-formed BCP-47 primary subtag, and already collapses `az-Latn-AZ` and `AZ` down to `az` — confirmed by running it.

**Verified:** `svelte-check` and the production build are clean.

**Note on the endonym:** `Azərbaycan dili` matches Mastodon's label. `Azərbaycanca` is the shorter alternative if that reads better.

The docs discuss the language feature but never enumerate the list, so no `omicron-docs` change is needed.