### PR TITLE
feat(mobile-nav): retract the bottom tab bar on scroll-down

### DIFF
--- a/apps/frontend/src/lib/components/MobileNav.svelte
+++ b/apps/frontend/src/lib/components/MobileNav.svelte
@@ -4,6 +4,9 @@
   SideNav rail is hidden. Carries just the few most-switched destinations to
   stay uncrowded on phones; the rest (Drafts, Settings, …) live in the avatar
   menu in the top bar. Signed-in only — guests navigate via the top bar.
+
+  Retracts on scroll-down and returns on scroll-up, so a long post gets the whole
+  screen while the reader is moving through it.
 -->
 <script lang="ts">
   import { page } from "$app/state";
@@ -64,11 +67,48 @@
       vv.removeEventListener("scroll", measure);
     };
   });
+
+  // Retract on scroll-down, return on scroll-up. Driven by scroll direction
+  // rather than by the browser's own toolbar, which no engine exposes and which
+  // Blink and Gecko drive on different rules — reading it would make the bar
+  // behave differently per browser, which is exactly what this replaces.
+  let hiddenByScroll = $state(false);
+
+  // Below this much travel a gesture is thumb-jitter, not a direction change;
+  // reacting to it makes the bar flicker mid-scroll.
+  const DIRECTION_THRESHOLD = 6;
+  // Within this far from the top the bar always shows: at the head of a feed
+  // there is nothing to read past, and hiding it there just costs a scroll-up.
+  const ALWAYS_VISIBLE_ZONE = 80;
+
+  $effect(() => {
+    let lastY = window.scrollY;
+
+    const onScroll = () => {
+      const y = window.scrollY;
+      const delta = y - lastY;
+      // Leave `lastY` alone below the threshold so slow travel still accumulates
+      // into a direction change instead of being swallowed frame by frame.
+      if (Math.abs(delta) < DIRECTION_THRESHOLD) return;
+      hiddenByScroll = y > ALWAYS_VISIBLE_ZONE && delta > 0;
+      lastY = y;
+    };
+
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  });
+
+  // A retracted bar is off-screen but still in the tab order, so keyboard focus
+  // can land on a tab nobody can see. Bring it back when that happens.
+  function reveal() {
+    hiddenByScroll = false;
+  }
 </script>
 
 <nav
-  class="border-border bg-background/95 fixed inset-x-0 bottom-0 z-30 flex border-t pb-[env(safe-area-inset-bottom)] backdrop-blur lg:hidden"
-  style={overhang ? `transform: translateY(${overhang}px)` : undefined}
+  class="border-border bg-background/95 fixed inset-x-0 bottom-0 z-30 flex border-t pb-[env(safe-area-inset-bottom)] backdrop-blur transition-transform duration-200 ease-out motion-reduce:transition-none lg:hidden"
+  style={`transform: translateY(${overhang}px)${hiddenByScroll ? " translateY(100%)" : ""}`}
+  onfocusin={reveal}
   aria-label="Primary"
 >
   {#each items as item (item.href)}


### PR DESCRIPTION
Follow-up to #22 and #23.

## Why

#22 accidentally produced a hide-on-scroll bottom bar in Brave, by pushing it
off-screen with a doubled viewport offset. #23 removed the accident. The
behaviour itself was worth keeping, so this adds it deliberately and on every
browser: a long post gets the whole screen while the reader is moving through it,
and the bar comes back the moment they scroll up.

## Approach

Driven by **scroll direction**, not by the browser's own toolbar. That is the
whole point of the design: no engine exposes its toolbar state to script, and
Blink and Gecko retract theirs on different rules, so anything derived from the
toolbar would give a different feel per browser — the exact problem #22 and #23
were spent on. Scroll direction is identical everywhere.

Details worth flagging for review:

- **6px threshold.** Below that a gesture is thumb-jitter; reacting to it makes
  the bar flicker mid-scroll. `lastY` is deliberately *not* updated when the
  delta is under the threshold, so slow travel accumulates into a direction
  change instead of being swallowed frame by frame.
- **Top 80px always shows the bar.** At the head of a feed there is nothing to
  read past, so hiding it there only costs the reader a scroll-up.
- **Keyboard access.** A retracted bar is off-screen but still in the tab order.
  `onfocusin` brings it back, so focus cannot land on a tab nobody can see.
- **`prefers-reduced-motion`** disables the transition via `motion-reduce:`.
- The Gecko viewport offset from #22/#23 is untouched and composes with this as a
  second `translateY` — the bar still has to be pinned correctly at the point it
  returns.

## Verified

- `deno task check` — 4646 files, 0 errors, 0 warnings.

**Not verified on hardware.** The scroll-direction logic is engine-independent
and low-risk, but the interaction between the retract transform and the Gecko
offset has only been reasoned about, not watched on a Firefox Android handset.
The specific thing to look at there: the bar should return to the true bottom
edge, not to the stranded position #22 was fixing.

## Deploy notes

None.
