### PR TITLE
feat(posts): readable, id-free post permalinks

### DIFF
--- a/apps/backend/drizzle/0028_post_slugs.sql
+++ b/apps/backend/drizzle/0028_post_slugs.sql
@@ -1,0 +1,31 @@
+-- Readable, id-free post URLs. Additive and idempotent.
+--
+-- A permalink used to be `/@author/<title-slug>-<8 hex of the uuid>`. The id was
+-- there because nothing guaranteed the slug alone identified a post; the cost
+-- was a random token in every shared link. `posts.slug` makes the slug itself
+-- the key — unique per author — so the id can go.
+--
+-- Backfilled at boot rather than here (see services/postSlugs.ts): the slug is
+-- produced by the same TypeScript that the editor and the sitemap use, and
+-- reimplementing its transliteration in PL/pgSQL would give two answers that
+-- drift. Rows stay NULL until then, which reads as "no slug yet" and serves the
+-- old id-suffixed URL — the same thing an untitled draft does.
+ALTER TABLE "posts" ADD COLUMN IF NOT EXISTS "slug" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "posts_author_slug_idx" ON "posts" ("author_id", "slug");
+--> statement-breakpoint
+-- Slugs a post has been moved off, kept so links shared before a retitle still
+-- resolve. Unique per author for the same reason the live slug is: a retired
+-- address must never be reassigned to different writing.
+CREATE TABLE IF NOT EXISTS "post_slug_history" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "post_id" uuid NOT NULL REFERENCES "posts"("id") ON DELETE CASCADE,
+  "author_id" uuid NOT NULL REFERENCES "users"("id") ON DELETE CASCADE,
+  "slug" text NOT NULL,
+  "created_at" timestamptz DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "post_slug_history_author_slug_idx"
+  ON "post_slug_history" ("author_id", "slug");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "post_slug_history_post_idx" ON "post_slug_history" ("post_id");

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1786209507620,
       "tag": "0027_post_cover_credit",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1786209507621,
+      "tag": "0028_post_slugs",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -12,8 +12,17 @@ import {
   or,
   sql,
 } from "drizzle-orm";
+import { union } from "drizzle-orm/pg-core";
 import { db } from "@/db/client.ts";
-import { type NewPost, posts, postTags, remoteActors, tags, users } from "@/db/schema.ts";
+import {
+  type NewPost,
+  posts,
+  postSlugHistory,
+  postTags,
+  remoteActors,
+  tags,
+  users,
+} from "@/db/schema.ts";
 import { type Cursor, DEFAULT_PAGE_SIZE } from "@/lib/pagination.ts";
 import type { LanguageFilter } from "@/lib/languages.ts";
 
