### PR TITLE
feat(comments): grow the comment box with the text

### DIFF
--- a/apps/frontend/src/lib/actions/autoGrow.svelte.ts
+++ b/apps/frontend/src/lib/actions/autoGrow.svelte.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Grows a <textarea> to fit its content instead of scrolling a fixed box, so a
+// long comment stays readable while it is being written.
+//
+// The field keeps its `rows` attribute as the floor (an empty box still looks
+// like a comment box) and stops growing at MAX_HEIGHT_PX, after which it
+// scrolls — otherwise a 2000-character response would push its own Respond
+// button off the screen.
+
+const MAX_HEIGHT_PX = 320;
+
+/**
+ * Svelte action: sizes `node` to its content whenever the bound value changes.
+ *
+ * The value is passed as a getter (`use:autoGrow={() => draft}`) because
+ * programmatic writes — clearing after submit, inserting an emoji — do not fire
+ * an `input` event, so listening to the element alone would miss them.
+ */
+export function autoGrow(node: HTMLTextAreaElement, value: () => string) {
+  // Measured before anything is written to `style.height`, so this is the
+  // height the `rows` attribute asked for.
+  const floor = node.offsetHeight;
+  // With `box-sizing: border-box` (Tailwind's default) `height` includes the
+  // borders but `scrollHeight` does not, so the borders have to be added back
+  // or the field would end up a couple of pixels short and scroll forever.
+  const styles = getComputedStyle(node);
+  const borders =
+    parseFloat(styles.borderTopWidth) + parseFloat(styles.borderBottomWidth);
+
+  function resize() {
+    // Collapse first: `scrollHeight` never shrinks below the current height, so
+    // without this the field could only ever get taller.
+    node.style.height = "auto";
+    const content = node.scrollHeight + borders;
+    node.style.height = `${Math.max(floor, Math.min(content, MAX_HEIGHT_PX))}px`;
+    node.style.overflowY = content > MAX_HEIGHT_PX ? "auto" : "hidden";
+  }
+
+  $effect(() => {
+    value();
+    resize();
+  });
+
+  // A narrower column re-wraps the text into more lines. Only width matters:
+  // reacting to height would react to the resize this action just performed.
+  $effect(() => {
+    let width = node.clientWidth;
+    const observer = new ResizeObserver(() => {
+      if (node.clientWidth === width) return;
+      width = node.clientWidth;
+      resize();
+    });
+    observer.observe(node);
+    return () => observer.disconnect();
+  });
+}

--- a/apps/frontend/src/lib/components/CommentNode.svelte
+++ b/apps/frontend/src/lib/components/CommentNode.svelte
@@ -6,6 +6,7 @@
   box at a time across the whole tree); `actions` carries the handlers.
 -->
 <script lang="ts">
+  import { autoGrow } from "$lib/actions/autoGrow.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import Icon from "$lib/components/Icon.svelte";
@@ -64,6 +65,7 @@
           <textarea
             bind:this={editEl}
             bind:value={ui.editDraft}
+            use:autoGrow={() => ui.editDraft}
             rows={2}
             maxlength={2000}
             placeholder="Edit your comment…"
@@ -150,6 +152,7 @@
             <textarea
               bind:this={replyEl}
               bind:value={ui.replyDraft}
+              use:autoGrow={() => ui.replyDraft}
               rows={2}
               maxlength={2000}
               placeholder={`Reply to ${comment.author.displayName}…`}

--- a/apps/frontend/src/lib/components/Comments.svelte
+++ b/apps/frontend/src/lib/components/Comments.svelte
@@ -3,6 +3,7 @@
   import { untrack } from "svelte";
   import { goto } from "$app/navigation";
   import { endpoints, ApiError } from "$lib/api";
+  import { autoGrow } from "$lib/actions/autoGrow.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import EmojiTrigger from "$lib/components/EmojiTrigger.svelte";
@@ -258,6 +259,7 @@
           <textarea
             bind:this={draftEl}
             bind:value={draft}
+            use:autoGrow={() => draft}
             rows={2}
             maxlength={2000}
             placeholder="What are your thoughts?"


### PR DESCRIPTION
## Symptom

The response box is a fixed two-row textarea. Write more than two lines and the text scrolls inside it — you can see a sliver of what you wrote, and rereading your own sentence means scrolling back up in a 60px window. Same for the reply and edit boxes, which share the styling.

## Fix

A `use:autoGrow` action sizes the textarea to its content on every change.

- `rows={2}` still sets the floor, so an empty box looks exactly as it does today.
- Growth stops at 320px, after which it scrolls. Without a cap a 2000-character response (the field's `maxlength`) would push the Respond button off the screen.
- The bound value is passed as a getter — `use:autoGrow={() => draft}` — rather than read from `input` events, because clearing the box after a submit and inserting an emoji both write the value programmatically and fire no event.
- The borders are added back to `scrollHeight` when setting the height: Tailwind's `box-sizing: border-box` means `height` includes them and `scrollHeight` does not, and without that the field lands 2px short and scrolls forever.
- A `ResizeObserver` refits on width changes only (the text re-wraps in a narrower column); reacting to height would react to the action's own resize.

Applied to all three boxes: new comment, reply, and edit.

## Verified

Headless Chromium against the dev server, driving a textarea with the real action and the real `field` classes. All twelve checks pass:

- empty field keeps its `rows=2` height (62px) and has no scrollbar
- grows with typed lines (62 → 102 → 142), 13.3px per line, no scrollbar while growing
- shrinks back to the floor when the value is cleared programmatically
- stops at exactly 320px and switches to `overflow-y: auto` there
- re-measures when the column narrows (62 → 102) with no scrollbar after re-wrapping

`deno task check`: 0 errors, 0 warnings.

Not verified: touch keyboards on a real phone, and the interaction with an IME composing over multiple lines.

## Deploy notes

None — plain rebuild.