### PR TITLE
fix: repair WhatsApp/Facebook link previews (image, crawlability, charset)

### DIFF
--- a/apps/backend/deno.json
+++ b/apps/backend/deno.json
@@ -32,6 +32,8 @@
     "@types/markdown-it": "npm:@types/markdown-it@14.1.2",
     "@vscode/markdown-it-katex": "npm:@vscode/markdown-it-katex@1.1.2",
     "katex": "npm:katex@0.16.47",
+    "@imagemagick/magick-wasm": "npm:@imagemagick/magick-wasm@0.0.35",
+    "@imagemagick/magick-wasm/magick.wasm": "npm:@imagemagick/magick-wasm@0.0.35/magick.wasm",
     "zod": "npm:zod@^4.0",
     "@std/assert": "jsr:@std/assert@^1.0",
     "@/": "./src/"

--- a/apps/backend/src/lib/shareImage.ts
+++ b/apps/backend/src/lib/shareImage.ts
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import {
+  AlphaAction,
+  ImageMagick,
+  initializeImageMagick,
+  MagickColor,
+  MagickFormat,
+} from "@imagemagick/magick-wasm";
+
+// Transcoding an uploaded image into the JPEG used as a post's Open Graph
+// share image.
+//
+// Deliberately free of config and filesystem imports, like lib/webhook.ts, so
+// the transcode is unit-testable on its own; the caching that needs the uploads
+// directory lives in services/shareImage.ts.
+//
+// Everything uploaded here is re-encoded to WebP in the browser before it is
+// sent (see the frontend's editor/image.ts), which is right for the page: it is
+// materially smaller than JPEG and every browser has supported it for years.
+// Link-preview scrapers are not browsers. WhatsApp's handling of a WebP
+// `og:image` is unreliable and fails *silently* — no image, no error — while
+// Telegram renders it fine, which is exactly the "works there, blank here"
+// report this exists to fix.
+//
+// So the page keeps its WebP and the share tag points at a JPEG derivative
+// generated from it on first request and cached on disk. Nothing about the
+// stored upload changes, which is what makes this work for posts published
+// before any of this existed — no backfill, no re-upload.
+//
+// Only ever fetched by a scraper, once per image per platform, so the cost is a
+// single transcode amortised over the life of the post.
+
+// 1200x630 is the size every platform documents for a share card. The image is
+// fitted inside that box rather than cropped to it: a banner is the author's
+// composition, and silently cutting a third off it to hit an aspect ratio is
+// worse than a card that letterboxes. Fitting also keeps us inside WhatsApp's
+// stated bounds (at least 300px wide, no narrower than 4:1).
+const OG_WIDTH = 1200;
+const OG_HEIGHT = 630;
+// Comfortably under WhatsApp's ~600KB ceiling at these dimensions.
+const OG_QUALITY = 82;
+
+// The wasm blob is ~14MB and initialising it is not free, so it happens once,
+// lazily, on the first share-image request — never during boot, which would tax
+// every instance whether or not a link is ever shared. Held as the promise
+// rather than a flag so concurrent first requests await one initialisation
+// instead of racing into several.
+let ready: Promise<void> | null = null;
+
+function initialize(): Promise<void> {
+  if (!ready) {
+    ready = (async () => {
+      // Resolved through the import map rather than a path into node_modules,
+      // so it works the same under `deno cache` in the image and a local run.
+      const wasm = await Deno.readFile(
+        new URL(import.meta.resolve("@imagemagick/magick-wasm/magick.wasm")),
+      );
+      await initializeImageMagick(wasm);
+    })().catch((err) => {
+      // Let a failed initialisation be retried rather than poisoning every
+      // later request with the same rejected promise.
+      ready = null;
+      throw err;
+    });
+  }
+  return ready;
+}
+
+/** Transcode an uploaded image to the JPEG used as a share image. */
+export async function toShareJpeg(source: Uint8Array): Promise<Uint8Array<ArrayBuffer>> {
+  await initialize();
+  let out: Uint8Array<ArrayBuffer> | null = null;
+  ImageMagick.read(source, (img) => {
+    // Drops EXIF: a scraper needs none of it, and a phone photo's camera and
+    // GPS tags have no business being republished on a share card.
+    img.strip();
+    // Only ever shrinks — enlarging a small image to fill the box would just
+    // ship a blurry upscale.
+    if (img.width > OG_WIDTH || img.height > OG_HEIGHT) img.resize(OG_WIDTH, OG_HEIGHT);
+    img.quality = OG_QUALITY;
+    // JPEG has no alpha channel, and dropping one without compositing first
+    // leaves every transparent pixel black — a logo on a transparent PNG would
+    // arrive as a black slab. Flatten onto white instead, which is what the
+    // card is shown against anyway.
+    img.backgroundColor = new MagickColor("white");
+    img.alpha(AlphaAction.Remove);
+    // Copied out of the callback: the buffer magick hands over is only valid
+    // for the duration of the call.
+    img.write(MagickFormat.Jpeg, (bytes) => {
+      out = new Uint8Array(bytes);
+    });
+  });
+  if (!out) throw new Error("Share image could not be encoded.");
+  return out;
+}

