### PR TITLE
fix(posts): repair post bodies that were stored as escaped HTML

### DIFF
--- a/apps/backend/deno.json
+++ b/apps/backend/deno.json
@@ -8,6 +8,7 @@
     "backfill:markdown": "deno run -A scripts/backfill_markdown.ts",
     "backfill:sanitize": "deno run -A scripts/backfill_sanitize.ts",
     "backfill:math": "deno run -A scripts/backfill_math.ts",
+    "backfill:unescape": "deno run -A scripts/backfill_unescape.ts",
     "check": "deno check src/main.ts",
     "test": "deno test -A",
     "fmt": "deno fmt",

--- a/apps/backend/scripts/backfill_unescape.ts
+++ b/apps/backend/scripts/backfill_unescape.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// One-time repair: restore post bodies that were stored as escaped HTML by the
+// editor before it learned to parse an ingested body as HTML. See
+// lib/unescapeBody.ts for what the damage looks like and why the rule is narrow.
+//
+//   deno task backfill:unescape            # apply changes
+//   deno task backfill:unescape --dry-run  # preview without writing
+//
+// Safe to run more than once: a repaired body no longer matches the damage
+// signature, so a second run finds nothing.
+import * as postsRepo from "@/db/repositories/posts.ts";
+import { isEscapedBody, repairEscapedBody, unexpectedTags } from "@/lib/unescapeBody.ts";
+import { sql } from "@/db/client.ts";
+
+const dryRun = Deno.args.includes("--dry-run");
+
+const posts = await postsRepo.listAllContent();
+console.log(`Scanning ${posts.length} post(s)${dryRun ? " (dry run)" : ""}…`);
+
+let changed = 0;
+let skipped = 0;
+for (const post of posts) {
+  if (!isEscapedBody(post.contentHtml)) continue;
+
+  const unexpected = unexpectedTags(post.contentHtml);
+  if (unexpected.length > 0) {
+    skipped++;
+    console.log(
+      `• ${post.id} SKIPPED — carries real markup too (${
+        unexpected.join(", ")
+      }); repair it by hand`,
+    );
+    continue;
+  }
+
+  const fixed = repairEscapedBody(post.contentHtml);
+  if (fixed === post.contentHtml) continue;
+
+  changed++;
+  console.log(
+    `• ${post.id} ${
+      dryRun ? "would be" : ""
+    } repaired (${post.contentHtml.length} → ${fixed.length} chars)`,
+  );
+  // The stored Tiptap document is the escaped text too, so it goes with it —
+  // the editor prefers it over the HTML and would show the damage again.
+  if (!dryRun) await postsRepo.update(post.id, { contentHtml: fixed, contentJson: null });
+}
+
+console.log(
+  dryRun
+    ? `Done. ${changed} post(s) would be repaired, ${skipped} need a human. Re-run without --dry-run to apply.`
+    : `Done. Repaired ${changed} post(s); ${skipped} skipped for manual repair.`,
+);
+
+await sql.end();