@@ -101,6 +110,103 @@ export function findById(id: string) {
     .orderBy(posts.createdAt)
     .limit(1)
     .then((r: unknown[]) => (r[0] ?? null) as PostWithAuthor | null);
+}
+
+// One author's post by its live slug — the lookup behind every canonical
+// `/@author/<slug>` read, served by `posts_author_slug_idx`. Local posts only:
+// `slug` is null on everything remote.
+export function findByAuthorSlug(username: string, slug: string) {
+  return selectPosts()
+    .where(and(eq(users.username, username), eq(posts.slug, slug)))
+    .limit(1)
+    .then((r: unknown[]) => (r[0] ?? null) as PostWithAuthor | null);
+}
+
+// The post a retired slug used to address, so a link shared before a retitle
+// still resolves (the caller redirects it to the current URL).
+export function findIdByHistorySlug(username: string, slug: string) {
+  return db
+    .select({ postId: postSlugHistory.postId })
+    .from(postSlugHistory)
+    .innerJoin(users, eq(postSlugHistory.authorId, users.id))
+    .where(and(eq(users.username, username), eq(postSlugHistory.slug, slug)))
+    .limit(1)
+    .then((r) => r[0]?.postId ?? null);
+}
+
+// Every slug this author has that is `base` or `base-<n>`, live or retired —
+// what slug allocation picks the first free suffix from (services/postSlugs.ts).
+// A post's own slugs are excluded so re-saving a post can keep the slug it
+// already holds instead of stepping to `-2`.
+export async function slugsLike(authorId: string, base: string, excludePostId?: string) {
+  const pattern = `${base}-%`;
+  const live = db
+    .select({ slug: sql<string>`${posts.slug}`.as("slug") })
+    .from(posts)
+    .where(
+      and(
+        eq(posts.authorId, authorId),
+        or(eq(posts.slug, base), sql`${posts.slug} like ${pattern}`),
+        excludePostId ? sql`${posts.id} <> ${excludePostId}` : undefined,
+      ),
+    );
+  const retired = db
+    .select({ slug: sql<string>`${postSlugHistory.slug}`.as("slug") })
+    .from(postSlugHistory)
+    .where(
+      and(
+        eq(postSlugHistory.authorId, authorId),
+        or(eq(postSlugHistory.slug, base), sql`${postSlugHistory.slug} like ${pattern}`),
+        excludePostId ? sql`${postSlugHistory.postId} <> ${excludePostId}` : undefined,
+      ),
+    );
+  const rows = await union(live, retired);
+  return new Set(rows.map((r) => r.slug));
+}
+
+// Moves a post onto `slug`, as one transaction so a reader can never find the
+// post at neither address: the slug it is leaving is filed in the history table
+// (which is what keeps already-shared links alive) and any history row that
+// held the incoming slug for this same post is dropped — a post retitled back
+// to an earlier name reclaims its old URL rather than colliding with itself.
+export async function setSlug(postId: string, authorId: string, slug: string) {
+  await db.transaction(async (tx) => {
+    const [current] = await tx
+      .select({ slug: posts.slug })
+      .from(posts)
+      .where(eq(posts.id, postId));
+    if (current?.slug === slug) return;
+    await tx
+      .delete(postSlugHistory)
+      .where(and(eq(postSlugHistory.authorId, authorId), eq(postSlugHistory.slug, slug)));
+    await tx.update(posts).set({ slug }).where(eq(posts.id, postId));
+    if (current?.slug) {
+      await tx
+        .insert(postSlugHistory)
+        .values({ postId, authorId, slug: current.slug })
+        .onConflictDoNothing();
+    }
+  });
+}
+
+// Local, titled posts still without a slug, oldest first — what the boot
+// backfill works through (services/postSlugs.ts). Oldest first so that when two
+// posts share a title the one published first takes the bare slug, which is the
+// order a reader would expect and is stable across re-runs.
+export function listWithoutSlug(limit: number) {
+  return db
+    .select({ id: posts.id, authorId: posts.authorId, title: posts.title })
+    .from(posts)
+    .where(
+      and(
+        eq(posts.remote, false),
+        isNull(posts.slug),
+        sql`${posts.authorId} is not null`,
+        sql`${posts.title} is not null`,
+      ),
+    )
+    .orderBy(posts.createdAt, posts.id)
+    .limit(limit);
 }
 
 export function findByApId(apId: string) {
@@ -199,6 +305,7 @@ export function listSitemapEntries(page = 1) {
     .select({
       id: posts.id,
       title: posts.title,
+      slug: posts.slug,
       authorUsername: users.username,
       createdAt: posts.createdAt,
       updatedAt: posts.updatedAt,

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -132,6 +132,13 @@ export const posts = pgTable("posts", {
   authorId: uuid("author_id").references(() => users.id, { onDelete: "cascade" }),
   remoteActorId: uuid("remote_actor_id").references(() => remoteActors.id, { onDelete: "cascade" }),
   title: text("title"),
+  // The post's share of its canonical URL: `/@author/<slug>`, derived from the
+  // title (see lib/slug.ts) and unique within the author. Null for a remote
+  // post (addressed by its origin's URL) and for an untitled draft (nothing to
+  // derive one from), both of which fall back to the post's short id. A retitle
+  // mints a new slug and files the old one in `post_slug_history`, so links
+  // already shared keep resolving.
+  slug: text("slug"),
   contentHtml: text("content_html").notNull(),
   contentJson: jsonb("content_json"),
   apId: text("ap_id"),
@@ -201,6 +208,30 @@ export const posts = pgTable("posts", {
   // own posts, so two of them can both publish a "hello-world" slug. NULLs are
   // distinct in a Postgres unique index, so this constrains ingested rows only.
   uniqueIndex("posts_author_external_idx").on(t.authorId, t.externalId),
+  // One live slug per author, and the lookup behind every `/@author/<slug>`
+  // read. NULLs are distinct in Postgres, so remote and untitled rows are
+  // unconstrained.
+  uniqueIndex("posts_author_slug_idx").on(t.authorId, t.slug),
+]);
+
+// ── post slug history ──────────────────────────────────────────────────
+// Slugs a post used to live at. Renaming a published post changes its URL, and
+// the old one has already been shared somewhere this instance cannot edit — a
+// tweet, a newsletter, someone's bookmarks. Each superseded slug is kept here
+// so that address keeps working, 308-redirecting to wherever the post is now.
+//
+// Unique per author for the same reason `posts.slug` is: a retired slug must
+// not be handed to a new post, or an old link would silently land on different
+// writing. Allocation checks both tables (see services/postSlugs.ts).
+export const postSlugHistory = pgTable("post_slug_history", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  postId: uuid("post_id").notNull().references(() => posts.id, { onDelete: "cascade" }),
+  authorId: uuid("author_id").notNull().references(() => users.id, { onDelete: "cascade" }),
+  slug: text("slug").notNull(),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  uniqueIndex("post_slug_history_author_slug_idx").on(t.authorId, t.slug),
+  index("post_slug_history_post_idx").on(t.postId),
 ]);
 
 // ── follows ────────────────────────────────────────────────────────────

--- a/apps/backend/src/lib/slug.ts
+++ b/apps/backend/src/lib/slug.ts
@@ -1,15 +1,47 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 // Kebab-case slugs. Kept byte-for-byte in step with the frontend's `slugify`
-// (apps/frontend/src/lib/links.ts), which builds the canonical
-// `/@user/some-title-9e962281` post URLs — an ingesting CMS that derives its
-// key from a title must land on the same string the reader sees in the
-// address bar.
+// (apps/frontend/src/lib/links.ts), which builds the canonical `/@user/some-title`
+// post URLs — an ingesting CMS that derives its key from a title must land on
+// the same string the reader sees in the address bar.
+
+/**
+ * Letters that carry no ASCII decomposition, so NFKD leaves them intact and the
+ * `[^a-z0-9]` sweep below would otherwise turn each one into a dash — a title
+ * written in Azerbaijani came out as `s-rz-nisl-r` instead of `sozunuslar`.
+ *
+ * Only letters NFKD cannot handle belong here. `ö`, `ü`, `ş`, `ç`, `ğ` and the
+ * rest of the accented Latin range decompose to a base letter plus a combining
+ * mark and are handled by stripping the mark; `ə` and `ı` are letters in their
+ * own right and have no decomposition at all.
+ *
+ * Non-Latin scripts (Cyrillic, Greek, Arabic, CJK…) are deliberately absent:
+ * transliterating them is a per-language decision with no single right answer,
+ * and a title in one of them slugifies to empty and falls back to the post's
+ * short id, which is a working URL rather than a wrong one.
+ */
+const TRANSLITERATIONS: Record<string, string> = {
+  "ə": "e",
+  "ı": "i",
+  "ø": "o",
+  "đ": "d",
+  "ð": "d",
+  "ħ": "h",
+  "ŋ": "n",
+  "ł": "l",
+  "ß": "ss",
+  "æ": "ae",
+  "œ": "oe",
+  "þ": "th",
+};
+
+const TRANSLITERATE_RE = new RegExp(`[${Object.keys(TRANSLITERATIONS).join("")}]`, "g");
 
 /** Kebab-case an arbitrary title; ASCII-only, matching Medium-style slugs. */
 export function slugify(title: string): string {
   return title
     .toLowerCase()
+    .replace(TRANSLITERATE_RE, (ch) => TRANSLITERATIONS[ch])
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "") // strip accents
     .replace(/['\u2019`]/g, "") // drop apostrophes so "it's" -> "its"

--- a/apps/backend/src/lib/slug_test.ts
+++ b/apps/backend/src/lib/slug_test.ts
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { assertEquals } from "@std/assert";
+import { slugify } from "@/lib/slug.ts";
+
+// A slug is now the whole address of a post (`/@author/<slug>`), not decoration
+// in front of an id, so what this function returns is what gets shared, indexed
+// and linked to. It also has to agree byte-for-byte with the frontend's copy in
+// apps/frontend/src/lib/links.ts.
+
+Deno.test("slugify: kebab-cases a plain title", () => {
+  assertEquals(slugify("Hello World"), "hello-world");
+  assertEquals(slugify("  Spaced   out  "), "spaced-out");
+});
+
+Deno.test("slugify: keeps Azerbaijani and Turkish words readable", () => {
+  // The bug this exists for: every non-ASCII letter used to become a dash, so
+  // this title slugified to "cok-yoruldum-patron-daga-dasa-s-rz-nisl-r".
+  assertEquals(
+    slugify("Çox yoruldum patron, dağa daşa sözünüzü nişanlar"),
+    "cox-yoruldum-patron-daga-dasa-sozunuzu-nisanlar",
+  );
+  assertEquals(slugify("Ə ə ı ğ ö ü ş ç"), "e-e-i-g-o-u-s-c");
+  assertEquals(slugify("İstanbul'da bir gün"), "istanbulda-bir-gun");
+});
+
+Deno.test("slugify: transliterates Latin letters NFKD cannot decompose", () => {
+  assertEquals(slugify("Straße"), "strasse");
+  assertEquals(slugify("Ærø"), "aero");
+});
+
+Deno.test("slugify: drops apostrophes rather than breaking the word", () => {
+  assertEquals(slugify("It's a Trap"), "its-a-trap");
+  assertEquals(slugify("It’s a Trap"), "its-a-trap");
+});
+
+Deno.test("slugify: yields empty for a title with nothing to romanize", () => {
+  // Not a failure — the caller falls back to the post's short id, which is a
+  // working URL. Non-Latin scripts are deliberately not transliterated.
+  assertEquals(slugify("Привет мир"), "");
+  assertEquals(slugify("!!!"), "");
+});
+
+Deno.test("slugify: caps length without leaving a trailing dash", () => {
+  const slug = slugify("word ".repeat(40));
+  assertEquals(slug.length <= 80, true);
+  assertEquals(slug.endsWith("-"), false);
+});

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { config } from "@/config.ts";
 import { runMigrations } from "@/db/migrate.ts";
+import { backfillSlugs } from "@/services/postSlugs.ts";
 import { buildApp } from "@/app.ts";
 import { getFederationEnabled } from "@/services/instanceSetup.ts";
 import { seedFederationRunning } from "@/services/federationState.ts";
@@ -11,6 +12,10 @@ import { APP_VERSION } from "@/version.ts";
 // Entry point: migrate → build app → serve. Stateless; all data in Postgres.
 async function main() {
   await runMigrations();
+  // Posts written before permalinks were readable have no slug yet, and one
+  // cannot be derived in SQL — see services/postSlugs.ts. Idempotent, and a
+  // single indexed query once every post has one.
+  await backfillSlugs();
   // Resolve the effective federation state (admin toggle → env → default) before
   // the app binds its ActivityPub routes; the value is fixed for this process.
   seedFederationRunning(await getFederationEnabled());

--- a/apps/backend/src/routes/posts.ts
+++ b/apps/backend/src/routes/posts.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { Hono } from "hono";
+import { type Context, Hono } from "hono";
 import { getCookie, setCookie } from "hono/cookie";
 import * as postsService from "@/services/posts.ts";
 import * as likesService from "@/services/likes.ts";
@@ -63,31 +63,50 @@ postRoutes.get("/trending", async (c) => {
   return c.json({ items: await enrichPosts(items, viewer?.id ?? null) });
 });
 
+// Count an on-instance view of a local published post. Fire-and-forget and
+// privacy-gated inside the service (DNT/GPC, bots, instance opt-out); it must
+// never delay or fail serving the page. Drafts and remote posts are skipped.
+// Shared by both ways of addressing a post, so a reader arriving by permalink
+// counts the same as one arriving by id.
+function countView(c: Context<AppEnv>, row: { post: { id: string } }) {
+  const viewer = c.get("user");
+  const headers = c.req.raw.headers;
+  let anonCookie = getCookie(c, VIEW_COOKIE) ?? null;
+  // Only issue the anonymous reader cookie to readers who could actually be
+  // counted — never to an opted-out or bot request, so nothing is set for
+  // traffic we're not going to track anyway.
+  if (
+    !viewer && !anonCookie && !readerOptedOut(headers) && !isBot(headers.get("user-agent") ?? "")
+  ) {
+    anonCookie = crypto.randomUUID() + crypto.randomUUID();
+    setCookie(c, VIEW_COOKIE, anonCookie, viewCookieOpts);
+  }
+  analyticsService.recordPostView(row.post.id, headers, viewer?.id ?? null, anonCookie).catch(
+    () => {},
+  );
+}
+
+// A post by its permalink, `/@username/<slug>` (public). Resolves the live
+// slug, then a retired one, then a trailing short id, so every permalink this
+// instance has ever issued still lands on the right post — see
+// postsService.getPostBySlug. Registered before "/:id" so "by" is not read as
+// a post id.
+postRoutes.get("/by/:username/:slug", async (c) => {
+  const viewer = c.get("user");
+  const row = await postsService.getPostBySlug(
+    c.req.param("username"),
+    c.req.param("slug"),
+    viewer?.id ?? null,
+  );
+  if (row.post.authorId && row.post.status === "published") countView(c, row);
+  return c.json({ post: await enrichPost(row, viewer?.id ?? null) });
+});
+
 // Single post (public). Drafts are visible only to their author.
 postRoutes.get("/:id", async (c) => {
   const viewer = c.get("user");
   const row = await postsService.getPost(c.req.param("id"), viewer?.id ?? null);
-
-  // Count an on-instance view of a local published post. Fire-and-forget and
-  // privacy-gated inside the service (DNT/GPC, bots, instance opt-out); it must
-  // never delay or fail serving the page. Drafts and remote posts are skipped.
-  if (row.post.authorId && row.post.status === "published") {
-    const headers = c.req.raw.headers;
-    let anonCookie = getCookie(c, VIEW_COOKIE) ?? null;
-    // Only issue the anonymous reader cookie to readers who could actually be
-    // counted — never to an opted-out or bot request, so nothing is set for
-    // traffic we're not going to track anyway.
-    if (
-      !viewer && !anonCookie && !readerOptedOut(headers) && !isBot(headers.get("user-agent") ?? "")
-    ) {
-      anonCookie = crypto.randomUUID() + crypto.randomUUID();
-      setCookie(c, VIEW_COOKIE, anonCookie, viewCookieOpts);
-    }
-    analyticsService.recordPostView(row.post.id, headers, viewer?.id ?? null, anonCookie).catch(
-      () => {},
-    );
-  }
-
+  if (row.post.authorId && row.post.status === "published") countView(c, row);
   return c.json({ post: await enrichPost(row, viewer?.id ?? null) });
 });
 

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -109,6 +109,9 @@ export function postWithAuthor(
   return {
     id: row.post.id,
     title: row.post.title,
+    // The readable half of the permalink, `/@author/<slug>` (lib/slug.ts). Null
+    // on remote and untitled posts, which the frontend addresses by short id.
+    slug: row.post.slug,
     contentHtml: row.post.contentHtml,
     contentJson: row.post.contentJson,
     remote: row.post.remote,
@@ -275,6 +278,7 @@ export function barePost(p: Omit<Post, "searchVector">) {
   return {
     id: p.id,
     title: p.title,
+    slug: p.slug,
     contentHtml: p.contentHtml,
     status: p.status,
     language: p.language,

--- a/apps/backend/src/services/indexNow.ts
+++ b/apps/backend/src/services/indexNow.ts
@@ -2,7 +2,6 @@
 import { config } from "@/config.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
-import { slugify } from "@/lib/slug.ts";
 import { getSeoSettings } from "@/services/seo.ts";
 
 // IndexNow: tell participating search engines that a URL changed, instead of
@@ -28,10 +27,14 @@ const ENDPOINT = "https://api.indexnow.org/IndexNow";
 const TIMEOUT_MS = 5000;
 
 /** Canonical public path for a post — mirrors the frontend's `postPath`. */
-export function postPath(post: { id: string; title: string | null }, username: string): string {
-  const slug = post.title ? slugify(post.title) : "";
-  const shortId = post.id.slice(0, 8);
-  return `/@${username}/${slug ? `${slug}-${shortId}` : shortId}`;
+export function postPath(
+  post: { id: string; title: string | null; slug: string | null },
+  username: string,
+): string {
+  // The stored slug is the post's address; a post without one (untitled, or not
+  // yet reached by the boot backfill) is addressed by its short id, as every
+  // post was before slugs existed.
+  return `/@${username}/${post.slug ?? post.id.slice(0, 8)}`;
 }
 
 /** Where the engines fetch the key from to confirm we own this host. */

--- a/apps/backend/src/services/postSlugs.ts
+++ b/apps/backend/src/services/postSlugs.ts
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import * as postsRepo from "@/db/repositories/posts.ts";
+import { slugify } from "@/lib/slug.ts";
+
+// Allocation of the slug half of a post's permalink, `/@author/<slug>`.
+//
+// Two rules make an id-free URL safe to hand out:
+//
+//   1. A slug is unique within its author, so `/@author/<slug>` names exactly
+//      one post. Collisions take a `-2`, `-3`, … suffix.
+//   2. A slug is never reused. When a retitle moves a post to a new slug the
+//      old one is filed in `post_slug_history` and stays out of circulation, so
+//      a link shared before the retitle can only ever redirect to the post it
+//      was originally pointing at — never to somebody's later article that
+//      happened to slugify the same way.
+//
+// Remote posts get no slug: they are addressed by their origin instance's URL,
+// and this instance has no say in it. Untitled drafts get none either — there
+// is nothing to derive one from — and fall back to their short id, which is
+// what every post's URL used to be.
+
+// How many `-n` suffixes to try before giving up on a readable slug. Reached
+// only by an author who has published the same title 50 times; past that the
+// post keeps its short-id URL rather than growing an ever-longer number.
+const MAX_SUFFIX = 50;
+
+// Post ids are v4 UUIDs, so the first block is 32 random bits — the same token
+// the pre-slug permalinks used, and enough to disambiguate a title an author
+// has somehow exhausted the suffix range for.
+function shortId(id: string): string {
+  return id.slice(0, 8);
+}
+
+/**
+ * The slug this post should live at, or null when it should have none.
+ *
+ * Returns the post's current slug unchanged when the title still slugifies to
+ * it, so re-saving a post (or an ingest webhook re-delivering it) is a no-op
+ * rather than a walk up the suffix range.
+ */
+async function allocate(
+  post: { id: string; authorId: string; title: string | null; slug?: string | null },
+): Promise<string | null> {
+  const base = post.title ? slugify(post.title) : "";
+  if (!base) return null;
+
+  // The post's own slugs never block it: keeping `hello-world` on an edit that
+  // did not touch the title must not push it to `hello-world-2`.
+  const taken = await postsRepo.slugsLike(post.authorId, base, post.id);
+  if (!taken.has(base)) return base;
+  for (let n = 2; n <= MAX_SUFFIX; n++) {
+    const candidate = `${base}-${n}`;
+    if (!taken.has(candidate)) return candidate;
+  }
+  return `${base}-${shortId(post.id)}`;
+}
+
+/**
+ * Give a post the slug its title implies, moving it off its previous one (which
+ * keeps redirecting) if the title changed. A no-op for a post that should have
+ * no slug, so callers can invoke it unconditionally after any write.
+ *
+ * Returns the slug now in force, or null when the post has none.
+ *
+ * Never throws: a permalink that stays at its short-id form is a working URL,
+ * and losing an author's publish over a slug would not be.
+ */
+export async function syncSlug(
+  post: { id: string; authorId: string | null; title: string | null; slug?: string | null },
+): Promise<string | null> {
+  if (!post.authorId) return null;
+  const authorId = post.authorId;
+  try {
+    const slug = await allocate({ ...post, authorId });
+    if (!slug || slug === post.slug) return slug ?? post.slug ?? null;
+    // Two concurrent writes can allocate the same slug — both read the same
+    // taken-set before either inserts. The unique index catches the loser, and
+    // a second pass sees the winner's row and picks the next suffix.
+    try {
+      await postsRepo.setSlug(post.id, authorId, slug);
+      return slug;
+    } catch {
+      const retry = await allocate({ ...post, authorId });
+      if (!retry) return post.slug ?? null;
+      await postsRepo.setSlug(post.id, authorId, retry);
+      return retry;
+    }
+  } catch (err) {
+    console.error(`Could not assign a slug to post ${post.id}:`, err);
+    return post.slug ?? null;
+  }
+}
+
+// One boot's worth of backfill. Large enough to finish any realistic instance
+// in a single start, bounded so a pathological database cannot hold the process
+// at the door — whatever is left is picked up by the next restart, and until
+// then those posts serve their old id-suffixed URLs.
+const BACKFILL_LIMIT = 20000;
+
+/**
+ * Give every pre-existing titled post a slug, once, at boot.
+ *
+ * This is a migration, but it cannot be written as SQL: the slug comes from
+ * `slugify`, whose transliteration would have to be reimplemented in PL/pgSQL
+ * and would then drift from the copy the editor and the sitemap use. Running it
+ * here keeps exactly one definition of what a title's slug is.
+ *
+ * Idempotent and cheap when there is nothing to do — one indexed query against
+ * `slug is null`. Old links keep working either way: a post's short id resolves
+ * whether or not it has been given a slug yet.
+ */
+export async function backfillSlugs(): Promise<void> {
+  const pending = await postsRepo.listWithoutSlug(BACKFILL_LIMIT);
+  if (pending.length === 0) return;
+
+  const start = Date.now();
+  let done = 0;
+  // Sequential, not parallel: allocation reads the slugs an author already has,
+  // so two of the same author's posts running at once would both see the base
+  // slug free and one would lose the insert. This runs once per instance.
+  for (const post of pending) {
+    const slug = await syncSlug(post);
+    if (slug) done++;
+  }
+  console.log(`✔ Backfilled ${done} post slug(s) (${Date.now() - start}ms).`);
+}

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -11,6 +11,7 @@ import { type LanguageFilter, normalizeLanguage } from "@/lib/languages.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
 import { normalizeCoverCredit, normalizeCoverUrl } from "@/lib/cover.ts";
 import { SUMMARY_LENGTH as MAX_SUMMARY } from "@/lib/webhook.ts";
+import { syncSlug } from "@/services/postSlugs.ts";
 import { queue } from "@/queue/queue.ts";
 
 // Business logic for posts. Creating a local post enqueues federation delivery.
@@ -101,6 +102,11 @@ export async function createPost(authorId: string, input: {
 
   if (tags !== undefined) await tagsRepo.setPostTags(post.id, tags);
 
+  // The permalink's readable half, allocated from the title (see
+  // services/postSlugs.ts). An untitled draft gets none and is addressed by its
+  // short id until it is titled.
+  post.slug = await syncSlug(post);
+
   // Only published posts fan out to remote followers; drafts stay private.
   if (status === "published") {
     queue.add("federate_post", { postId: post.id });
@@ -115,13 +121,61 @@ export async function getPost(id: string, viewerId: string | null = null) {
   if (!/^[0-9a-f-]{8,}$/i.test(id)) throw notFound("Post not found.");
   const row = await postsRepo.findById(id);
   if (!row) throw notFound("Post not found.");
+  return assertVisible(row, viewerId);
+}
+
+// A trailing short id in a `[slug]` route param — what a permalink shared
+// before readable slugs existed carries (`some-title-9e962281`), and what an
+// untitled or remote post's URL is made of on its own. The leading dash is
+// optional so both forms match.
+const TRAILING_SHORT_ID = /(?:^|-)([0-9a-f]{8,})$/i;
+
+/**
+ * Resolve `/@username/<slug>` to a post, in the order a reader's link can mean
+ * things:
+ *
+ *   1. the author's live slug — the canonical URL, one indexed lookup;
+ *   2. a slug the post has been moved off (`post_slug_history`), so a link
+ *      shared before a retitle still arrives;
+ *   3. a trailing short id, which is what every permalink looked like before
+ *      slugs and what remote and untitled posts still use.
+ *
+ * The live slug is tried first so a post whose title genuinely slugifies to
+ * something ending in hex is reachable at its own address rather than being
+ * read as an id. The caller compares what it got back against the canonical
+ * path and redirects when they differ, which is what turns (2) and (3) into
+ * permanent redirects to the current URL.
+ */
+export async function getPostBySlug(
+  username: string,
+  slug: string,
+  viewerId: string | null = null,
+) {
+  const bySlug = await postsRepo.findByAuthorSlug(username, slug);
+  if (bySlug) return assertVisible(bySlug, viewerId);
+
+  const retiredId = await postsRepo.findIdByHistorySlug(username, slug);
+  if (retiredId) {
+    const row = await postsRepo.findById(retiredId);
+    if (row) return assertVisible(row, viewerId);
+  }
+
+  const shortId = slug.match(TRAILING_SHORT_ID)?.[1];
+  if (shortId) return getPost(shortId.toLowerCase(), viewerId);
+
+  throw notFound("Post not found.");
+}
+
+// Who may read a single post. Feeds filter in SQL (visibleToViewer); a direct
+// permalink is gated here, whichever way the reader addressed it.
+async function assertVisible(row: postsRepo.PostWithAuthor, viewerId: string | null) {
   // Drafts are private to their author — anyone else gets a plain not-found.
   if (row.post.status === "draft" && row.post.authorId !== viewerId) {
     throw notFound("Post not found.");
   }
   // A block hides the two users' posts from each other everywhere — including a
-  // direct link to a single post (feeds filter separately). Local authors are
-  // bidirectional; remote authors can only be blocked by the local viewer.
+  // direct link to a single post. Local authors are bidirectional; remote
+  // authors can only be blocked by the local viewer.
   if (viewerId) {
     const blocked = row.post.authorId
       ? await relationsRepo.localBlockExists(viewerId, row.post.authorId)
@@ -221,6 +275,11 @@ export async function updatePost(authorId: string, id: string, input: {
   // an empty SET) and keep the existing row.
   const touchedColumns = Object.keys(changes).length > 0;
   const post = touchedColumns ? await postsRepo.update(id, changes) : row.post;
+
+  // A retitle moves the post to a new slug and leaves the old one redirecting,
+  // so a link shared under the previous title still lands here. Only worth a
+  // query when the title actually changed.
+  if (post.title !== row.post.title) post.slug = await syncSlug(post);
 
   // Tags are replaced wholesale when provided; an empty array clears them.
   if (input.tags !== undefined) {

--- a/apps/backend/src/services/webhooks.ts
+++ b/apps/backend/src/services/webhooks.ts
@@ -18,6 +18,7 @@ import {
   summarize,
 } from "@/lib/webhook.ts";
 import { queue } from "@/queue/queue.ts";
+import { syncSlug } from "@/services/postSlugs.ts";
 import { config } from "@/config.ts";
 import type { NewPost, User } from "@/db/schema.ts";
 
@@ -221,6 +222,11 @@ export async function ingestContent(
 
   // Only reachable when the post was deleted between the lookup and the write.
   if (!post) throw conflict("That post was removed while this update was in flight.");
+
+  // Ingested posts get the same readable permalink as ones written here, from
+  // the same title. `externalId` is the CMS's key for its own document and
+  // never appears in a URL.
+  if (post.title !== existing?.title || !post.slug) post.slug = await syncSlug(post);
 
   // Tags are replaced wholesale when the payload carries the field; omitting it
   // leaves whatever the post already has, and `[]` clears them.

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -214,15 +214,24 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
       api.get<Page<Post>>(`/posts${timelineQuery(cursor, langFilter, "local")}`),
     trendingPosts: () => api.get<{ items: Post[] }>("/posts/trending"),
     post: (id: string) => api.get<{ post: Post }>(`/posts/${id}`),
+    // A post by its permalink. The backend resolves the author's live slug, a
+    // slug the post has been moved off, or a trailing short id from a
+    // pre-slug link — so every permalink ever issued arrives here.
+    postBySlug: (username: string, slug: string) =>
+      api.get<{ post: Post }>(
+        `/posts/by/${encodeURIComponent(username)}/${encodeURIComponent(slug)}`,
+      ),
     drafts: (cursor?: string | null) =>
       api.get<Page<Post>>(`/posts/drafts${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""}`),
     createPost: (
       body: { title?: string; contentHtml: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; coverUrl?: string | null; coverCredit?: CoverCredit | null; tags?: string[] },
-    ) => api.post<{ post: { id: string } }>("/posts", body),
+    ) => api.post<{ post: { id: string; slug: string | null } }>("/posts", body),
     updatePost: (
       id: string,
       body: { title?: string; contentHtml?: string; contentJson?: unknown; status?: "draft" | "published"; language?: string | null; summary?: string | null; coverUrl?: string | null; coverCredit?: CoverCredit | null; tags?: string[] },
-    ) => api.patch<{ post: { id: string } }>(`/posts/${id}`, body),
+      // `slug` comes back because a retitle changes it, and the editor has to
+      // navigate to the post's new address.
+    ) => api.patch<{ post: { id: string; slug: string | null } }>(`/posts/${id}`, body),
     deletePost: (id: string) => api.del<{ ok: true }>(`/posts/${id}`),
     // Posts to read next, shown under an article (see relatedPosts service).
     relatedPosts: (id: string) => api.get<{ items: Post[] }>(`/posts/${id}/related`),

--- a/apps/frontend/src/lib/links.ts
+++ b/apps/frontend/src/lib/links.ts
@@ -18,10 +18,37 @@ function shortId(id: string): string {
   return id.slice(0, 8);
 }
 
+/**
+ * Letters that carry no ASCII decomposition, so NFKD leaves them intact and the
+ * `[^a-z0-9]` sweep below would otherwise turn each one into a dash — a title
+ * written in Azerbaijani came out as `s-rz-nisl-r` instead of `sozunuslar`.
+ *
+ * Mirrors apps/backend/src/lib/slug.ts, which is what the ingest webhook derives
+ * its key with; keep the two identical. See that file for why non-Latin scripts
+ * are absent.
+ */
+const TRANSLITERATIONS: Record<string, string> = {
+  "ə": "e",
+  "ı": "i",
+  "ø": "o",
+  "đ": "d",
+  "ð": "d",
+  "ħ": "h",
+  "ŋ": "n",
+  "ł": "l",
+  "ß": "ss",
+  "æ": "ae",
+  "œ": "oe",
+  "þ": "th",
+};
+
+const TRANSLITERATE_RE = new RegExp(`[${Object.keys(TRANSLITERATIONS).join("")}]`, "g");
+
 /** Kebab-case an arbitrary title; ASCII-only, matching Medium-style slugs. */
 export function slugify(title: string): string {
   return title
     .toLowerCase()
+    .replace(TRANSLITERATE_RE, (ch) => TRANSLITERATIONS[ch])
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "") // strip accents
     .replace(/['\u2019`]/g, "") // drop apostrophes so "it's" \u2192 "its"

--- a/apps/frontend/src/lib/links.ts
+++ b/apps/frontend/src/lib/links.ts
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Canonical, title-based URLs for posts — e.g.
-//   /@burk/europe-is-ditching-visa-and-mastercard-and-its-a-huge-step-9e962281
-// The trailing token is the first block of the post UUID (8 hex chars); the
-// backend resolves it by prefix. The slug is cosmetic and regenerated from the
-// title, so renaming a post is safe and stale slugs still redirect to canonical.
+//   /@burk/europe-is-ditching-visa-and-mastercard-and-its-a-huge-step
+// The slug is the post's address: the backend stores it (unique per author) and
+// resolves it directly. Retitling a post mints a new slug and keeps the old one
+// redirecting, so links already shared stay good, and permalinks issued before
+// slugs existed — `<slug>-9e962281`, the first block of the post's UUID — still
+// resolve by that trailing id and 308 to the current URL.
+//
+// A post with no slug (remote, or untitled) is addressed by that short id alone.
 
 import type { Post, ReadingList } from "$lib/types";
 
@@ -23,9 +27,8 @@ function shortId(id: string): string {
  * `[^a-z0-9]` sweep below would otherwise turn each one into a dash — a title
  * written in Azerbaijani came out as `s-rz-nisl-r` instead of `sozunuslar`.
  *
- * Mirrors apps/backend/src/lib/slug.ts, which is what the ingest webhook derives
- * its key with; keep the two identical. See that file for why non-Latin scripts
- * are absent.
+ * Mirrors apps/backend/src/lib/slug.ts, which is what actually stores the slug;
+ * keep the two identical. See that file for why non-Latin scripts are absent.
  */
 const TRANSLITERATIONS: Record<string, string> = {
   "ə": "e",
@@ -51,27 +54,26 @@ export function slugify(title: string): string {
     .replace(TRANSLITERATE_RE, (ch) => TRANSLITERATIONS[ch])
     .normalize("NFKD")
     .replace(/[\u0300-\u036f]/g, "") // strip accents
-    .replace(/['\u2019`]/g, "") // drop apostrophes so "it's" \u2192 "its"
+    .replace(/['\u2019`]/g, "") // drop apostrophes so "it's" → "its"
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "")
     .slice(0, 80)
     .replace(/-+$/g, "");
 }
 
-/** Canonical path for a post, e.g. `/@user/some-title-9e962281`. */
+/** Canonical path for a post, e.g. `/@user/some-title`. */
 export function postPath(
-  post: Pick<Post, "id" | "title"> & { author: { username: string } },
+  post: Pick<Post, "id" | "slug"> & { author: { username: string } },
 ): string {
-  const slug = post.title ? slugify(post.title) : "";
-  const id = shortId(post.id);
-  const tail = slug ? `${slug}-${id}` : id;
-  return `/@${post.author.username}/${tail}`;
+  // The slug is the server's, not a local re-derivation: it is what disambiguates
+  // two posts with the same title, and what an already-shared link redirects to.
+  return `/@${post.author.username}/${post.slug || shortId(post.id)}`;
 }
 
 /**
  * Resolve the post id from a `[slug]` route param. Prefers a full UUID (legacy
  * permalinks), then falls back to the trailing short id. Returns null if neither
- * is present.
+ * is present — a slug-addressed post, which only the backend can resolve.
  */
 export function postIdFromSlug(slug: string): string | null {
   const full = slug.match(FULL_UUID)?.[0];

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -63,6 +63,11 @@ export type CoverCredit = {
 export type Post = {
   id: string;
   title: string | null;
+  // The readable half of the permalink: `/@author/<slug>`, allocated server-side
+  // from the title and unique within the author. Null on a remote post (its
+  // origin owns the URL) and on an untitled draft, both of which are addressed
+  // by the post's short id instead. Build links with `postPath`, never by hand.
+  slug?: string | null;
   contentHtml: string;
   contentJson?: unknown;
   remote: boolean;
@@ -326,6 +331,7 @@ export type StockPhoto = {
 export type SitemapEntry = {
   id: string;
   title: string | null;
+  slug: string | null;
   authorUsername: string;
   createdAt: string;
   updatedAt: string;

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.server.ts
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.server.ts
@@ -3,22 +3,24 @@ import { error, redirect } from "@sveltejs/kit";
 import { endpoints, ApiError } from "$lib/api";
 import { deferBodyImages } from "$lib/bodyImages";
 import { highlightCodeBlocks } from "$lib/highlight";
-import { postIdFromSlug, postPath } from "$lib/links";
+import { postPath } from "$lib/links";
 import type { PageServerLoad } from "./$types";
 
-// Blog post at /@username/<slug>-<uuid>. The trailing UUID is authoritative;
-// the slug and handle are cosmetic and redirect to the canonical path when they
-// drift (e.g. after a rename or a hand-typed link).
+// Blog post at /@username/<slug>. The slug is the address: the backend resolves
+// it against the author's live slug, then against slugs the post has been moved
+// off (a retitle), then against a trailing short id — which is what permalinks
+// looked like before slugs (`<slug>-9e962281`) and what a remote or untitled
+// post still uses. Anything that resolves but is not the canonical path — an
+// old slug, an id link, a drifted handle — redirects to the current one, so a
+// link shared years ago still arrives and search engines see a single URL.
 export const load: PageServerLoad = async ({ fetch, locals, params, url }) => {
-  const id = postIdFromSlug(params.slug);
-  if (!id) error(404, "Post not found");
+  const handle = params.handle.replace(/^@/, "");
+  if (!handle || params.handle[0] !== "@") error(404, "Post not found");
 
   let data;
   try {
     const api = endpoints(fetch);
-    // Resolve the post first (id may be a short prefix), then load its comments
-    // by the full id.
-    const { post } = await api.post(id);
+    const { post } = await api.postBySlug(handle, params.slug);
     // Comments and the read-next rail are independent of each other, so they go
     // out together. A failure in the rail must not cost the reader the article,
     // so it degrades to an empty list rather than propagating.

--- a/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
+++ b/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
@@ -62,7 +62,7 @@
     error = "";
     busy = true;
     try {
-      await endpoints().updatePost(post.id, {
+      const { post: saved } = await endpoints().updatePost(post.id, {
         title: title.trim(),
         contentHtml: html,
         contentJson: json,
@@ -72,8 +72,9 @@
         coverCredit,
         tags,
       });
-      // Title may have changed, so navigate to the freshly-built canonical path.
-      goto(postPath({ ...post, title: title.trim() }));
+      // A retitle moves the post to a new slug, so navigate to the one the
+      // save came back with rather than to the address it had on open.
+      goto(postPath({ ...post, slug: saved.slug }));
     } catch (err) {
       error = err instanceof ApiError ? err.message : "Failed to save.";
       busy = false;

--- a/apps/frontend/src/routes/sitemap/posts-[page].xml/+server.ts
+++ b/apps/frontend/src/routes/sitemap/posts-[page].xml/+server.ts
@@ -34,7 +34,7 @@ export const GET: RequestHandler = async ({ fetch, params, url }) => {
   for (const e of entries) {
     const path = postPath({
       id: e.id,
-      title: e.title,
+      slug: e.slug,
       author: { username: e.authorUsername },
     });
     // The post's own edit time, so a rewritten article asks to be re-read


### PR DESCRIPTION
## The symptom

A post's permalink carried a random token and, for anything not written in
English, mangled the title on the way there:

```
/@subhangadirli/cok-yoruldum-patron-daga-dasa-s-rz-nisl-r-0ee3a5cc
```

Two separate problems in one URL. `sözünüzü nişanlar` came out as `s-rz-nisl-r`,
and `-0ee3a5cc` is in every link anyone shares.

## Root cause

**The dashes.** `slugify` strips combining marks after NFKD and then replaces
everything outside `[a-z0-9]` with a dash. `ö`, `ü`, `ş`, `ç`, `ğ` decompose to a
base letter plus a mark and survive that fine — but `ə` and `ı` are letters in
their own right with no decomposition at all, so each one reached the sweep and
became a dash.

**The id.** It was load-bearing: nothing guaranteed the slug alone identified a
post, so the id was the actual key and the slug was decoration in front of it
(`postIdFromSlug` read the trailing hex, the slug was never looked at).

## The fix

Two commits, separately revertable.

**1. Transliterate the letters NFKD leaves behind** — `ə→e`, `ı→i`, plus `ß→ss`,
`æ→ae`, `ø→o`, `đ/ð→d`, `ł→l`, `œ→oe`, `þ→th`, `ħ`, `ŋ`. Only those; anything the
existing normalize/strip pair already handles is left to it, so a title that was
fine is unchanged. Non-Latin scripts are deliberately not covered — transliterating
Cyrillic or Greek is a per-language decision with no single right answer, and such a
title slugifies to empty and falls back to the short id, which is a working URL
rather than a wrong one. Both copies of `slugify` move together: the frontend
builds the URL a reader sees, the backend derives an ingest webhook's key from the
same title, and the two have to agree byte-for-byte.

**2. Make the slug the key.** `posts.slug`, unique per author, allocated from the
title at publish and on webhook ingest, with a `-2`, `-3`, … suffix when an author
publishes the same title twice. The permalink is now `/@author/<slug>`. Remote
posts and untitled drafts get no slug and keep the short-id form, which is the only
address they ever had.

## Nothing already shared breaks

`getPostBySlug` resolves in order:

1. the author's live slug — the canonical URL, one indexed lookup;
2. a slug the post has been moved off (`post_slug_history`);
3. a trailing short id.

(3) is exactly what every permalink issued before this PR carries, so a link posted
elsewhere years ago still resolves and 308s to the current URL. The live slug is
tried first so a post whose title genuinely slugifies to something ending in hex is
reachable at its own address rather than being read as an id.

Retitling a post moves it to a new slug and files the old one in
`post_slug_history`, which both keeps the old address redirecting and holds it out
of circulation — a retired slug is never handed to a later post, so an old link can
only ever land on the writing it was pointing at. Retitling back reclaims the
original slug instead of colliding with the post's own history.

## Backfill

Existing posts are given slugs at boot, not in the migration. The slug comes from
`slugify`, whose transliteration would have to be reimplemented in PL/pgSQL and
would then drift from the copy the editor and the sitemap use; running it in the
app keeps one definition of what a title's slug is. It is idempotent, costs one
indexed query once every post has one, and until a post is reached it serves its
old id-suffixed URL.

## What was verified

Against a real Postgres (throwaway container, migrations replayed from scratch):

- migration applies; allocation from an Azerbaijani title; the `-2` suffix on a
  duplicate title;
- lookup by live slug, by retired slug, by legacy id-suffixed link, and by bare
  short id;
- retitle → new slug with the old one still resolving; retitle back → original
  slug reclaimed;
- a new post with a retired slug's title does not get that slug, and the retired
  slug still points at the original post;
- untitled draft gets no slug; boot backfill fills a cleared one; unknown slug 404s.

Backend suite (140 tests, including 6 new `slugify` cases) and frontend
`svelte-check` (0 errors) pass.

**Not verified:** two writers publishing the same title concurrently. Both would
read the same taken-set, the unique index catches the loser and allocation retries
onto the next suffix — reasoned about, not raced.

## Deploy notes

Plain `docker compose up -d`. The migration is additive; the backfill runs once on
the first boot of the new backend and logs how many slugs it wrote. Old URLs keep
working before, during and after it.

Docs: this changes the shape of every post URL a reader sees, so `omicron-docs`
may quote the old form — worth a follow-up PR there, separate from this one.