--- a/apps/backend/src/lib/shareImage_test.ts
+++ b/apps/backend/src/lib/shareImage_test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { assert, assertEquals } from "@std/assert";
+import { toShareJpeg } from "@/lib/shareImage.ts";
+
+// The share image exists for one reason: a link-preview scraper — WhatsApp
+// above all — must receive a JPEG, because it silently shows nothing for the
+// WebP every upload is stored as. So what is asserted here is the promise the
+// feature makes, not the library's behaviour: JPEG bytes out, small enough and
+// large enough for the platforms that consume them.
+//
+// Also guards the wasm binding itself. It loads a 14MB module through an import
+// map and a callback API; an upgrade that moved either would otherwise fail
+// only in production, on a page nobody looks at until a share comes out blank.
+
+// A 400x200 PNG, left half opaque red and right half fully transparent — so the
+// decode, the alpha flattening and the encode are all exercised.
+const TRANSPARENT_PNG = Uint8Array.from(
+  atob(
+    "iVBORw0KGgoAAAANSUhEUgAAAZAAAADICAYAAADGFbfiAAADsElEQVR42u3VAQ0AAAgCQfqXxgJawN1tXwHSpJL2AtyMhORAwIFIDgQciORAwIFIDgQciORAAAciORBwIJIDAQciORBwIJIDAQciORDAgUgOBByI5EDAgUgOBByI5EDAgUgOBHAgkgMBByI5EHAgkgMBByI5EHAgkhwIOBDJgYADkRwIOBDJgYADkRwIOBBJDgQciORAwIFIDgQciORAwIFIDgQciCQHAg5EciDgQCQHAg5EciDgQCQHAg5EkgMBByI5EHAgkgMBByI5EHAgkgMBHIjkQMCBSA4EHIjkQMCBSA4EHIjkQAAHIjkQcCCSAwEHIjkQcCCSAwEHIjkQwIFIDgQciORAwIFIDgQciORAwIFIDgRwIJIDAQciORBwIJIDAQciORBwIJIcCDgQyYGAA5EcCDgQyYGAA5EcCDgQSQ4EHIjkQMCBSA4EHIjkQMCBSA4EHIgkBwIORHIg4EAkBwIORHIg4EAkBwIOxEhIDgQciORAwIFIDgQciORAwIFIDgRwIJIDAQciORBwIJIDAQciORBwIJIDARyI5EDAgUgOBByI5EDAgUgOBByI5EAAByI5EHAgkgMBByI5EHAgkgMBByLJQoADkRwIOBDJgYADkRwIOBDJgYADkeRAwIFIDgQciORAwIFIDgQciORAwIFIciDgQCQHAg5EciDgQCQHAg5EciDgQCQ5EHAgkgMBByI5EHAgkgMBByI5EMCBSA4EHIjkQMCBSA4EHIjkQMCBSA4EcCCSAwEHIjkQcCCSAwEHIjkQcCCSAwEciORAwIFIDgQciORAwIFIDgQciORAAAciORBwIJIDAQciORBwIJIDAQciyYGAA5EcCDgQyYGAA5EcCDgQyYGAA5HkQMCBSA4EHIjkQMCBSA4EHIjkQMCBSHIg4EAkBwIORHIg4EAkBwIORHIg4ECMhORAwIFIDgQciORAwIFIDgQciORAAAciORBwIJIDAQciORBwIJIDAQciORDAgUgOBByI5EDAgUgOBByI5EDAgUgOBHAgkgMBByI5EHAgkgMBByI5EHAgkgMBHIjkQMCBSA4EHIjkQMCBSA4EHIgkBwIORHIg4EAkBwIORHIg4EAkBwIORJIDAQciORBwIJIDAQciORBwIJIDAQciyYGAA5EcCDgQyYGAA5EcCDgQyYEADkRyIOBAJAcCDkRyIOBAJAcCDkRyIIADkRwIOBDJgYADkRwIOBDJgYADkRwI4EAkBwIORHIg4EAkBwIORHIg8N8Aqh9Zuu00k14AAAAASUVORK5CYII=",
+  ),
+  (c) => c.charCodeAt(0),
+);
+
+/** Width and height read out of a JPEG's start-of-frame marker. */
+function jpegSize(bytes: Uint8Array): { width: number; height: number } | null {
+  for (let i = 2; i < bytes.length - 9;) {
+    if (bytes[i] !== 0xff) {
+      i++;
+      continue;
+    }
+    const marker = bytes[i + 1];
+    if (marker === 0xc0 || marker === 0xc1 || marker === 0xc2) {
+      return {
+        height: (bytes[i + 5] << 8) | bytes[i + 6],
+        width: (bytes[i + 7] << 8) | bytes[i + 8],
+      };
+    }
+    i += 2 + ((bytes[i + 2] << 8) | bytes[i + 3]);
+  }
+  return null;
+}
+
+Deno.test("toShareJpeg: returns JPEG bytes, whatever went in", async () => {
+  const jpeg = await toShareJpeg(TRANSPARENT_PNG);
+  // SOI + the first marker: what a scraper sniffs for.
+  assertEquals([jpeg[0], jpeg[1], jpeg[2]], [0xff, 0xd8, 0xff]);
+});
+
+Deno.test("toShareJpeg: an image already inside the card box is not upscaled", async () => {
+  // 400x200 fits within 1200x630, so enlarging it would only ship a blurry
+  // upscale to save nobody anything.
+  assertEquals(jpegSize(await toShareJpeg(TRANSPARENT_PNG)), { width: 400, height: 200 });
+});
+
+Deno.test("toShareJpeg: stays well under WhatsApp's ~600KB ceiling", async () => {
+  const jpeg = await toShareJpeg(TRANSPARENT_PNG);
+  assert(jpeg.length < 600 * 1024, `share image was ${jpeg.length} bytes`);
+});

