### PR TITLE
feat(editor): character, word and read-time counter under the editor

### DIFF
--- a/apps/frontend/src/lib/editor/Editor.svelte
+++ b/apps/frontend/src/lib/editor/Editor.svelte
@@ -11,6 +11,7 @@
   import { EDIT_ALT_EVENT, type EditAltDetail } from "./resizable-image";
   import { extensions } from "./extensions";
   import { CODE_LANGUAGES, codeLanguageLabel } from "$lib/codeLanguages";
+  import { countWords, readTimeFromWords } from "$lib/format";
 
   // Isolated Tiptap integration. The parent receives content via `onUpdate`.
   // This component is lazy-loaded (dynamic import) so Tiptap stays out of the
@@ -31,6 +32,27 @@
 
   let element: HTMLDivElement;
   let editor: Editor;
+
+  // The status line every desktop editor has: how much is there, and how long
+  // it will take to read. Recomputed from the document itself rather than from
+  // the serialized HTML, so markup never inflates the count.
+  //
+  // Only on a document change, never on a bare cursor move — `onTransaction`
+  // fires for every arrow key, and walking the whole document that often buys
+  // nothing that changes on screen.
+  let stats = $state({ characters: 0, words: 0, minutes: 0 });
+
+  function refreshStats(ed: Editor) {
+    // One newline per block, so paragraphs are counted as separated rather than
+    // running the last word of one into the first of the next.
+    const text = ed.getText({ blockSeparator: "\n" });
+    const words = countWords(text);
+    stats = { characters: text.length, words, minutes: readTimeFromWords(words) };
+  }
+
+  const LOCALE = "en-US";
+  const count = (n: number, one: string) =>
+    `${n.toLocaleString(LOCALE)} ${n === 1 ? one : one + "s"}`;
 
   // Heading levels offered in the text-style dropdown.
   const HEADING_LEVELS = [1, 2, 3, 4, 5, 6] as const;
@@ -335,10 +357,16 @@
         handlePaste,
         handleDrop,
       },
-      onUpdate: ({ editor }) => onUpdate(editor.getHTML(), editor.getJSON()),
+      onUpdate: ({ editor }) => {
+        onUpdate(editor.getHTML(), editor.getJSON());
+        refreshStats(editor);
+      },
       onTransaction: ({ editor }) => refreshActive(editor),
     });
     refreshActive();
+    // A reopened draft arrives with its body already in place, so the counter
+    // has to start from that rather than from zero.
+    refreshStats(editor);
     // The alt-text button lives inside a node view, so its event surfaces on
     // the editor's own DOM rather than anywhere Svelte can bind to directly.
     editor.view.dom.addEventListener(EDIT_ALT_EVENT, openAltDialog);
@@ -503,6 +531,17 @@
   {/if}
 
   <div bind:this={element}></div>
+
+  <!-- Bottom right, out of the way: read when wanted, ignored otherwise. -->
+  <p class="text-muted-foreground mt-2 flex justify-end gap-2 text-xs tabular-nums">
+    <span>{count(stats.characters, "character")}</span>
+    <span aria-hidden="true">·</span>
+    <span>{count(stats.words, "word")}</span>
+    {#if stats.words > 0}
+      <span aria-hidden="true">·</span>
+      <span>{stats.minutes} min read</span>
+    {/if}
+  </p>
 </div>
 
 <Dialog.Root bind:open={codeOpen}>

--- a/apps/frontend/src/lib/format.ts
+++ b/apps/frontend/src/lib/format.ts
@@ -38,7 +38,17 @@ export function excerpt(html: string, len = 180): string {
 
 // Rough Medium-style read time (~200 words/min, floored at 1).
 export function readTime(html: string): number {
-  const words = stripHtml(html).split(/\s+/).filter(Boolean).length;
+  return readTimeFromWords(countWords(stripHtml(html)));
+}
+
+export function countWords(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+// Split out so the editor's live counter and the reader's badge cannot drift:
+// the editor has the words already and would otherwise re-derive them from its
+// own HTML with a second, subtly different rule.
+export function readTimeFromWords(words: number): number {
   return Math.max(1, Math.round(words / 200));
 }
 


### PR DESCRIPTION
## The symptom

The composer gave no indication of length. An author writing to a target, or wondering whether a draft had grown past what anyone will sit through, had to publish it and read the badge on the post.

## The fix

A status line under the editor body, bottom right where every desktop editor puts one:

```
1,240 characters · 210 words · 2 min read
```

It lives in `Editor.svelte`, so the composer and the published-post edit page both get it with no wiring at either call site.

Two decisions worth stating:

- **Counted from the ProseMirror document, not the serialized HTML.** Markup would otherwise inflate the character count — `<p>alpha beta gamma</p>` is 23 characters and three words of text.
- **Recomputed on document change only.** `onTransaction` fires for every arrow key; walking the whole document that often buys nothing that changes on screen. It hangs off `onUpdate` instead, plus one call after construction so a reopened draft starts from its stored body rather than zero.

`readTime` and the editor now share `readTimeFromWords` in `lib/format.ts`, so the number here and the number readers see cannot drift. Read time is hidden while the document is empty — "0 min read" would be noise — and the floor of 1 minute is the existing reader-facing rule, so a short draft says "1 min read" exactly as the published post will.

## What was verified

Headless Chromium against a real Postgres and backend, 8 checks:

- an empty editor reads `0 characters · 0 words`, with no read time;
- typing a known 64-character, 12-word sentence gives exactly that;
- moving the cursor changes nothing;
- a 413-word body reports `2 min read` (~200 wpm) and formats as `2,065`;
- reopening a stored two-paragraph draft counts **18 characters · 4 words** — the paragraph break separates "two" and "three" rather than fusing them;
- the published post's edit page carries the same line.

`svelte-check`: 0 errors, 0 warnings.

**Not verified:** how the word count behaves for scripts without spaces (CJK), where "words" is not a meaningful split. It uses the same whitespace rule the reader-facing read time has always used, so it is no worse than what ships today — but it is not right for those languages either.

## Unrelated bug found while testing

A post whose `contentJson` is null — which is **every post ingested through the content webhook** (`services/webhooks.ts:179` sets it to null explicitly) — opens in the editor showing its raw HTML as literal text. The edit page passes `post.contentJson ?? post.contentHtml`, and a plain string is parsed as Markdown, so `<p>alpha beta gamma</p>` renders as those 23 characters rather than a paragraph.

Pre-existing, not touched here, and worth its own fix.

## Deploy notes

None. Frontend-only.