### PR TITLE
fix(mobile-nav): apply the viewport offset on Gecko only

### DIFF
--- a/apps/frontend/src/lib/components/MobileNav.svelte
+++ b/apps/frontend/src/lib/components/MobileNav.svelte
@@ -35,6 +35,13 @@
   // and article text shows through underneath it. Measuring the gap and pushing
   // the bar down by it re-pins it to what the reader actually sees.
   //
+  // Gecko-gated, and it has to be. Blink re-pins fixed elements to the visual
+  // viewport bottom itself, at composite time — so the same offset applied there
+  // pushes the bar a toolbar-height *below* the screen and it slides out of view
+  // on every scroll. Script cannot tell the two apart: `getBoundingClientRect()`
+  // reports identical layout-viewport coordinates in both engines, because Blink's
+  // correction never touches layout. Sniffing the engine is the only signal left.
+  //
   // Clamped at zero on purpose: when the on-screen keyboard shrinks the visual
   // viewport this would otherwise lift the bar up over the keyboard, which is a
   // different behaviour change than the one being fixed here.
@@ -42,7 +49,7 @@
 
   $effect(() => {
     const vv = window.visualViewport;
-    if (!vv) return;
+    if (!vv || !navigator.userAgent.includes("Gecko/")) return;
 
     const measure = () => {
       const layoutHeight = document.documentElement.clientHeight;


### PR DESCRIPTION
Follow-up to #22.

## Symptom

After #22, the mobile bottom tab bar slides out of view on scroll-down in Brave
(and Chrome) and slides back on scroll-up — it reads as an "intellihide" that was
never asked for. Firefox, the browser #22 set out to fix, is unaffected by this
regression.

## Root cause

#22 assumed all engines resolve `bottom: 0` against a layout viewport that does
not grow when the browser toolbar retracts, leaving the bar stranded above the
visible bottom edge. That is true of Gecko. It is not true of Blink: Blink
re-pins fixed elements to the visual viewport bottom itself, at composite time,
so the bar was already in the right place. Adding the measured offset on top
moved it a further toolbar-height down, off the bottom of the screen.

## The fix

Gate the offset on the `Gecko/` UA token. Blink and WebKit carry only the
historical `like Gecko)` string — no slash — so the token matches Firefox alone.

UA sniffing is not the first choice, and it is worth being explicit about why
there is no better one here: Blink's correction happens *after* layout, so
`getBoundingClientRect()` returns identical layout-viewport coordinates in both
engines whether or not the browser has re-pinned the element. The visual
difference is real but invisible to script, so no feature test or measurement can
separate the two cases. The engine token is the only signal available.

Desktop Firefox matches the token too, but has no dynamic toolbar: the visual and
layout viewports agree, the measured offset is 0, and the bar is `lg:hidden`
there anyway.

## Verified

- `deno task check` — 4646 files, 0 errors, 0 warnings.
- Blink path reasoned from the reported behaviour: hide on scroll-down, restore
  on scroll-up, magnitude of one toolbar height — which is what a doubled offset
  produces and what an incorrect gap measurement would not.

**Not verified on hardware.** Both branches of this still need a real handset:
Brave/Chrome to confirm the bar is back to sitting still, and Firefox to confirm
#22's actual fix survives. If Firefox still floats, the offset is not being
measured correctly there and #22's premise needs revisiting rather than its gate.

## Deploy notes

None.