--- a/apps/backend/src/lib/unescapeBody.ts
+++ b/apps/backend/src/lib/unescapeBody.ts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Repair for post bodies that were stored as *escaped* HTML.
+//
+// A post ingested over the content webhook — or imported over federation —
+// carries no Tiptap document, so the editor rehydrated it from `contentHtml`.
+// Until the editor learned to parse that string as HTML it handed the string to
+// the Markdown parser instead, which is configured `html: false` and therefore
+// escaped every tag it found. Saving such a post wrote the escaped text back:
+// the body became one paragraph per line of the original, each reading
+// `&lt;p&gt;…&lt;/p&gt;`, which the reader displays as literal angle brackets.
+//
+// The editor no longer does this (it parses the HTML). This module repairs the
+// rows it already wrote — see scripts/backfill_unescape.ts.
+//
+// This is a one-way edit to stored content, so it is deliberately narrow:
+// anything that is not unmistakably this damage is left alone for a human.
+
+import { sanitizePostHtml } from "@/lib/sanitize.ts";
+
+// What is inside <pre>/<code> is content, not markup: a tutorial legitimately
+// shows `&lt;p&gt;` in a sample. Those regions are removed before the test
+// rather than matched around.
+const CODE = /<pre\b[\s\S]*?<\/pre>|<code\b[\s\S]*?<\/code>/gi;
+
+// The signature of the damage: an escaped block-level tag out in the prose.
+const ESCAPED_BLOCK = /&lt;\/?(?:p|div|h[1-6]|ul|ol|li|blockquote|figure|table)[\s/&>]/i;
+
+// Everything a damaged body may legitimately contain as *real* markup: Tiptap
+// wrapped each line of the escaped source in a paragraph and emitted nothing
+// else. A row carrying any other real tag mixes working markup with escaped
+// text, and no automatic rule can split those apart safely.
+const WRAPPERS = new Set(["p", "br"]);
+const TAG = /<\/?([a-z][a-z0-9]*)\b[^>]*>/gi;
+
+/** True when `html` looks like HTML source that was escaped into a body. */
+export function isEscapedBody(html: string): boolean {
+  return ESCAPED_BLOCK.test(html.replace(CODE, ""));
+}
+
+/** Real tags in `html` that are not the wrappers this repair expects. */
+export function unexpectedTags(html: string): string[] {
+  const found = [...html.matchAll(TAG)].map((m) => m[1].toLowerCase());
+  return [...new Set(found.filter((t) => !WRAPPERS.has(t)))];
+}
+
+// Undo one round of HTML escaping. `&amp;` goes last: doing it first would turn
+// `&amp;lt;` — a body that really does display "&lt;" — into a tag.
+function unescape(text: string): string {
+  return text
+    .replaceAll("&lt;", "<")
+    .replaceAll("&gt;", ">")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'")
+    .replaceAll("&#x27;", "'")
+    .replaceAll("&nbsp;", " ")
+    .replaceAll("&amp;", "&");
+}
+
+/**
+ * Rebuild the original source from the paragraphs it was escaped into, and put
+ * it back through the sanitizer — the only gateway into `contentHtml`.
+ */
+export function repairEscapedBody(html: string): string {
+  const source = html
+    // Each wrapper paragraph boundary and each <br> was a newline in the source.
+    .replace(/<\/p>\s*<p[^>]*>/gi, "\n")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/^\s*<p[^>]*>/i, "")
+    .replace(/<\/p>\s*$/i, "")
+    .trim();
+  return sanitizePostHtml(unescape(source));
+}

--- a/apps/backend/src/lib/unescapeBody_test.ts
+++ b/apps/backend/src/lib/unescapeBody_test.ts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { assertEquals, assertStringIncludes } from "@std/assert";
+import { isEscapedBody, repairEscapedBody, unexpectedTags } from "@/lib/unescapeBody.ts";
+
+// What these guard is a one-way edit to stored rows: the repair overwrites the
+// body of every post it matches. Leaving a post alone is always acceptable;
+// rewriting one that was never damaged is not.
+
+// A body exactly as the editor stored it: the ingested HTML escaped, one
+// paragraph per line of the original.
+const damaged = [
+  "<p>&lt;p&gt;This post is synced from &lt;a href=&quot;https://example.com/blog/post&quot;",
+  " rel=&quot;noopener noreferrer nofollow&quot; target=&quot;_blank&quot;&gt;my website&lt;/a&gt;",
+  " using webhooks.&lt;/p&gt;</p><p>&lt;h2&gt;1. Rendering&lt;/h2&gt;</p>",
+].join("");
+
+Deno.test("escaped body: the damage is recognised", () => {
+  assertEquals(isEscapedBody(damaged), true);
+});
+
+Deno.test("escaped body: the original markup comes back", () => {
+  const out = repairEscapedBody(damaged);
+  assertStringIncludes(out, '<a href="https://example.com/blog/post"');
+  assertStringIncludes(out, "<h2>1. Rendering</h2>");
+  assertEquals(out.includes("&lt;"), false);
+});
+
+Deno.test("escaped body: repairing twice changes nothing the second time", () => {
+  const once = repairEscapedBody(damaged);
+  assertEquals(isEscapedBody(once), false);
+});
+
+Deno.test("escaped body: a healthy post is not matched", () => {
+  const healthy = "<p>Angle brackets, &lt; and &gt;, in prose.</p><h2>Fine</h2>";
+  assertEquals(isEscapedBody(healthy), false);
+});
+
+Deno.test("escaped body: a post that quotes HTML in a code sample is not matched", () => {
+  const tutorial = "<p>Wrap it:</p><pre><code>&lt;p&gt;hello&lt;/p&gt;</code></pre>";
+  assertEquals(isEscapedBody(tutorial), false);
+});
+
+Deno.test("escaped body: a body mixing real markup with escaped text is left to a human", () => {
+  const mixed = "<h2>Real heading</h2><p>&lt;p&gt;escaped&lt;/p&gt;</p>";
+  assertEquals(isEscapedBody(mixed), true);
+  assertEquals(unexpectedTags(mixed), ["h2"]);
+});
+
+Deno.test("escaped body: wrappers alone are not flagged as unexpected", () => {
+  assertEquals(unexpectedTags(damaged), []);
+});
+
+Deno.test("escaped body: a doubly-escaped ampersand stays an ampersand", () => {
+  // `&amp;lt;` is a body that really does display "&lt;" — one round of
+  // unescaping must leave it as text, not turn it into a tag.
+  const out = repairEscapedBody("<p>&lt;p&gt;a &amp;amp;lt; b&lt;/p&gt;</p>");
+  assertStringIncludes(out, "&amp;lt;");
+  assertEquals(out.includes("<lt;"), false);
+});
+
+Deno.test("escaped body: the repair still goes through the sanitizer", () => {
+  const hostile = "<p>&lt;p&gt;hi&lt;/p&gt;&lt;script&gt;alert(1)&lt;/script&gt;</p>";
+  const out = repairEscapedBody(hostile);
+  assertEquals(out.includes("<script"), false);
+  assertEquals(out.includes("alert(1)"), false);
+  assertStringIncludes(out, "<p>hi</p>");
+});


