### PR TITLE
fix(mobile-nav): keep the bottom tab bar pinned when Firefox retracts its toolbar

### DIFF
--- a/apps/frontend/src/lib/components/MobileNav.svelte
+++ b/apps/frontend/src/lib/components/MobileNav.svelte
@@ -27,10 +27,41 @@
     const path = page.url.pathname;
     return href === "/" ? path === "/" : path.startsWith(href);
   }
+
+  // Firefox on Android retracts its browser toolbar on scroll-down but keeps the
+  // *layout* viewport at its original, shorter height; only the *visual* viewport
+  // grows into the strip the toolbar vacated. `bottom: 0` resolves against the
+  // layout viewport, so the bar parks a toolbar-height above the real bottom edge
+  // and article text shows through underneath it. Measuring the gap and pushing
+  // the bar down by it re-pins it to what the reader actually sees.
+  //
+  // Clamped at zero on purpose: when the on-screen keyboard shrinks the visual
+  // viewport this would otherwise lift the bar up over the keyboard, which is a
+  // different behaviour change than the one being fixed here.
+  let overhang = $state(0);
+
+  $effect(() => {
+    const vv = window.visualViewport;
+    if (!vv) return;
+
+    const measure = () => {
+      const layoutHeight = document.documentElement.clientHeight;
+      overhang = Math.max(0, vv.offsetTop + vv.height - layoutHeight);
+    };
+
+    measure();
+    vv.addEventListener("resize", measure);
+    vv.addEventListener("scroll", measure);
+    return () => {
+      vv.removeEventListener("resize", measure);
+      vv.removeEventListener("scroll", measure);
+    };
+  });
 </script>
 
 <nav
   class="border-border bg-background/95 fixed inset-x-0 bottom-0 z-30 flex border-t pb-[env(safe-area-inset-bottom)] backdrop-blur lg:hidden"
+  style={overhang ? `transform: translateY(${overhang}px)` : undefined}
   aria-label="Primary"
 >
   {#each items as item (item.href)}


### PR DESCRIPTION
## Symptom

On Firefox for Android, the mobile bottom tab bar stops sitting at the bottom of
the screen. After any downward scroll it parks roughly a browser-toolbar height
above the real bottom edge, with article text visible in the strip underneath it.
It stays there when scrolling stops, and only snaps back once the reader scrolls
to the top of the page.

## Root cause

Firefox's dynamic toolbar retracts on scroll-down without resizing the **layout**
viewport — only the **visual** viewport grows into the strip the toolbar vacated.
The bar is `position: fixed; bottom: 0` (`MobileNav.svelte:33`), and `bottom: 0`
resolves against the layout viewport, so it lands on the old, higher bottom edge
rather than the one the reader can see. Scrolling back to the top brings the
toolbar back, the two viewports match again, and the bar looks correct — which is
exactly the reported behaviour.

Chrome for Android and Safari resize the layout viewport in step with the visual
one, which is why the bug is Firefox-specific.

## The fix

Measure the difference between the two viewports through the VisualViewport API
and translate the bar down by it:

```
overhang = max(0, vv.offsetTop + vv.height - documentElement.clientHeight)
```

Recomputed on `visualViewport`'s `resize` and `scroll` events, applied as a
`translateY`. On browsers where the viewports agree, `overhang` is always 0 and
nothing changes.

The alternative — dropping `position: fixed` for a `sticky` footer inside a
scroll container — would mean restructuring the whole app layout around a custom
scroller, and would cost the native scroll behaviour on every other browser to
fix one browser's quirk.

The clamp at zero is deliberate. An open on-screen keyboard also shrinks the
visual viewport, and without the clamp the same formula would lift the tab bar up
over the keyboard. That may or may not be desirable, but it is a different change
from this one and shouldn't ride along silently.

## Verified

- `deno task check` — 4646 files, 0 errors, 0 warnings.
- Reasoning about the viewport model was confirmed against the reporter's
  observed behaviour (stuck while scrolled down, correct at the top).

**Not verified:** this has not been run on a physical Firefox Android device. The
fix depends on Firefox reporting `visualViewport.height` as the *grown* height
while the toolbar is retracted. If it does not, `overhang` stays 0 and the
behaviour is simply today's — a no-op rather than a regression — but the bug
would remain. Worth a quick check on a real handset before relying on it.

## Deploy notes

None — plain frontend change, no env vars, no migrations.
