### PR TITLE
feat(editor): autosave drafts, with a last-saved time

### DIFF
--- a/apps/frontend/src/lib/autosave.svelte.ts
+++ b/apps/frontend/src/lib/autosave.svelte.ts
@@ -1,0 +1,152 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Debounced autosave for the composer.
+//
+// The rule this encodes: a save happens when the author stops typing, and it
+// happens *anyway* if they never stop. Idle-only debouncing loses an hour of
+// continuous writing to one closed tab, and interval-only saving writes a
+// half-finished sentence to the server every tick. Both timers run together —
+// whichever comes first wins.
+//
+// Deliberately unaware of what it is saving: it owns the timers, the
+// in-flight/dirty bookkeeping and the retry, and the caller owns the request.
+
+export type SaveState = "idle" | "saving" | "saved" | "error";
+
+export interface AutosaveOptions {
+  /** Performs one save. Rejecting means it failed; the work stays dirty. */
+  save: () => Promise<void>;
+  /** False when there is nothing worth writing yet (an empty draft). */
+  canSave: () => boolean;
+  /** Quiet period after the last change before saving. */
+  idleMs?: number;
+  /** Longest a change may sit unsaved while the author keeps typing. */
+  maxMs?: number;
+  /** Wait before re-trying a failed save. */
+  retryMs?: number;
+}
+
+export class Autosave {
+  /** What the status indicator shows. */
+  state = $state<SaveState>("idle");
+  /** When the last successful save landed, as epoch ms. */
+  savedAt = $state<number | null>(null);
+  /** Message from the last failure, cleared by the next success. */
+  error = $state<string | null>(null);
+  /** True while there are changes the server has not acknowledged. */
+  dirty = $state(false);
+
+  #opts: Required<AutosaveOptions>;
+  #idleTimer: ReturnType<typeof setTimeout> | null = null;
+  #maxTimer: ReturnType<typeof setTimeout> | null = null;
+  #inFlight: Promise<void> | null = null;
+  #stopped = false;
+  // Bumped by every change. A save that finishes on a stale generation leaves
+  // `dirty` set, so an edit made *during* the request is not marked saved.
+  #generation = 0;
+
+  constructor(opts: AutosaveOptions) {
+    this.#opts = {
+      idleMs: 2_000,
+      maxMs: 30_000,
+      retryMs: 15_000,
+      ...opts,
+    };
+  }
+
+  /** Call on every author-visible change. */
+  schedule(): void {
+    if (this.#stopped) return;
+    this.dirty = true;
+    this.#generation++;
+    // A pending failure is superseded by the new edit: the retry it scheduled
+    // would send the same body this run is about to replace.
+    if (this.state === "error") this.state = "idle";
+
+    if (this.#idleTimer) clearTimeout(this.#idleTimer);
+    this.#idleTimer = setTimeout(() => this.#run(), this.#opts.idleMs);
+    // Started on the first change of a burst and left alone afterwards, so it
+    // measures time-since-first-unsaved-change rather than resetting with the
+    // idle timer and never firing.
+    this.#maxTimer ??= setTimeout(() => this.#run(), this.#opts.maxMs);
+  }
+
+  /**
+   * Saves now if anything is pending, and resolves when it has landed. Used
+   * before deliberately leaving the editor.
+   */
+  async flush(): Promise<void> {
+    if (this.#inFlight) await this.#inFlight;
+    if (this.dirty) await this.#run();
+  }
+
+  /**
+   * Stops scheduling permanently. The page calls this once it is committing a
+   * save of its own (publish, explicit "Save draft"), so a timer cannot fire a
+   * competing write into the same post, and on destroy.
+   */
+  stop(): void {
+    this.#stopped = true;
+    this.#clearTimers();
+  }
+
+  /**
+   * Re-enables scheduling after a `stop()` that turned out to be temporary —
+   * the publish the page stopped for failed, and the author is still writing.
+   */
+  resume(): void {
+    this.#stopped = false;
+    if (this.dirty) this.schedule();
+  }
+
+  #clearTimers(): void {
+    if (this.#idleTimer) clearTimeout(this.#idleTimer);
+    if (this.#maxTimer) clearTimeout(this.#maxTimer);
+    this.#idleTimer = null;
+    this.#maxTimer = null;
+  }
+
+  async #run(): Promise<void> {
+    this.#clearTimers();
+    if (this.#stopped) return;
+    // One request at a time: two overlapping PATCHes of the same post can land
+    // out of order and resurrect the older body.
+    if (this.#inFlight) return this.#inFlight;
+    if (!this.dirty || !this.#opts.canSave()) return;
+
+    const generation = this.#generation;
+    let failed = false;
+    this.state = "saving";
+    this.#inFlight = (async () => {
+      try {
+        await this.#opts.save();
+        if (this.#stopped) return;
+        this.savedAt = Date.now();
+        this.error = null;
+        this.state = "saved";
+        if (generation === this.#generation) this.dirty = false;
+      } catch (err) {
+        if (this.#stopped) return;
+        failed = true;
+        this.error = err instanceof Error ? err.message : "Failed to save.";
+        this.state = "error";
+      }
+    })();
+
+    try {
+      await this.#inFlight;
+    } finally {
+      this.#inFlight = null;
+    }
+    if (this.#stopped) return;
+    // Changes that arrived mid-request, or a failure to re-try. Either way the
+    // next attempt goes through the normal idle debounce rather than
+    // immediately, so a server that is down is not hammered.
+    if (this.dirty) {
+      this.#idleTimer = setTimeout(
+        () => this.#run(),
+        failed ? this.#opts.retryMs : this.#opts.idleMs,
+      );
+    }
+  }
+}

--- a/apps/frontend/src/lib/components/Icon.svelte
+++ b/apps/frontend/src/lib/components/Icon.svelte
@@ -81,6 +81,7 @@
     Table,
     Rss,
     Bell,
+    TriangleAlert,
   } from "@lucide/svelte";
 
   export const icons = {
@@ -162,6 +163,7 @@
     inbox: Inbox,
     gavel: Gavel,
     table: Table,
+    alert: TriangleAlert,
   } as const;
 
   export type IconName = keyof typeof icons;

--- a/apps/frontend/src/lib/components/SaveStatus.svelte
+++ b/apps/frontend/src/lib/components/SaveStatus.svelte
@@ -1,0 +1,74 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import Icon from "$lib/components/Icon.svelte";
+  import type { SaveState } from "$lib/autosave.svelte";
+
+  // The composer's autosave indicator: what the editor did with the author's
+  // work and when. Its whole job is to make the missing "Save" click feel safe,
+  // so it names a time rather than saying "Saved" forever — an author who
+  // cannot tell whether that was two seconds or two hours ago saves by hand
+  // anyway, and the feature has bought them nothing.
+
+  let {
+    status,
+    savedAt,
+    error = null,
+  }: {
+    status: SaveState;
+    /** Epoch ms of the last successful save, or null if none yet. */
+    savedAt: number | null;
+    error?: string | null;
+  } = $props();
+
+  // The label ages on its own — nothing changes on the page between "just now"
+  // and "3 minutes ago", so without a tick it would sit there lying.
+  let now = $state(Date.now());
+  $effect(() => {
+    const id = setInterval(() => (now = Date.now()), 30_000);
+    return () => clearInterval(id);
+  });
+
+  function ago(at: number, from: number): string {
+    const s = Math.max(0, Math.round((from - at) / 1000));
+    if (s < 45) return "just now";
+    const m = Math.round(s / 60);
+    if (m < 60) return `${m} minute${m === 1 ? "" : "s"} ago`;
+    const h = Math.round(m / 60);
+    if (h < 24) return `${h} hour${h === 1 ? "" : "s"} ago`;
+    // Past a day the clock time is the useful fact, not the count of hours.
+    return new Date(at).toLocaleTimeString("en-US", {
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    });
+  }
+
+  const label = $derived(
+    status === "saving"
+      ? "Saving…"
+      : status === "error"
+        ? "Couldn't save"
+        : savedAt !== null
+          ? `Saved ${ago(savedAt, now)}`
+          : "",
+  );
+</script>
+
+{#if label}
+  <p
+    class="flex items-center gap-1.5 text-xs {status === 'error'
+      ? 'text-destructive'
+      : 'text-muted-foreground'}"
+    title={status === "error" ? (error ?? undefined) : undefined}
+    aria-live="polite"
+  >
+    {#if status === "saving"}
+      <Icon name="spinner" size={13} class="animate-spin" />
+    {:else if status === "error"}
+      <Icon name="alert" size={13} />
+    {:else}
+      <Icon name="check" size={13} />
+    {/if}
+    {label}
+  </p>
+{/if}

--- a/apps/frontend/src/routes/compose/+page.svelte
+++ b/apps/frontend/src/routes/compose/+page.svelte
@@ -1,13 +1,15 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
-  import { onMount, untrack } from "svelte";
+  import { onDestroy, onMount, untrack } from "svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import type { Content } from "@tiptap/core";
-  import { beforeNavigate, goto } from "$app/navigation";
+  import { beforeNavigate, goto, replaceState } from "$app/navigation";
   import { endpoints, ApiError } from "$lib/api";
+  import { Autosave } from "$lib/autosave.svelte";
   import { confirm } from "$lib/components/ui/confirm";
   import Button from "$lib/components/ui/Button.svelte";
   import Icon from "$lib/components/Icon.svelte";
+  import SaveStatus from "$lib/components/SaveStatus.svelte";
   import TagInput from "$lib/components/TagInput.svelte";
   import LanguageSelect from "$lib/components/LanguageSelect.svelte";
   import BannerPicker from "$lib/components/BannerPicker.svelte";
@@ -60,7 +62,13 @@
   function onUpdate(h: string, j: unknown) {
     html = h;
     json = j;
+    change();
+  }
+
+  /** Every author-visible edit funnels through here, so nothing escapes autosave. */
+  function change() {
     touched = true;
+    autosave.schedule();
   }
 
   // The tag input mutates `tags` directly; mark touched when it diverges from
@@ -73,8 +81,11 @@
   const initialLanguage = draft ? draft.language ?? null : reading.composeLang;
   const initialSummary = draft?.summary ?? "";
   $effect(() => {
-    if (tags.join(",") !== initialTags || language !== initialLanguage) touched = true;
-    if (summary !== initialSummary) touched = true;
+    const changed =
+      tags.join(",") !== initialTags ||
+      language !== initialLanguage ||
+      summary !== initialSummary;
+    if (changed) change();
   });
 
   // There's unsaved work worth keeping if the author has edited and there's
@@ -91,6 +102,45 @@
 
   // `bypass` lets our own post-save navigations through the unsaved-changes guard.
   let bypass = false;
+
+  /** Everything the composer holds, in the shape the API takes. */
+  function body() {
+    return {
+      title: title.trim(),
+      contentHtml: html,
+      contentJson: json,
+      language,
+      // Null, not "", so the reader falls back to the derived excerpt
+      // rather than showing an empty description.
+      summary: summary.trim() || null,
+      coverUrl,
+      coverCredit,
+      tags,
+    };
+  }
+
+  // Autosave, drafts only. The composer is the draft surface — a published post
+  // is edited on its own page — so a background write here can never push an
+  // unfinished sentence to readers or federate an Update to remote instances.
+  //
+  // `status` is only ever sent on the create: an update that omits it leaves
+  // the post a draft, so no timer can publish anything.
+  const autosave = new Autosave({
+    canSave: () => hasContent(),
+    save: async () => {
+      if (postId) {
+        await endpoints().updatePost(postId, body());
+        return;
+      }
+      const { post } = await endpoints().createPost({ ...body(), status: "draft" });
+      postId = post.id;
+      // Put the new draft's id in the address bar, so a reload — or the browser
+      // restoring the tab — continues this draft instead of starting a second
+      // one and leaving the author with duplicates in /drafts.
+      replaceState(`/compose?id=${post.id}`, {});
+    },
+  });
+  onDestroy(() => autosave.stop());
 
   // Creates or updates the post in the requested state, then leaves the editor.
   async function persist(status: "draft" | "published") {
@@ -111,24 +161,17 @@
     bypass = true;
     if (status === "published") busy = true;
     else savingDraft = true;
+    // Hand over from autosave cleanly: no new timer may fire, and an autosave
+    // already in flight must land before this write, or a create could race a
+    // create and leave two drafts — or an old body could overwrite the new one.
+    autosave.stop();
+    await autosave.flush();
     try {
-      const body = {
-        title: title.trim(),
-        contentHtml: html,
-        contentJson: json,
-        status,
-        language,
-        // Null, not "", so the reader falls back to the derived excerpt
-        // rather than showing an empty description.
-        summary: summary.trim() || null,
-        coverUrl,
-        coverCredit,
-        tags,
-      };
+      const payload = { ...body(), status };
       if (postId) {
-        await endpoints().updatePost(postId, body);
+        await endpoints().updatePost(postId, payload);
       } else {
-        const { post } = await endpoints().createPost(body);
+        const { post } = await endpoints().createPost(payload);
         postId = post.id;
       }
       // Remember what they actually published in, so the next post starts
@@ -139,15 +182,19 @@
       bypass = false;
       busy = false;
       savingDraft = false;
+      // The editor stays open on a failure, so autosave has to come back with
+      // it — otherwise a failed publish silently leaves the author unprotected.
+      autosave.resume();
       error = err instanceof ApiError ? err.message : "Failed to save.";
     }
   }
 
-  // Warn on full-page unload (closing/reloading the tab). Browsers only allow a
-  // generic prompt here — the "save as draft" choice is offered on in-app
-  // navigation below.
+  // Warn on full-page unload (closing or reloading the tab) only while a change
+  // is still unsaved. Autosave means that window is now a couple of seconds
+  // wide, not the whole session — but closing the tab inside it would still
+  // lose the change, and the browser gives us no time to write it first.
   function onBeforeUnload(e: BeforeUnloadEvent) {
-    if (hasContent() && !bypass) {
+    if (autosave.dirty && hasContent() && !bypass) {
       e.preventDefault();
       e.returnValue = "";
     }
@@ -161,24 +208,30 @@
     return () => window.removeEventListener("beforeunload", onBeforeUnload);
   });
 
-  // Leaving via an in-app link (a nav tab, etc.) with unsaved content: hold the
-  // navigation and offer to save the work as a draft first.
+  // Leaving via an in-app link with a pending change: write it out and carry on
+  // to where they were going. This used to ask whether to save as a draft —
+  // with autosave the draft already exists, so the question had no answer left
+  // that changed anything.
   beforeNavigate(async (nav) => {
-    if (bypass || nav.willUnload || !hasContent()) return;
+    if (bypass || nav.willUnload || !autosave.dirty || !hasContent()) return;
     nav.cancel();
     const target = nav.to?.url;
-    const save = await confirm({
-      title: "Save as draft?",
-      description: "You have unsaved changes. Save them as a draft before leaving?",
-      confirmText: "Save draft",
-      cancelText: "Discard",
-    });
-    if (save) {
-      await persist("draft");
-    } else {
-      bypass = true;
-      if (target) goto(target);
+    await autosave.flush();
+    // Still dirty means that write failed. Navigating anyway would throw the
+    // change away without telling anyone, so this is the one case left that is
+    // genuinely the author's call.
+    if (autosave.dirty) {
+      const leave = await confirm({
+        title: "Leave without saving?",
+        description:
+          "Your last change could not be saved. Leaving now loses it — staying lets the editor try again.",
+        confirmText: "Leave",
+        cancelText: "Stay",
+      });
+      if (!leave) return;
     }
+    bypass = true;
+    if (target) goto(target);
   });
 </script>
 
@@ -189,6 +242,7 @@
     <Icon name="compose" size={16} /> Draft
   </p>
   <div class="flex items-center gap-2">
+    <SaveStatus status={autosave.state} savedAt={autosave.savedAt} error={autosave.error} />
     <Button onclick={() => persist("draft")} disabled={busy || savingDraft} variant="ghost">
       {savingDraft ? "Saving…" : "Save draft"}
     </Button>
@@ -201,11 +255,11 @@
 <input
   placeholder="Title"
   bind:value={title}
-  oninput={() => (touched = true)}
+  oninput={change}
   class="mb-6 w-full border-none bg-transparent text-3xl font-bold tracking-tight text-foreground placeholder:text-muted-foreground focus:outline-none sm:text-4xl"
 />
 
-<SummaryField bind:summary onChange={() => (touched = true)} />
+<SummaryField bind:summary onChange={change} />
 
 <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start">
   <div class="min-w-0 flex-1">
@@ -214,12 +268,7 @@
   <LanguageSelect bind:value={language} />
 </div>
 
-<BannerPicker
-  bind:coverUrl
-  bind:coverCredit
-  contentHtml={html}
-  onChange={() => (touched = true)}
-/>
+<BannerPicker bind:coverUrl bind:coverCredit contentHtml={html} onChange={change} />
 
 {#if EditorComponent}
   <EditorComponent {onUpdate} content={(draft?.contentJson as Content) ?? draft?.contentHtml} />

--- a/apps/frontend/src/routes/compose/+page.svelte
+++ b/apps/frontend/src/routes/compose/+page.svelte
@@ -1,6 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
-  import { onDestroy, onMount, untrack } from "svelte";
+  import { onMount, untrack } from "svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import type { Content } from "@tiptap/core";
   import { beforeNavigate, goto } from "$app/navigation";
@@ -152,10 +152,14 @@
       e.returnValue = "";
     }
   }
+  // Registered on mount and torn down by its own cleanup: `window` does not
+  // exist while this component renders on the server, and Svelte runs onDestroy
+  // there too — so reaching for it from onDestroy threw during SSR and the page
+  // never rendered at all.
   onMount(() => {
     window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
   });
-  onDestroy(() => window.removeEventListener("beforeunload", onBeforeUnload));
 
   // Leaving via an in-app link (a nav tab, etc.) with unsaved content: hold the
   // navigation and offer to save the work as a draft first.


### PR DESCRIPTION
## The symptom

Work in the composer existed only in the browser tab until the author pressed **Save draft**. Close the tab, crash the browser, misclick a link — it was gone. The only safety net was a "You have unsaved changes" prompt, which does nothing for a crash and nothing for a tab closed in a hurry.

Separately, and unrelated to the feature: **a hard load of `/compose` returned 500.** `ReferenceError: window is not defined` at `compose/+page.svelte:158`. Svelte 5 runs `onDestroy` on the server too, so the `window.removeEventListener` sitting in it threw during SSR. Only a client-side navigation into the composer worked; a refresh or a bookmark got the error page. Fixed first, in its own commit — autosave is not much use on a page that will not load.

## The fix

**`lib/autosave.svelte.ts`** — a small engine that owns the timers and the bookkeeping, and knows nothing about posts:

- saves 2s after typing stops, and at least every 30s while typing continues (idle-only debouncing loses an hour of unbroken writing to one closed tab);
- one request in flight at a time — two overlapping `PATCH`es of the same post can land out of order and resurrect the older body;
- a generation counter, so an edit made *during* a request is not marked saved by it;
- a failure keeps the work dirty, surfaces itself, and retries after 15s;
- `flush()` / `stop()` / `resume()`, so Publish and Save draft hand over without racing a timer.

**`components/SaveStatus.svelte`** — "Saving…" → "Saved just now" → "Saved 4 minutes ago" → a clock time past the day. The label ticks on its own; nothing else on the page changes as it ages. Naming the time is the whole point — a permanent "Saved" tells an author nothing about whether the last twenty minutes are safe.

### Why the composer only

A published post is edited on `/posts/[id]/edit`, and `updatePost` on a published post queues `federate_post` (an `Update` to every remote follower) and `indexnow_submit`. Autosaving there would fan out to the fediverse on every pause for thought. Published posts keep their explicit **Save**; autosave is drafts only.

Within the composer the same caution: `status` is sent only on the create, so no timer can publish; and the new draft's id is pushed into the address bar with `replaceState`, so a reload continues that draft rather than starting a second one and leaving duplicates in `/drafts`.

### The unsaved-changes prompt narrows

Leaving by an in-app link no longer asks "Save as draft?" — the draft already exists, so the question had no answer left that changed anything. It saves and goes, and asks only if that final write actually failed. `beforeunload` still warns, because closing the tab inside the two-second window does lose the change and the browser gives us no time to write it.

## What was verified

Against a real Postgres 17 and the Deno backend:

- **The state machine, 20 checks** (the class compiled from source and driven against a fake save): no write while typing, exactly one after the burst, the max-interval fires under continuous typing, an empty draft is never written, no overlapping requests, an edit mid-request stays dirty and gets its own save, failure sets the message and retries, `flush()` resolves only after the write lands, `stop()` halts scheduling but still awaits an in-flight save, `resume()` restores it.
- **The composer in headless Chromium**, typed into for real: typing creates exactly one draft, the header reads "Saved just now", the URL picks up `?id=<uuid>`, a second burst updates rather than duplicates, and the stored post is still `status: draft`.
- `GET /compose` now returns **200** (was 500), verified with the SSR fix alone and again with the full branch.
- `svelte-check`: 0 errors, 0 warnings.

**Not verified:** behaviour on a genuinely flaky network (offline/timeout was simulated by a rejecting save, not by a real dropped connection), and Safari/Firefox — checked in Chromium only.

## Deploy notes

None. Frontend-only; no schema, config, or API change.