### PR TITLE
fix(editor): stored HTML is parsed as HTML, and block boundaries are not characters

### DIFF
--- a/apps/frontend/src/lib/editor/Editor.svelte
+++ b/apps/frontend/src/lib/editor/Editor.svelte
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
   import { onDestroy, onMount } from "svelte";
-  import { type Content, Editor } from "@tiptap/core";
+  import { type Content, Editor, generateJSON } from "@tiptap/core";
   import Placeholder from "@tiptap/extension-placeholder";
   import { Dialog, DropdownMenu, Label, Select, Toolbar } from "bits-ui";
   import Icon, { type IconName } from "$lib/components/Icon.svelte";
@@ -17,9 +17,9 @@
   // This component is lazy-loaded (dynamic import) so Tiptap stays out of the
   // initial bundle — see /compose.
   //
-  // `content` should be Tiptap's native JSON (ProseMirror doc) when rehydrating
-  // an existing post — a plain string is parsed as Markdown by the markdown
-  // extension, so passing stored HTML as a string would show the tags verbatim.
+  // `content` is Tiptap's native JSON (ProseMirror doc) when the post has one,
+  // and the post's stored HTML otherwise. Both rehydrate the same document —
+  // see `initialContent` below for why a string needs converting first.
   let {
     onUpdate,
     placeholder = "Write your article…",
@@ -343,7 +343,22 @@
     return true;
   }
 
+  // A post's body is stored as HTML, and only posts written here also have the
+  // ProseMirror JSON. Everything ingested through the content webhook has
+  // `contentJson` null (services/webhooks.ts sets it so explicitly), so opening
+  // one for editing hands Tiptap a string — and tiptap-markdown replaces the
+  // initial-content parse with its own, running that string through markdown-it.
+  // Configured with `html: false`, as it must be for pasted Markdown we do not
+  // trust, markdown-it escapes the tags: the author was shown `<p>alpha</p>` as
+  // literal text, and saving stored that escaped text as the post.
+  //
+  // Parsing it as the HTML it actually is fixes both halves. Typed and pasted
+  // Markdown is untouched — that goes through input rules and the clipboard
+  // handler, not through here.
   onMount(() => {
+    const initialContent = typeof content === "string"
+      ? (generateJSON(content, extensions) as Content)
+      : content;
     editor = new Editor({
       element,
       // Placeholder is per-instance (it needs the `placeholder` prop), so it's
@@ -356,7 +371,7 @@
           placeholder: ({ pos }) => (pos === 0 ? placeholder : "Write something…"),
         }),
       ],
-      content,
+      content: initialContent,
       editorProps: {
         attributes: { class: "tiptap prose-omicron" },
         handlePaste,

--- a/apps/frontend/src/lib/editor/Editor.svelte
+++ b/apps/frontend/src/lib/editor/Editor.svelte
@@ -44,10 +44,15 @@
 
   function refreshStats(ed: Editor) {
     // One newline per block, so paragraphs are counted as separated rather than
-    // running the last word of one into the first of the next.
+    // running the last word of one into the first of the next. Those newlines
+    // are the counter's own doing, not the author's, so they are dropped again
+    // before counting characters — a document nested in lists or table cells
+    // carries a separator per level and would otherwise report characters
+    // nobody typed.
     const text = ed.getText({ blockSeparator: "\n" });
     const words = countWords(text);
-    stats = { characters: text.length, words, minutes: readTimeFromWords(words) };
+    const characters = text.replace(/\n/g, "").length;
+    stats = { characters, words, minutes: readTimeFromWords(words) };
   }
 
   const LOCALE = "en-US";


### PR DESCRIPTION
Two fixes, one commit each.

## 1. A post's stored HTML was parsed as Markdown

**The symptom.** Open a post that has no stored ProseMirror JSON and the editor shows its raw markup as literal text — `<h2>Heading</h2><p>alpha <strong>beta</strong> gamma</p>`, character for character, in the body. Save from there and that escaped text becomes the post.

**Who hits it.** Every post ingested through the [content webhook](https://github.com/the-jk-labs/omicron/blob/main/apps/backend/src/services/webhooks.ts): `services/webhooks.ts:179` sets `contentJson = null` explicitly. Both editor call sites pass `post.contentJson ?? post.contentHtml`, so those posts hand Tiptap a string.

**The root cause.** tiptap-markdown replaces Tiptap's initial-content parse with its own — `Markdown.js` `onBeforeCreate` does `editor.options.content = parser.parse(editor.options.content)` — and `MarkdownParser.parse` runs any string through markdown-it. We configure it `html: false`, which is right for the job it was added for (Markdown pasted into the composer must not smuggle in raw HTML), so markdown-it escapes the tags exactly as asked.

**The fix.** The string was never Markdown. `generateJSON(content, extensions)` (already in `@tiptap/core`, no new dependency) parses it as HTML against the editor's own schema, which is what both callers already meant. Typed and pasted Markdown is untouched — that path is input rules and the clipboard handler, not initial content.

## 2. The character counter counted block boundaries

The counter shipped in #28 builds its text with one newline per block so paragraphs do not run together when splitting words — then counted those newlines as characters. Nobody typed them. "one two" + "three four" reported 18 characters for 17, and the error grows with nesting: a list contributes a separator per level, so four short list items came out six characters over. Words and read time were always right.

## What was verified

Headless Chromium against a real Postgres and backend.

A post stored as HTML with `contentJson` null:

- opens with a real `<h2>` node, a `<strong>` mark and a `<ul>` — not escaped text;
- shows no `<p>`/`<h2>` in the visible body text;
- counts **29 characters · 6 words**, the text rather than the markup;
- saves back as `<h2>Heading</h2><p>alpha <strong>beta</strong> gamma</p><ul><li>one</li><li>two</li></ul>` — byte-identical to what was stored, no `&lt;`.

The counter suite from #28 re-run against the new rule: empty editor, a typed 64-character sentence, cursor movement changing nothing, a 413-word body at 2 min and `2,065`, a two-paragraph draft now correctly at **17 characters · 4 words**, and the published edit page.

`svelte-check`: 0 errors, 0 warnings.

**Recorded, not fixed:** saving an ingested post *without editing it* leaves `contentJson` null, because the page's `json` is only set by an actual document change. Harmless now that the HTML re-parses correctly — the post simply keeps taking the HTML path — but worth knowing rather than assuming.

## Deploy notes

None. Frontend-only. Posts already saved with escaped markup are not repaired by this — it stops new ones happening; an affected post needs its body re-pasted.