--- a/apps/backend/src/routes/media.ts
+++ b/apps/backend/src/routes/media.ts
@@ -4,6 +4,7 @@ import { config } from "@/config.ts";
 import { notFound } from "@/lib/http.ts";
 import { requireUser } from "@/routes/middleware.ts";
 import * as mediaService from "@/services/media.ts";
+import * as shareImageService from "@/services/shareImage.ts";
 import type { AppEnv } from "@/routes/types.ts";
 
 // Serves and accepts user-uploaded media (avatars, post images) on local disk.
@@ -28,6 +29,40 @@ const CONTENT_TYPE: Record<string, string> = {
   webp: "image/webp",
   gif: "image/gif",
 };
+
+// The JPEG share image for an upload (see lib/shareImage.ts for why one
+// exists at all). Registered before "/:file" so "og" isn't captured as a
+// filename. Public and unauthenticated by necessity — the caller is a link
+// preview scraper, which has no session and follows no login.
+mediaRoutes.get("/og/:file", async (c) => {
+  const file = c.req.param("file");
+  // The share URL is always `<uuid>.jpg`; the stored source may be any format.
+  const id = /^([a-zA-Z0-9-]+)\.jpg$/.exec(file)?.[1];
+  if (!id) throw notFound("File not found.");
+
+  let jpeg: Uint8Array | null;
+  try {
+    jpeg = await shareImageService.shareJpeg(id);
+  } catch (err) {
+    // A share image is a nicety; an image the encoder chokes on must not be a
+    // 500 in a scraper's face. Log it and let the platform fall back to the
+    // instance's brand image.
+    console.warn(`Share image failed for ${id}: ${err instanceof Error ? err.message : err}`);
+    throw notFound("File not found.");
+  }
+  if (!jpeg) throw notFound("File not found.");
+
+  // A Uint8Array is a valid runtime BodyInit; the DOM typing (this project
+  // compiles with `lib: dom`) omits it — same cast as the inbox in app.ts.
+  return new Response(jpeg as BodyInit, {
+    headers: {
+      "content-type": "image/jpeg",
+      // Derived from an immutable upload, so it can be cached as hard as one.
+      "cache-control": "public, max-age=31536000, immutable",
+      "x-content-type-options": "nosniff",
+    },
+  });
+});
 
 mediaRoutes.get("/:file", async (c) => {
   const file = c.req.param("file");

--- a/apps/backend/src/services/openverse.ts
+++ b/apps/backend/src/services/openverse.ts
@@ -33,6 +33,14 @@ const USER_AGENT = `Omicron/${APP_VERSION} (+https://github.com/the-jk-labs/omic
 // a writer would otherwise be offered and quietly breach by publishing.
 const LICENSE_FILTER = "commercial,modification";
 
+// Openverse indexes SVGs and WebPs alongside photographs, and a banner becomes
+// this post's Open Graph share image. WhatsApp shows nothing at all for a WebP
+// and no scraper renders SVG, so restricting the search is simpler and more
+// reliable than transcoding someone else's file: an uploaded banner gets a JPEG
+// derivative from us (lib/shareImage.ts), but a remote one is hotlinked as-is
+// and has to be a safe format to begin with.
+const EXTENSION_FILTER = "jpg,jpeg,png";
+
 /** Human-readable licence name, e.g. "CC BY-SA 2.0" or "Public domain". */
 function licenseLabel(code: string, version: string): string {
   const slug = code.toUpperCase();
@@ -111,6 +119,7 @@ export async function search(query: string, page = 1): Promise<StockPhoto[]> {
     page: String(page),
     page_size: String(PER_PAGE),
     license_type: LICENSE_FILTER,
+    extension: EXTENSION_FILTER,
     // Openverse flags what its providers marked as sensitive; a banner picker
     // in a writing tool should not surface it.
     mature: "false",

--- a/apps/backend/src/services/shareImage.ts
+++ b/apps/backend/src/services/shareImage.ts
@@ -1,0 +1,62 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { config } from "@/config.ts";
+import { toShareJpeg } from "@/lib/shareImage.ts";
+import { IMAGE_TYPES } from "@/services/media.ts";
+
+// On-disk caching for post share images. The transcode itself is in
+// lib/shareImage.ts, which explains why a JPEG copy exists at all.
+
+/** Where a derivative is cached on disk. */
+export function cachePath(id: string): string {
+  return `${config.UPLOADS_DIR}/og/${id}.jpg`;
+}
+
+/**
+ * The stored upload a share image should be built from.
+ *
+ * Uploads are named `<uuid>.<ext>` and the share URL carries only the uuid, so
+ * the extension is recovered by trying the ones we accept. At most a handful of
+ * stat calls, and only on the first request for a given image.
+ */
+export async function findSource(id: string): Promise<Uint8Array<ArrayBuffer> | null> {
+  for (const ext of new Set(Object.values(IMAGE_TYPES))) {
+    try {
+      return await Deno.readFile(`${config.UPLOADS_DIR}/${id}.${ext}`);
+    } catch {
+      // Not this extension; try the next.
+    }
+  }
+  return null;
+}
+
+/**
+ * The cached JPEG for an upload, generating it if this is the first request.
+ *
+ * Returns null when no upload with that id exists. Written to a temporary file
+ * and renamed into place, so two scrapers arriving together can never serve
+ * each other a half-written image.
+ */
+export async function shareJpeg(id: string): Promise<Uint8Array<ArrayBuffer> | null> {
+  const cached = cachePath(id);
+  try {
+    return await Deno.readFile(cached);
+  } catch {
+    // Not built yet.
+  }
+
+  const source = await findSource(id);
+  if (!source) return null;
+
+  const jpeg = await toShareJpeg(source);
+  await Deno.mkdir(`${config.UPLOADS_DIR}/og`, { recursive: true });
+  const tmp = `${cached}.${crypto.randomUUID()}.tmp`;
+  try {
+    await Deno.writeFile(tmp, jpeg);
+    await Deno.rename(tmp, cached);
+  } catch {
+    // A failed cache write costs a re-transcode next time; it must not cost the
+    // caller their share image.
+    await Deno.remove(tmp).catch(() => {});
+  }
+  return jpeg;
+}

--- a/apps/frontend/src/hooks.server.ts
+++ b/apps/frontend/src/hooks.server.ts
@@ -66,6 +66,20 @@ export const handle: Handle = async ({ event, resolve }) => {
       transformPageChunk: ({ html }) => html.replace(LANG_PLACEHOLDER, pageLang(event.locals)),
     });
 
+  // State the encoding in the header, not only in the document.
+  //
+  // SvelteKit sends a bare `text/html`, which leaves `<meta charset>` as the
+  // only declaration — and that is a declaration a *parser* honours, several
+  // kilobytes into the document. A link-preview fetcher reading only the head,
+  // or anything that trusts the header over the markup, is left guessing, and
+  // its guess is Latin-1. On an instance writing Azerbaijani, Turkish or Greek
+  // that turns a title into mojibake in the share card while the page itself
+  // renders perfectly. Set once, here, where every HTML response passes.
+  const contentType = response.headers.get("content-type");
+  if (contentType?.startsWith("text/html") && !contentType.includes("charset")) {
+    response.headers.set("Content-Type", `${contentType}; charset=utf-8`);
+  }
+
   // Never MIME-sniff a response into a more dangerous type. Belt-and-suspenders
   // for /api/uploads (which is proxied through here, so the backend's own header
   // would otherwise be dropped by the proxy's header allowlist).

--- a/apps/frontend/src/lib/cover.ts
+++ b/apps/frontend/src/lib/cover.ts
@@ -29,7 +29,7 @@ export function firstBodyImage(html: string): string | null {
 
 // A path served by this instance's own uploads route — the only relative form
 // that is ours to resolve. Mirrors the backend's UPLOAD_PATH (lib/cover.ts).
-const UPLOAD_PATH = /^\/api\/uploads\/[A-Za-z0-9-]+\.(?:png|jpe?g|webp|gif)$/;
+const UPLOAD_PATH = /^\/api\/uploads\/([A-Za-z0-9-]+)\.(?:png|jpe?g|webp|gif)$/;
 
 /**
  * A banner URL in the absolute form an Open Graph scraper needs.
@@ -50,7 +50,14 @@ export function absoluteBanner(
   origin: string,
 ): string | undefined {
   if (!url) return undefined;
-  if (UPLOAD_PATH.test(url)) return `${origin}${url}`;
+  // An upload is published as its JPEG derivative rather than the stored file.
+  // Everything uploaded here is WebP (the browser re-encodes before sending),
+  // and WhatsApp's handling of a WebP `og:image` is unreliable — it shows no
+  // image at all, while Telegram renders the same tag fine. The backend serves
+  // a cached JPEG copy at this path purely for scrapers; the page itself goes
+  // on using the WebP. See backend lib/shareImage.ts.
+  const uploadId = url.match(UPLOAD_PATH)?.[1];
+  if (uploadId) return `${origin}/api/uploads/og/${uploadId}.jpg`;
   if (!/^https?:\/\//i.test(url)) return undefined;
   try {
     return new URL(url).href;

--- a/apps/frontend/src/routes/robots.txt/+server.ts
+++ b/apps/frontend/src/routes/robots.txt/+server.ts
@@ -24,6 +24,20 @@ import type { RequestHandler } from "./$types";
 // also cover `/lists/<public-list>`, which is shareable curated content with
 // its own feed and belongs in the index. The bare index page behind it needs a
 // session anyway.
+// Carved out of the `/api/` disallow below, and load-bearing for link previews.
+//
+// A robots.txt path is a prefix, so `Disallow: /api/` covered `/api/uploads/`
+// too — the one place under `/api/` that is not an endpoint but a file: every
+// image an author uploads, avatars included. A post's share image is one of
+// them, and the crawlers that build link cards (Facebook's, and WhatsApp's with
+// it) check robots.txt before fetching an `og:image`. So a banner uploaded here
+// was declared off-limits to the very fetchers it exists for, and the card came
+// out blank however correct the tag was.
+//
+// Listed before the disallows because that is the order the spec resolves ties
+// in for crawlers that don't implement longest-match.
+const ALLOW = ["/api/uploads/"];
+
 const DISALLOW = [
   "/compose",
   "/drafts",
@@ -52,6 +66,7 @@ export const GET: RequestHandler = async ({ fetch, url }) => {
     ? [
       "User-agent: *",
       "Allow: /",
+      ...ALLOW.map((p) => `Allow: ${p}`),
       ...DISALLOW.map((p) => `Disallow: ${p}`),
       "",
       `Sitemap: ${origin}/sitemap.xml`,


### PR DESCRIPTION
Sharing a post to WhatsApp produced a card with no image, no title and no description — just the domain and the raw URL. The same link on Telegram rendered correctly.

I fetched a real post from `omicron.blog` as each crawler rather than reasoning from the code alone. That found **three separate defects**, plus one thing that turned out to be fine.

## 1. `robots.txt` blocked every uploaded image

The biggest one, and it affects *all* platforms that honour robots.txt (Facebook, WhatsApp, LinkedIn, X).

```
Disallow: /api/
```

A robots.txt path is a prefix, so this also covered `/api/uploads/` — the one thing under `/api/` that is a file rather than an endpoint. Every uploaded image lives there, avatars included, and a post's banner is one of them. Link-card crawlers check robots.txt before fetching an `og:image`, so **an uploaded banner was declared off-limits to the very fetchers it exists for.** The tag was correct; the image was simply never allowed to be fetched.

Now explicitly allowed, listed before the disallows for crawlers that don't implement longest-match. Verified under both semantics — with longest-match, `/api/uploads/**` is allowed while `/api/posts`, `/admin` and `/search` stay disallowed. (Checked the live robots.txt too, to confirm the naive-parser result was pre-existing and not a regression from this change.)

## 2. `og:image` was WebP, which WhatsApp silently drops

Every image uploaded through Omicron is re-encoded to WebP in the browser (`editor/image.ts`). That is right for the page, but it means `og:image` pointed at a `.webp` for both banner paths — one uploaded in the picker, and the body's first image standing in when none was chosen.

Telegram handles WebP. [WhatsApp's support is inconsistent and fails silently](https://speedwppro.com/the-threat-of-webp-for-whatsapp-the-untold-truth/) — no image, no error — with [JPEG/PNG the reliable choice](https://opengraphplus.com/consumers/whatsapp/images).

The page keeps its WebP; `og:image` now points at a JPEG derivative generated on first request and cached on disk beside the upload. **No backfill** — this works for posts published before any of it existed, with no page-weight cost. Fitted inside 1200×630 rather than cropped (a banner is the author's composition), EXIF-stripped, and flattened onto white so a transparent PNG isn't a black slab once JPEG drops the alpha channel.

Remote banners can't be transcoded — they're hotlinked — so Openverse search is restricted to jpg/jpeg/png, since it indexes SVG and WebP alongside photographs and neither renders in a card.

## 3. No `charset` in the `Content-Type` header

SvelteKit sends a bare `text/html`, leaving `<meta charset>` as the only declaration — several KB into the document, and only honoured by something parsing the markup properly. A fetcher that trusts the header guesses Latin-1, turning a title into mojibake in the card while the page renders perfectly. Not hypothetical on an instance publishing Azerbaijani. Now set once where every HTML response passes; non-HTML responses (the proxied uploads especially) are untouched.

## What I checked and found healthy

Worth recording, because it narrows where any remaining problem can be:

- **The Anubis shield is not blocking WhatsApp.** `botPolicy.yaml` allow-lists it, and WhatsApp's documented UA (`WhatsApp/2.x.x.x A|I|N`, [Meta's docs](https://developers.facebook.com/documentation/business-messaging/whatsapp/link-previews/)) gets the full 84KB page in <1s. Browser-like UAs correctly get the 9KB proof-of-work interstitial.
- **The tags are present and early** — `og:title` at byte ~1.8KB, `<head>` only 5.8KB total. Nothing is running out of parse budget.
- TLS chain complete and valid; content negotiation honest (gzip requested → gzip returned, never Brotli-when-unasked); `og:image` 200 OK, 182KB JPEG; no `noindex` on the page; indexing enabled; `<meta charset>` at byte 320.

## Honest limitation

I could **not** reproduce the missing *title and description* against the live site — it currently serves both correctly to WhatsApp's user-agent. The fixes here explain the missing **image** conclusively; the missing text is most likely WhatsApp's preview cache holding a result from an earlier fetch (WhatsApp caches per URL and reuses it on re-share).

**The definitive test after deploying:** share the post with a query string appended (`?v=2`). That is a new URL to WhatsApp's cache. If the full card appears, the text was a stale cache; if it is still bare, there is something left to find and I'd want the result.

## Verified

- Simulated the full scraper flow with a WhatsApp UA: `og:image` → `/api/uploads/og/<id>.jpg`, served `image/jpeg`, JPEG magic bytes, **104KB (under the ~600KB ceiling), 949×630 (≥300 wide, under 4:1)** — every documented WhatsApp requirement, for both the uploaded-banner and body-image-fallback cases.
- Built the Docker image and ran the transcode **inside it with `--network=none`** — the 14MB wasm is genuinely baked in.
- Confirmed live: `robots.txt` emits the Allow, HTML responses carry `charset=utf-8`, and image responses keep `image/webp` / `image/jpeg`.
- 134 backend tests (3 new), lint, fmt, svelte-check, frontend build — all clean.

## Deploy notes

Adds a dependency: `@imagemagick/magick-wasm` (~14MB in the backend image), cached at build time. Nothing to configure; the derivative cache is created under the existing uploads volume. Plain `docker compose up -d` is enough — no Caddyfile change.