### PR DESCRIPTION
## Symptom

A post synced in over the content webhook opens in the editor as raw text — `<p>This post is synced from <a href="…" rel="noopener noreferrer nofollow" target="_blank">my website</a></p>` shown literally, tags and all, instead of formatted prose. The reader shows the same angle brackets.

## Root cause

Two parts, and only one of them is already fixed.

An ingested post has no Tiptap document (`webhooks.ts` sets `contentJson = null` on every body change), so the editor rehydrates from `contentHtml`. Before #29 it passed that string to tiptap-markdown, whose parser is configured `html: false` — so every tag was escaped into text. #29 fixed the load path (`generateJSON`), but any post that was opened and saved before it landed had the escaped text **written back to the database**. Those rows are still broken, and no amount of fixing the editor repairs them.

The giveaway that the stored text is Omicron's own output rather than something a CMS sent is the `rel="noopener noreferrer nofollow" target="_blank"` on the link: those attributes are added by our sanitizer, so this HTML was rendered correctly on ingest and escaped afterwards.

## Fix

`src/lib/unescapeBody.ts` plus `deno task backfill:unescape`, following the existing backfill scripts.

Because this overwrites stored bodies one-way, the rule refuses anything that is not unmistakably this damage:

- Escaped tags inside `<pre>`/`<code>` are **content**, not damage — a tutorial that shows `&lt;p&gt;` in a sample is skipped.
- A damaged body contains only `<p>`/`<br>` as real markup (Tiptap wrapped each line of the escaped source). Anything carrying other real tags mixes working markup with escaped text; it is reported by id for manual repair rather than guessed at.
- `&amp;` is unescaped last, so `&amp;lt;` — a body that really does display `&lt;` — stays text instead of becoming a tag.
- The result goes back through `sanitizePostHtml`; the repair is not a new way into `contentHtml`.
- `contentJson` is cleared alongside, since it holds the same escaped text and the editor prefers it over the HTML.

## Verified

`deno test` — 9 unit tests on the transform: the damage is recognised, the original markup comes back, a healthy body and a code-sample body are not matched, a mixed body is flagged for a human, `&amp;lt;` survives, `<script>` in the escaped text is still sanitized away, and a repaired body no longer matches (idempotent).

End to end against a real Postgres with migrations applied and four seeded rows (damaged / healthy / tutorial / mixed):

```
Scanning 4 post(s) (dry run)…
• 2222…2222 would be repaired (251 → 172 chars)
• 5555…5555 SKIPPED — carries real markup too (h2); repair it by hand
```

After applying, the damaged row reads `<p>This post is synced from <a href="…">my website</a> using webhooks.</p><h2>1. Rendering</h2>` with `content_json` NULL; the healthy and tutorial rows are byte-identical to before; a second run is a no-op.

Not verified: the actual production rows. Run the dry run there first — if it reports a post as SKIPPED, that one needs its body re-pasted by hand.

## Deploy notes

Nothing runs automatically. After `docker compose up -d --build`:

```
docker compose exec backend deno task backfill:unescape --dry-run
docker compose exec backend deno task backfill:unescape
```