### PR TITLE
feat(editor): collapse the description field behind a trigger

### DIFF
--- a/apps/frontend/src/lib/components/SummaryField.svelte
+++ b/apps/frontend/src/lib/components/SummaryField.svelte
@@ -1,0 +1,94 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { Collapsible } from "bits-ui";
+  import Button from "$lib/components/ui/Button.svelte";
+  import Icon from "$lib/components/Icon.svelte";
+
+  // The post's description: what a search engine prints under the title and what
+  // a link preview shows. Genuinely optional — leave it blank and the opening
+  // lines of the post are used — and most writers never touch it, so it starts
+  // as one line and opens on request instead of holding a labelled input, a
+  // placeholder and a counter between the title and the body of every draft.
+  //
+  // A post that already has one opens expanded: an author returning to edit must
+  // see what they wrote without having to know it is behind a button.
+  // Matches the backend's cap (services/posts.ts `normalizeSummary`), which
+  // rejects anything longer — the counter is the author's warning, not the rule.
+  const MAX_SUMMARY = 150;
+
+  let {
+    summary = $bindable(""),
+    onChange,
+  }: {
+    summary?: string;
+    /** Called on any change, so the page can mark itself dirty. */
+    onChange?: () => void;
+  } = $props();
+
+  let open = $state(summary.trim().length > 0);
+  let input = $state<HTMLInputElement | null>(null);
+  let focusOnOpen = $state(false);
+
+  // Opening is a request to type, so land the cursor there rather than making
+  // the author click twice. The content is only mounted while open, so the
+  // focus waits for the input to exist rather than firing into nothing.
+  function onOpenChange(next: boolean) {
+    if (next) focusOnOpen = true;
+  }
+
+  $effect(() => {
+    if (!focusOnOpen || !input) return;
+    input.focus();
+    focusOnOpen = false;
+  });
+
+  // Closing discards the text: leaving a description stored but hidden behind a
+  // collapsed row would publish something the author can no longer see.
+  function clear() {
+    summary = "";
+    open = false;
+    onChange?.();
+  }
+</script>
+
+<Collapsible.Root bind:open {onOpenChange} class="mb-6">
+  {#if !open}
+    <Collapsible.Trigger>
+      {#snippet child({ props })}
+        <Button {...props} variant="ghost" size="xs" class="-ml-2 text-muted-foreground">
+          <Icon name="plus" size={14} /> Add a description
+        </Button>
+      {/snippet}
+    </Collapsible.Trigger>
+  {/if}
+
+  <Collapsible.Content>
+    <label for="post-summary" class="text-muted-foreground mb-1.5 block text-xs font-medium">
+      Description — shown in search results and link previews. Optional; the opening
+      lines are used when it's blank.
+    </label>
+    <div class="flex items-center gap-3">
+      <input
+        id="post-summary"
+        bind:this={input}
+        bind:value={summary}
+        oninput={() => onChange?.()}
+        maxlength={MAX_SUMMARY}
+        placeholder="One sentence on what this post is about"
+        class="rounded-input border border-input bg-background shadow-btn min-w-0 flex-1 px-3.5 py-2.5 text-sm outline-none placeholder:text-muted-foreground focus:border-foreground"
+      />
+      <span class="text-muted-foreground shrink-0 text-xs tabular-nums">
+        {summary.length}/{MAX_SUMMARY}
+      </span>
+      <Button
+        onclick={clear}
+        variant="ghost"
+        size="xs"
+        class="shrink-0 text-muted-foreground"
+        aria-label="Remove the description"
+      >
+        <Icon name="close" size={14} />
+      </Button>
+    </div>
+  </Collapsible.Content>
+</Collapsible.Root>

--- a/apps/frontend/src/routes/compose/+page.svelte
+++ b/apps/frontend/src/routes/compose/+page.svelte
@@ -11,12 +11,8 @@
   import TagInput from "$lib/components/TagInput.svelte";
   import LanguageSelect from "$lib/components/LanguageSelect.svelte";
   import BannerPicker from "$lib/components/BannerPicker.svelte";
+  import SummaryField from "$lib/components/SummaryField.svelte";
   import { reading } from "$lib/prefs.svelte";
-
-  // Matches SUMMARY_LENGTH in the backend (lib/webhook.ts), which caps the
-  // same column on the ingest path — so neither way of writing a post can
-  // store a description the other would reject.
-  const MAX_SUMMARY = 150;
   import type { CoverCredit } from "$lib/types";
   import type { PageData } from "./$types";
 
@@ -205,24 +201,7 @@
   class="mb-6 w-full border-none bg-transparent text-3xl font-bold tracking-tight text-foreground placeholder:text-muted-foreground focus:outline-none sm:text-4xl"
 />
 
-<div class="mb-6">
-  <label for="post-summary" class="text-muted-foreground mb-1.5 block text-xs font-medium">
-    Description — shown in search results and link previews. Optional; the opening
-    lines are used when it's blank.
-  </label>
-  <div class="flex items-center gap-3">
-    <input
-      id="post-summary"
-      bind:value={summary}
-      maxlength={MAX_SUMMARY}
-      placeholder="One sentence on what this post is about"
-      class="rounded-input border border-input bg-background shadow-btn min-w-0 flex-1 px-3.5 py-2.5 text-sm outline-none placeholder:text-muted-foreground focus:border-foreground"
-    />
-    <span class="text-muted-foreground shrink-0 text-xs tabular-nums">
-      {summary.length}/{MAX_SUMMARY}
-    </span>
-  </div>
-</div>
+<SummaryField bind:summary onChange={() => (touched = true)} />
 
 <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start">
   <div class="min-w-0 flex-1">

--- a/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
+++ b/apps/frontend/src/routes/posts/[id]/edit/+page.svelte
@@ -2,9 +2,6 @@
 <script lang="ts">
   import { onMount, untrack } from "svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
-
-  // Matches SUMMARY_LENGTH in the backend (lib/webhook.ts).
-  const MAX_SUMMARY = 150;
   import type { Content } from "@tiptap/core";
   import { goto } from "$app/navigation";
   import { endpoints, ApiError } from "$lib/api";
@@ -13,6 +10,7 @@
   import TagInput from "$lib/components/TagInput.svelte";
   import LanguageSelect from "$lib/components/LanguageSelect.svelte";
   import BannerPicker from "$lib/components/BannerPicker.svelte";
+  import SummaryField from "$lib/components/SummaryField.svelte";
   import { postPath } from "$lib/links";
   import type { CoverCredit } from "$lib/types";
   import type { PageData } from "./$types";
@@ -102,24 +100,7 @@
   class="mb-6 w-full border-none bg-transparent text-3xl font-bold tracking-tight text-foreground placeholder:text-muted-foreground focus:outline-none sm:text-4xl"
 />
 
-<div class="mb-6">
-  <label for="post-summary" class="text-muted-foreground mb-1.5 block text-xs font-medium">
-    Description — shown in search results and link previews. Optional; the opening
-    lines are used when it's blank.
-  </label>
-  <div class="flex items-center gap-3">
-    <input
-      id="post-summary"
-      bind:value={summary}
-      maxlength={MAX_SUMMARY}
-      placeholder="One sentence on what this post is about"
-      class="rounded-input border border-input bg-background shadow-btn min-w-0 flex-1 px-3.5 py-2.5 text-sm outline-none placeholder:text-muted-foreground focus:border-foreground"
-    />
-    <span class="text-muted-foreground shrink-0 text-xs tabular-nums">
-      {summary.length}/{MAX_SUMMARY}
-    </span>
-  </div>
-</div>
+<SummaryField bind:summary />
 
 <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start">
   <div class="min-w-0 flex-1">


### PR DESCRIPTION
## The symptom

Every draft opened with a description field wedged between the title and the
body — a label, an input and a character counter — whether or not the writer
wanted one. It is an optional field (blank means the post's opening lines are
used) that most posts never fill in, and it pushed the tags, the banner and the
editor itself down the page for everyone.

## The change

Collapse it to a single trigger:

```
+ Add a description
```

Clicking it expands the field and puts the cursor in it. An `×` closes it again.

Two behaviours worth calling out:

- **A post that already has a description opens expanded.** An author returning
  to edit must see what they wrote without having to know it is behind a button.
- **Closing clears the text.** A description left stored but hidden behind a
  collapsed row would be published where its author can no longer see it.

Compose and edit each carried their own copy of the markup, so this is also a
de-duplication: one `SummaryField.svelte`, which is where the 150-character cap
now lives too. It was written out in both pages and happened to match the
backend's `SUMMARY_LENGTH`; either copy could have drifted.

Bits UI `Collapsible` rather than an `{#if}` — it is the primitive for this, and
it brings the `aria-expanded` / `aria-controls` wiring and the open/closed data
attributes an ad-hoc toggle would have to reproduce by hand.

## What was verified

Against a running stack (throwaway Postgres, backend, dev server, signed in as a
real user):

- the edit page for a post **without** a description SSRs `200` with the trigger
  rendered and the field `hidden`;
- the edit page for a post **with** one renders expanded, no trigger, value
  filled in.

`svelte-check` 0 errors; production build clean.

**Not verified:** the click-to-expand and the focus-on-open. Both are
client-side and there is no browser driver in this environment, so that part is
reasoned from the component rather than observed.

## Unrelated bug found while testing

A hard load of `/compose` returns **500** — `ReferenceError: window is not
defined` at `compose/+page.svelte:158`, the `onDestroy(() =>
window.removeEventListener(…))`, which Svelte 5 also runs during SSR. Confirmed
on a clean checkout with these changes stashed, so it predates this PR. In-app
navigation to `/compose` is fine because it renders client-side; only a direct
visit or a refresh hits it. Not fixed here — it wants its own PR.
