### PR TITLE
feat(recommendations): add ActivityPub repost as "recommend"

### DIFF
--- a/apps/backend/drizzle/0029_recommendations.sql
+++ b/apps/backend/drizzle/0029_recommendations.sql
@@ -1,0 +1,34 @@
+-- Recommendations ("repost", federates as ActivityPub Announce). Additive.
+--
+-- One row per (post, recommender) — a recommender announcing a post to their
+-- followers. The recommender is either a local user or a cached remote actor,
+-- the same local-or-remote shape `follows`/`notifications` already use. Two
+-- partial unique indexes (one per recommender kind) make recommending
+-- idempotent, mirroring how `likes` uses a single one.
+--
+-- Deliberately absent from the Local/Global timelines: those list posts by
+-- their own publish time and never join this table. A recommendation only
+-- ever surfaces on the recommender's followers' "For you" feed and on the
+-- recommender's profile "Recommendations" tab (see
+-- db/repositories/recommendations.ts).
+CREATE TABLE IF NOT EXISTS "recommendations" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "post_id" uuid NOT NULL REFERENCES "posts"("id") ON DELETE CASCADE,
+  "user_id" uuid REFERENCES "users"("id") ON DELETE CASCADE,
+  "remote_actor_id" uuid REFERENCES "remote_actors"("id") ON DELETE CASCADE,
+  "created_at" timestamptz DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "recommendations_post_user_idx"
+  ON "recommendations" ("post_id", "user_id") WHERE "user_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "recommendations_post_remote_actor_idx"
+  ON "recommendations" ("post_id", "remote_actor_id") WHERE "remote_actor_id" IS NOT NULL;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "recommendations_post_idx" ON "recommendations" ("post_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "recommendations_user_created_idx"
+  ON "recommendations" ("user_id", "created_at" DESC, "id" DESC);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "recommendations_remote_actor_created_idx"
+  ON "recommendations" ("remote_actor_id", "created_at" DESC, "id" DESC);

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1786209507621,
       "tag": "0028_post_slugs",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1786209507622,
+      "tag": "0029_recommendations",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -31,14 +31,14 @@ import type { LanguageFilter } from "@/lib/languages.ts";
 
 // A post's author is either a local user or a cached remote actor; every read
 // left-joins both and the serializer coalesces whichever side is present.
-const localAuthorColumns = {
+export const localAuthorColumns = {
   id: users.id,
   username: users.username,
   displayName: users.displayName,
   avatarUrl: users.avatarUrl,
 };
 
-const remoteActorColumns = {
+export const remoteActorColumns = {
   id: remoteActors.id,
   handle: remoteActors.handle,
   displayName: remoteActors.displayName,
@@ -49,8 +49,9 @@ const remoteActorColumns = {
 // and only ever used inside the search query's `@@` / `ts_rank`, so timelines
 // must not pull it back for every row.
 const { searchVector: _searchVector, ...postColumns } = getTableColumns(posts);
+export { postColumns };
 
-function selectPosts() {
+export function selectPosts() {
   return db
     .select({ post: postColumns, localAuthor: localAuthorColumns, remoteActor: remoteActorColumns })
     .from(posts)
@@ -446,20 +447,20 @@ function beforeCursor(cursor: Cursor | null) {
 
 // Only published posts surface in public feeds and profiles; drafts are private
 // to their author (see listDraftsByAuthor).
-const isPublished = eq(posts.status, "published");
+export const isPublished = eq(posts.status, "published");
 
 // A locally-suspended author vanishes from every public listing — feeds,
 // trending, search, tags and their own profile — until an admin reinstates them
 // (nothing is deleted). Remote posts have no local author (`authorId is null`)
 // and are unaffected. Relies on every listing left-joining `users` on authorId.
-const notSuspended = sql`(${posts.authorId} is null or ${users.suspendedAt} is null)`;
+export const notSuspended = sql`(${posts.authorId} is null or ${users.suspendedAt} is null)`;
 
 // Gates posts by a *private* local author to approved followers only (plus the
 // author themselves). Public authors and remote posts (authorId null) are
 // unaffected. Relies on every listing left-joining `users` on authorId. Unlike
 // notHidden this can't be dropped for guests — a private author's posts must
 // never show to a logged-out viewer — so it always returns a condition.
-function visibleToViewer(viewerId: string | null) {
+export function visibleToViewer(viewerId: string | null) {
   if (!viewerId) {
     return sql`(${posts.authorId} is null or ${users.isPrivate} = false)`;
   }
@@ -479,7 +480,7 @@ function visibleToViewer(viewerId: string | null) {
 // Excludes authors the viewer has muted or blocked, and authors who have blocked
 // the viewer (blocks are bidirectional locally). Returns undefined for guests —
 // `and()` drops undefined operands, so feeds are unfiltered when logged out.
-function notHidden(viewerId: string | null) {
+export function notHidden(viewerId: string | null) {
   if (!viewerId) return undefined;
   const hiddenLocal = sql`(
     select target_user_id from mutes

--- a/apps/backend/src/db/repositories/recommendations.ts
+++ b/apps/backend/src/db/repositories/recommendations.ts
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { aliasedTable, and, desc, eq, inArray, lt, or, sql } from "drizzle-orm";
+import { db } from "@/db/client.ts";
+import { posts, recommendations, remoteActors, users } from "@/db/schema.ts";
+import {
+  isPublished,
+  localAuthorColumns,
+  notHidden,
+  notSuspended,
+  postColumns,
+  remoteActorColumns,
+  visibleToViewer,
+} from "@/db/repositories/posts.ts";
+import { type Cursor, DEFAULT_PAGE_SIZE } from "@/lib/pagination.ts";
+
+// Recommend-edge DB access ("repost", federates as ActivityPub Announce). One
+// row per (post, recommender); the recommender is either a local user or a
+// cached remote actor, mirroring the local-or-remote shape `follows` and
+// `notifications` already use. Recommending is idempotent via the two partial
+// unique indexes on the table.
+
+export async function add(postId: string, userId: string) {
+  await db.insert(recommendations).values({ postId, userId }).onConflictDoNothing();
+}
+
+export async function addRemote(postId: string, remoteActorId: string) {
+  await db.insert(recommendations).values({ postId, remoteActorId }).onConflictDoNothing();
+}
+
+export async function remove(postId: string, userId: string) {
+  await db.delete(recommendations).where(
+    and(eq(recommendations.postId, postId), eq(recommendations.userId, userId)),
+  );
+}
+
+export async function removeRemote(postId: string, remoteActorId: string) {
+  await db.delete(recommendations).where(
+    and(eq(recommendations.postId, postId), eq(recommendations.remoteActorId, remoteActorId)),
+  );
+}
+
+export type RecommendStats = { count: number; recommended: boolean };
+
+// Recommend count + whether `viewerId` recommended it, for many posts in one
+// query — mirrors likesRepo.statsFor.
+export async function statsFor(
+  postIds: string[],
+  viewerId: string | null,
+): Promise<Map<string, RecommendStats>> {
+  const map = new Map<string, RecommendStats>();
+  if (postIds.length === 0) return map;
+
+  const rows = await db
+    .select({
+      postId: recommendations.postId,
+      count: sql<number>`count(*)::int`,
+      recommended: viewerId
+        ? sql<boolean>`bool_or(${recommendations.userId} = ${viewerId})`
+        : sql<boolean>`false`,
+    })
+    .from(recommendations)
+    .where(inArray(recommendations.postId, postIds))
+    .groupBy(recommendations.postId);
+
+  for (const r of rows as { postId: string; count: number; recommended: boolean }[]) {
+    map.set(r.postId, { count: r.count, recommended: !!r.recommended });
+  }
+  return map;
+}
+
+// Keyset condition over the *recommendation's* own clock — distinct from
+// posts.ts's beforeCursor, which cursors on the post's publish time.
+function beforeCursor(cursor: Cursor | null) {
+  if (!cursor) return undefined;
+  const ts = new Date(cursor.createdAt);
+  return or(
+    lt(recommendations.createdAt, ts),
+    and(eq(recommendations.createdAt, ts), lt(recommendations.id, cursor.id)),
+  );
+}
+
+function selectRecommended() {
+  return db
+    .select({
+      post: postColumns,
+      localAuthor: localAuthorColumns,
+      remoteActor: remoteActorColumns,
+      // The recommendation edge's own id — the cursor tiebreak `beforeCursor`
+      // above filters on, distinct from the post's id.
+      recommendationId: recommendations.id,
+      recommendedAt: recommendations.createdAt,
+    })
+    .from(recommendations)
+    .innerJoin(posts, eq(posts.id, recommendations.postId))
+    .leftJoin(users, eq(posts.authorId, users.id))
+    .leftJoin(remoteActors, eq(posts.remoteActorId, remoteActors.id));
+}
+
+export type RecommendedPostRow = Awaited<ReturnType<typeof listByUser>>[number];
+
+// Posts a local user has recommended, newest-recommended first — the profile's
+// "Recommendations" tab. Same visibility rules as any other public post
+// listing (published, not suspended, not blocked/muted, private-author gated).
+export function listByUser(
+  userId: string,
+  viewerId: string | null,
+  cursor: Cursor | null,
+  limit = DEFAULT_PAGE_SIZE,
+) {
+  return selectRecommended()
+    .where(
+      and(
+        eq(recommendations.userId, userId),
+        isPublished,
+        notSuspended,
+        notHidden(viewerId),
+        visibleToViewer(viewerId),
+        beforeCursor(cursor),
+      ),
+    )
+    .orderBy(desc(recommendations.createdAt), desc(recommendations.id))
+    .limit(limit + 1);
+}
+
+// Posts a cached remote actor has recommended — the remote-profile analogue of
+// listByUser. Filtered to "Article" like listByRemoteActor, so a boosted
+// microblog Note (cached before this instance went long-form-only) never
+// surfaces here either.
+export function listByRemoteActor(
+  remoteActorId: string,
+  viewerId: string | null,
+  cursor: Cursor | null,
+  limit = DEFAULT_PAGE_SIZE,
+) {
+  return selectRecommended()
+    .where(
+      and(
+        eq(recommendations.remoteActorId, remoteActorId),
+        eq(posts.apType, "Article"),
+        notHidden(viewerId),
+        visibleToViewer(viewerId),
+        beforeCursor(cursor),
+      ),
+    )
+    .orderBy(desc(recommendations.createdAt), desc(recommendations.id))
+    .limit(limit + 1);
+}
+
+const recommenderUser = aliasedTable(users, "feed_recommender_user");
+const recommenderActor = aliasedTable(remoteActors, "feed_recommender_actor");
+
+export type FeedRecommendationRow = Awaited<ReturnType<typeof listFeedFor>>[number];
+
+// Posts recommended by `userId`'s followed local/remote authors — the
+// recommendation half of the "For you" feed's merged stream (see
+// services/feed.ts). Ordered on the recommendation's own clock, not the post's
+// publish time, so a boost of an old post surfaces when it was boosted, the
+// way a repost does on any federated timeline.
+export function listFeedFor(userId: string, cursor: Cursor | null, limit = DEFAULT_PAGE_SIZE) {
+  const followedLocal = sql`(
+    select followee_id from follows
+    where follower_id = ${userId} and followee_id is not null and approved = true
+  )`;
+  const followedRemote = sql`(
+    select remote_followee_id from follows
+    where follower_id = ${userId} and remote_followee_id is not null and approved = true
+  )`;
+  return db
+    .select({
+      post: postColumns,
+      localAuthor: localAuthorColumns,
+      remoteActor: remoteActorColumns,
+      recommenderId: sql<string>`coalesce(${recommenderUser.id}, ${recommenderActor.id})`,
+      recommenderUsername: sql<
+        string
+      >`coalesce(${recommenderUser.username}, ${recommenderActor.handle})`,
+      recommenderDisplayName: sql<
+        string
+      >`coalesce(${recommenderUser.displayName}, ${recommenderActor.displayName})`,
+      recommenderAvatarUrl: sql<
+        string | null
+      >`coalesce(${recommenderUser.avatarUrl}, ${recommenderActor.avatarUrl})`,
+      recommenderRemote: sql<boolean>`(${recommendations.remoteActorId} is not null)`,
+      recommendationId: recommendations.id,
+      recommendedAt: recommendations.createdAt,
+    })
+    .from(recommendations)
+    .innerJoin(posts, eq(posts.id, recommendations.postId))
+    .leftJoin(users, eq(posts.authorId, users.id))
+    .leftJoin(remoteActors, eq(posts.remoteActorId, remoteActors.id))
+    .leftJoin(recommenderUser, eq(recommendations.userId, recommenderUser.id))
+    .leftJoin(recommenderActor, eq(recommendations.remoteActorId, recommenderActor.id))
+    .where(
+      and(
+        eq(posts.apType, "Article"),
+        isPublished,
+        or(
+          sql`${recommendations.userId} in ${followedLocal}`,
+          sql`${recommendations.remoteActorId} in ${followedRemote}`,
+        ),
+        notSuspended,
+        notHidden(userId),
+        beforeCursor(cursor),
+      ),
+    )
+    .orderBy(desc(recommendations.createdAt), desc(recommendations.id))
+    .limit(limit + 1);
+}

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -318,6 +318,37 @@ export const likes = pgTable("likes", {
   index("likes_post_idx").on(t.postId),
 ]);
 
+// ── recommendations ("repost", federates as ActivityPub Announce) ───────
+// A recommender announcing a post (their own, another local post, or a cached
+// remote one) to their followers — the fediverse's "boost"/"repost", named
+// "recommend" in Omicron's UI. One row per (post, recommender); the recommender
+// is either a local user (`userId`) or a cached remote actor (`remoteActorId`),
+// the same local-or-remote shape `follows`/`notifications` use. Deliberately
+// NOT surfaced on the Local or Global timelines (those list posts by their own
+// publish time, unaffected by this table) — only on the recommender's
+// followers' "For you" feed and the recommender's profile "Recommendations"
+// tab (see db/repositories/recommendations.ts).
+export const recommendations = pgTable("recommendations", {
+  id: uuid("id").primaryKey().defaultRandom(),
+  postId: uuid("post_id").notNull().references(() => posts.id, { onDelete: "cascade" }),
+  userId: uuid("user_id").references(() => users.id, { onDelete: "cascade" }),
+  remoteActorId: uuid("remote_actor_id").references(() => remoteActors.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  // Recommending is idempotent per (post, recommender), local or remote.
+  uniqueIndex("recommendations_post_user_idx")
+    .on(t.postId, t.userId)
+    .where(sql`${t.userId} is not null`),
+  uniqueIndex("recommendations_post_remote_actor_idx")
+    .on(t.postId, t.remoteActorId)
+    .where(sql`${t.remoteActorId} is not null`),
+  index("recommendations_post_idx").on(t.postId),
+  // A recommender's own "Recommendations" tab, newest first.
+  index("recommendations_user_created_idx").on(t.userId, t.createdAt.desc(), t.id.desc()),
+  index("recommendations_remote_actor_created_idx")
+    .on(t.remoteActorId, t.createdAt.desc(), t.id.desc()),
+]);
+
 // ── comments ───────────────────────────────────────────────────────────
 // Single-level threaded comments. `content` is plain text — rendered escaped
 // on the client, never as HTML. `parentId` is null for top-level comments and
@@ -644,6 +675,7 @@ export type Follow = typeof follows.$inferSelect;
 export type Mute = typeof mutes.$inferSelect;
 export type Block = typeof blocks.$inferSelect;
 export type Like = typeof likes.$inferSelect;
+export type Recommendation = typeof recommendations.$inferSelect;
 export type Comment = typeof comments.$inferSelect;
 export type NewComment = typeof comments.$inferInsert;
 export type CommentLike = typeof commentLikes.$inferSelect;

--- a/apps/backend/src/federation/mod.ts
+++ b/apps/backend/src/federation/mod.ts
@@ -12,8 +12,10 @@ import {
 } from "@fedify/fedify";
 import { RedisKvStore, RedisMessageQueue } from "@fedify/redis";
 import { getRedis, redisEnabled, redisFactory } from "@/lib/redis.ts";
+import type { Context } from "@fedify/fedify";
 import {
   Accept,
+  Announce,
   Article,
   Block,
   Create,
@@ -30,6 +32,7 @@ import * as usersRepo from "@/db/repositories/users.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
+import * as recommendationsRepo from "@/db/repositories/recommendations.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
 import * as listsRepo from "@/db/repositories/readingLists.ts";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
@@ -41,6 +44,7 @@ import { cacheActor } from "@/federation/remote.ts";
 import { origin } from "@/config.ts";
 import { normalizeTags } from "@/lib/tags.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
+import type { Post } from "@/db/schema.ts";
 
 // ── ActivityPub wiring (isolated) ────────────────────────────────────────
 // This module is only imported when FEDERATION_ENABLED=true (see app.ts), so a
@@ -206,7 +210,47 @@ async function fromBlockedDomain(actorId: URL | null | undefined): Promise<boole
   }
 }
 
-// ── Inbox: inbound Follow / Undo / Create ────────────────────────────────
+// Ingests a remote Article, keyed by its ActivityPub id — shared by the
+// inbound Create handler (a fresh post) and the inbound Announce handler (a
+// remote actor boosting a post we may not have cached yet). Resolves the
+// article's *attributed author*, not the wrapping activity's actor, since
+// those two differ for an Announce (the booster isn't the writer). Returns the
+// existing cached row without refetching anything if we already have it.
+async function ingestArticle(
+  ctx: Context<ContextData>,
+  article: Article,
+): Promise<Post | undefined> {
+  if (!article.id) return undefined;
+  const existing = await postsRepo.findByApId(article.id.href);
+  if (existing) return existing;
+
+  if (!article.attributionId) return undefined;
+  const author = await ctx.lookupObject(article.attributionId);
+  if (!isActor(author) || !author.id) return undefined;
+  const actor = await cacheActor(author);
+
+  const post = await postsRepo.upsertRemotePost({
+    remoteActorId: actor.id,
+    apId: article.id.href,
+    title: article.name?.toString() ?? null,
+    // Remote HTML is untrusted and rendered with {@html} by the reader —
+    // sanitize before it ever touches the database.
+    contentHtml: sanitizePostHtml(article.content?.toString()),
+    apType: "Article",
+    language: articleLanguage(article),
+    createdAt: article.published ? new Date(article.published.epochMilliseconds) : undefined,
+  });
+
+  // Mirror any Hashtag tags onto the post so it joins our tag pages/feeds.
+  const tagNames: string[] = [];
+  for await (const tag of article.getTags(ctx)) {
+    if (tag instanceof Hashtag && tag.name) tagNames.push(tag.name.toString());
+  }
+  await tagsRepo.setPostTags(post.id, normalizeTags(tagNames));
+  return post;
+}
+
+// ── Inbox: inbound Follow / Undo / Create / Announce ─────────────────────
 function setupInbox(f: Federation<ContextData>) {
   f.setInboxListeners("/users/{identifier}/inbox", "/inbox")
     .on(Follow, async (ctx, follow) => {
@@ -265,12 +309,35 @@ function setupInbox(f: Federation<ContextData>) {
     .on(Undo, async (ctx, undo) => {
       if (await fromBlockedDomain(undo.actorId)) return;
       const object = await undo.getObject(ctx);
-      if (!(object instanceof Follow) || !object.objectId) return;
-      const parsed = ctx.parseUri(object.objectId);
-      if (parsed?.type !== "actor") return;
-      const followee = await usersRepo.findByUsername(parsed.identifier);
-      if (followee && undo.actorId) {
-        await followsRepo.removeRemoteFollower(followee.id, undo.actorId.href);
+      if (object instanceof Follow) {
+        if (!object.objectId) return;
+        const parsed = ctx.parseUri(object.objectId);
+        if (parsed?.type !== "actor") return;
+        const followee = await usersRepo.findByUsername(parsed.identifier);
+        if (followee && undo.actorId) {
+          await followsRepo.removeRemoteFollower(followee.id, undo.actorId.href);
+        }
+        return;
+      }
+      if (object instanceof Announce) {
+        // A remote actor un-boosted a post. `object` here is the original
+        // Announce, nested inside the Undo — its own `objectId` is the boosted
+        // post's URI (not the Announce's own id), which is what we keyed the
+        // recommendation on.
+        if (!object.objectId || !undo.actorId) return;
+        const post = await postsRepo.findByApId(object.objectId.href);
+        if (!post) return;
+        const actor = await remoteActorsRepo.findByApId(undo.actorId.href);
+        if (!actor) return;
+        await recommendationsRepo.removeRemote(post.id, actor.id);
+        if (post.authorId) {
+          await notifications.unnotify({
+            recipientId: post.authorId,
+            type: "recommend",
+            remoteActorId: actor.id,
+            postId: post.id,
+          });
+        }
       }
     })
     .on(Block, async (ctx, block) => {
@@ -313,29 +380,39 @@ function setupInbox(f: Federation<ContextData>) {
       // ignore microblog Notes (Mastodon, Pixelfed, …) outright.
       const object = await create.getObject(ctx);
       if (!(object instanceof Article)) return;
-      if (!object.id) return;
-      if (await postsRepo.findByApId(object.id.href)) return;
-      const author = await create.getActor(ctx);
-      if (!isActor(author) || !author.id) return;
-      const actor = await cacheActor(author);
-      const post = await postsRepo.upsertRemotePost({
-        remoteActorId: actor.id,
-        apId: object.id.href,
-        title: object.name?.toString() ?? null,
-        // Remote HTML is untrusted and rendered with {@html} by the reader —
-        // sanitize before it ever touches the database.
-        contentHtml: sanitizePostHtml(object.content?.toString()),
-        apType: "Article",
-        language: articleLanguage(object),
-        createdAt: object.published ? new Date(object.published.epochMilliseconds) : undefined,
-      });
+      await ingestArticle(ctx, object);
+    })
+    .on(Announce, async (ctx, announce) => {
+      if (await fromBlockedDomain(announce.actorId)) return;
+      // A remote actor "boosted" a post — record it as a recommendation from
+      // them, so it can surface on their local followers' "For you" feed (see
+      // db/repositories/recommendations.ts). Only Articles are recognised,
+      // matching the rest of this instance's long-form-only stance; a boosted
+      // Note (a Mastodon retweet) is silently ignored.
+      if (!announce.objectId) return;
+      const recommender = await announce.getActor(ctx);
+      if (!isActor(recommender) || !recommender.id) return;
+      const actor = await cacheActor(recommender);
 
-      // Mirror any Hashtag tags onto the post so it joins our tag pages/feeds.
-      const tagNames: string[] = [];
-      for await (const tag of object.getTags(ctx)) {
-        if (tag instanceof Hashtag && tag.name) tagNames.push(tag.name.toString());
+      let post = await postsRepo.findByApId(announce.objectId.href);
+      if (!post) {
+        const object = await announce.getObject(ctx);
+        if (!(object instanceof Article)) return;
+        post = await ingestArticle(ctx, object);
+        if (!post) return;
       }
-      await tagsRepo.setPostTags(post.id, normalizeTags(tagNames));
+
+      await recommendationsRepo.addRemote(post.id, actor.id);
+      // Notify the post's local author (if any); remote-authored posts have no
+      // local recipient.
+      if (post.authorId) {
+        await notifications.notify({
+          recipientId: post.authorId,
+          type: "recommend",
+          remoteActorId: actor.id,
+          postId: post.id,
+        });
+      }
     })
     .on(Update, async (ctx, update) => {
       if (await fromBlockedDomain(update.actorId)) return;

--- a/apps/backend/src/federation/outbound.ts
+++ b/apps/backend/src/federation/outbound.ts
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
+import type { Context } from "@fedify/fedify";
 import {
   Accept,
+  type Actor,
+  Announce,
   Block,
   Delete,
   Follow,
@@ -13,6 +16,7 @@ import { getFederation } from "@/federation/mod.ts";
 import { origin } from "@/config.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
+import * as postsRepo from "@/db/repositories/posts.ts";
 
 // Outbound Follow / Undo(Follow) to a remote actor URI. Wired for future use
 // when the UI lets users follow remote handles; the call site already enqueues
@@ -139,6 +143,78 @@ export async function sendAcceptFollow(
         actor: actor.id,
         object: actorUri,
       }),
+    }),
+  );
+}
+
+// Resolves a local user's remote followers into deliverable actor objects.
+// Shared by sendRecommend/sendUnrecommend, mirroring deliver.ts's
+// remoteRecipients (kept separate — that one also checks the blocklist, which
+// a recommend/undo-recommend doesn't need since the recipients are the
+// recommender's own approved followers).
+async function followerRecipients(ctx: Context<unknown>, userId: string): Promise<Actor[]> {
+  const uris = await followsRepo.remoteFollowerActors(userId);
+  const recipients: Actor[] = [];
+  for (const uri of uris) {
+    const actor = await ctx.lookupObject(uri);
+    if (isActor(actor)) recipients.push(actor);
+  }
+  return recipients;
+}
+
+// Outbound Announce — a local user "recommending" (reposting) a post to their
+// followers. The post may be local or a cached remote one; either way the
+// Announce references its canonical ActivityPub URI. The activity id is
+// deterministic (`#recommends/{postId}` under the recommender's actor) so
+// sendUnrecommend can reconstruct it below without persisting anything extra.
+export async function sendRecommend(userId: string, postId: string): Promise<void> {
+  const user = await usersRepo.findById(userId);
+  if (!user) return;
+  const row = await postsRepo.findById(postId);
+  if (!row) return;
+
+  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const recipients = await followerRecipients(ctx, user.id);
+  if (recipients.length === 0) return;
+
+  const objectUri = row.post.remote && row.post.apId
+    ? new URL(row.post.apId)
+    : new URL(`/posts/${row.post.id}`, origin);
+  const actorUri = ctx.getActorUri(user.username);
+
+  await ctx.sendActivity(
+    { identifier: user.username },
+    recipients,
+    new Announce({
+      id: new URL(`#recommends/${postId}`, actorUri),
+      actor: actorUri,
+      object: objectUri,
+      tos: [PUBLIC_COLLECTION],
+      cc: ctx.getFollowersUri(user.username),
+    }),
+  );
+}
+
+// Outbound Undo(Announce) — sent when a local user un-recommends a post.
+// Reconstructs the original Announce by its deterministic id; no lookup of the
+// post is needed (or possible, if it has since been deleted).
+export async function sendUnrecommend(userId: string, postId: string): Promise<void> {
+  const user = await usersRepo.findById(userId);
+  if (!user) return;
+
+  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const recipients = await followerRecipients(ctx, user.id);
+  if (recipients.length === 0) return;
+
+  const actorUri = ctx.getActorUri(user.username);
+  await ctx.sendActivity(
+    { identifier: user.username },
+    recipients,
+    new Undo({
+      id: new URL(`#undo-recommends/${postId}`, actorUri),
+      actor: actorUri,
+      object: new Announce({ id: new URL(`#recommends/${postId}`, actorUri), actor: actorUri }),
+      tos: [PUBLIC_COLLECTION],
     }),
   );
 }

--- a/apps/backend/src/queue/handlers.ts
+++ b/apps/backend/src/queue/handlers.ts
@@ -86,6 +86,20 @@ export function registerJobHandlers() {
     await sendAcceptFollow(userId, targetActor, followActivityId);
   });
 
+  // A local user recommended / un-recommended a post; fan out an
+  // Announce / Undo(Announce) to their remote followers (a "boost").
+  registerHandler("send_recommend", async ({ userId, postId }) => {
+    if (!federationRunning()) return;
+    const { sendRecommend } = await import("@/federation/outbound.ts");
+    await sendRecommend(userId, postId);
+  });
+
+  registerHandler("send_unrecommend", async ({ userId, postId }) => {
+    if (!federationRunning()) return;
+    const { sendUnrecommend } = await import("@/federation/outbound.ts");
+    await sendUnrecommend(userId, postId);
+  });
+
   // Account deletion. Broadcast a Delete(actor) to remote followers first (so
   // other instances tombstone us) while the key pair still exists, then remove
   // the user — FK cascades wipe their posts, follows, sessions, mutes & blocks.

--- a/apps/backend/src/queue/queue.ts
+++ b/apps/backend/src/queue/queue.ts
@@ -21,6 +21,8 @@ export type JobName =
   | "send_unblock"
   | "send_reject_follow"
   | "send_accept_follow"
+  | "send_recommend"
+  | "send_unrecommend"
   | "delete_actor"
   | "send_password_reset"
   | "send_email_verification";
@@ -37,6 +39,8 @@ export type JobPayloads = {
   send_unblock: { blockerId: string; targetActor: string };
   send_reject_follow: { userId: string; targetActor: string };
   send_accept_follow: { userId: string; targetActor: string; followActivityId: string | null };
+  send_recommend: { userId: string; postId: string };
+  send_unrecommend: { userId: string; postId: string };
   delete_actor: { userId: string };
   send_password_reset: { to: string; token: string };
   send_email_verification: { to: string; token: string };

--- a/apps/backend/src/routes/feed.ts
+++ b/apps/backend/src/routes/feed.ts
@@ -2,16 +2,18 @@
 import { Hono } from "hono";
 import * as feedService from "@/services/feed.ts";
 import { enrichPosts } from "@/services/engagement.ts";
-import { decodeCursor } from "@/lib/pagination.ts";
 import { requireUser } from "@/routes/middleware.ts";
 import type { AppEnv } from "@/routes/types.ts";
 
 export const feedRoutes = new Hono<AppEnv>();
 
-// Personalized home timeline (auth required).
+// Personalized home timeline (auth required). Unlike every other paginated
+// list, the cursor here is opaque to lib/pagination — it threads two merged
+// streams' positions (see services/feed.ts) — so it's passed through raw
+// rather than decoded with decodeCursor.
 feedRoutes.get("/", async (c) => {
   const user = requireUser(c);
-  const cursor = decodeCursor(c.req.query("cursor"));
+  const cursor = c.req.query("cursor") ?? null;
   const { items, nextCursor } = await feedService.homeFeed(user.id, cursor);
   return c.json({ items: await enrichPosts(items, user.id), nextCursor });
 });

--- a/apps/backend/src/routes/posts.ts
+++ b/apps/backend/src/routes/posts.ts
@@ -3,6 +3,7 @@ import { type Context, Hono } from "hono";
 import { getCookie, setCookie } from "hono/cookie";
 import * as postsService from "@/services/posts.ts";
 import * as likesService from "@/services/likes.ts";
+import * as recommendationsService from "@/services/recommendations.ts";
 import * as commentsService from "@/services/comments.ts";
 import * as commentLikesService from "@/services/commentLikes.ts";
 import { enrichPost, enrichPosts } from "@/services/engagement.ts";
@@ -145,6 +146,20 @@ postRoutes.delete("/:id/like", async (c) => {
   const user = requireUser(c);
   const stats = await likesService.unlike(user.id, c.req.param("id"));
   return c.json({ likeCount: stats.count, liked: stats.liked });
+});
+
+// Recommend / un-recommend a post ("repost"; auth required). Federates as an
+// ActivityPub Announce/Undo(Announce). Returns fresh recommend stats.
+postRoutes.post("/:id/recommend", async (c) => {
+  const user = requireUser(c);
+  const stats = await recommendationsService.recommend(user.id, c.req.param("id"));
+  return c.json({ recommendCount: stats.count, recommended: stats.recommended });
+});
+
+postRoutes.delete("/:id/recommend", async (c) => {
+  const user = requireUser(c);
+  const stats = await recommendationsService.unrecommend(user.id, c.req.param("id"));
+  return c.json({ recommendCount: stats.count, recommended: stats.recommended });
 });
 
 // Comments (list public, create requires auth).

--- a/apps/backend/src/routes/remote.ts
+++ b/apps/backend/src/routes/remote.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { federationRunning } from "@/services/federationState.ts";
 import * as remoteProfilesService from "@/services/remoteProfiles.ts";
 import * as relationsService from "@/services/relations.ts";
+import * as recommendationsService from "@/services/recommendations.ts";
 import { enrichPosts } from "@/services/engagement.ts";
 import { decodeCursor } from "@/lib/pagination.ts";
 import { remoteProfile } from "@/routes/serializers.ts";
@@ -77,6 +78,21 @@ remoteRoutes.get("/users/:handle/posts", async (c) => {
     handle,
     cursor,
     viewer?.id ?? null,
+  );
+  return c.json({ items: await enrichPosts(items, viewer?.id ?? null), nextCursor });
+});
+
+// A remote actor's "Recommendations" tab: posts they've boosted (recorded from
+// an inbound Announce), newest-recommended first.
+remoteRoutes.get("/users/:handle/recommendations", async (c) => {
+  const viewer = c.get("user");
+  const handle = c.req.param("handle");
+  const cursor = decodeCursor(c.req.query("cursor"));
+  const actor = await remoteProfilesService.getProfile(handle);
+  const { items, nextCursor } = await recommendationsService.listByRemoteActor(
+    actor.id,
+    viewer?.id ?? null,
+    cursor,
   );
   return c.json({ items: await enrichPosts(items, viewer?.id ?? null), nextCursor });
 });

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -8,7 +8,27 @@ import { bannerOf } from "@/lib/cover.ts";
 
 // Minimal API payloads — never leak password hashes, keys, or emails publicly.
 
-export type Engagement = { likeCount: number; liked: boolean; commentCount: number };
+export type Engagement = {
+  likeCount: number;
+  liked: boolean;
+  commentCount: number;
+  recommendCount: number;
+  recommended: boolean;
+};
+
+// Who recommended a post, and when — attached only to a feed item that reached
+// the viewer via a recommendation rather than authorship/follow (see
+// services/feed.ts). Shaped like `postAuthor` (local-or-remote, `username` a
+// `user@host` handle for a remote recommender) so `/@${username}` resolves
+// either way.
+export type RecommendedBy = {
+  id: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  remote: boolean;
+  recommendedAt: Date;
+};
 
 export type LinkSummary = { platform: string; url: string; label: string };
 
@@ -105,6 +125,7 @@ export function postWithAuthor(
   row: PostWithAuthor,
   engagement?: Engagement,
   tags: TagSummary[] = [],
+  recommendedBy: RecommendedBy | null = null,
 ) {
   return {
     id: row.post.id,
@@ -137,6 +158,12 @@ export function postWithAuthor(
     likeCount: engagement?.likeCount ?? 0,
     liked: engagement?.liked ?? false,
     commentCount: engagement?.commentCount ?? 0,
+    recommendCount: engagement?.recommendCount ?? 0,
+    recommended: engagement?.recommended ?? false,
+    // Present only on a "For you" feed item that arrived via a recommendation
+    // rather than authorship/follow; null everywhere else (profiles, Local,
+    // Global, search, …), which the frontend reads as "not a recommend entry".
+    recommendedBy,
   };
 }
 
@@ -252,7 +279,8 @@ export function notificationView(row: NotificationRow) {
       | "like"
       | "comment"
       | "reply"
-      | "comment_like",
+      | "comment_like"
+      | "recommend",
     actor,
     postId: n.postId,
     postTitle: row.postTitle,

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -4,6 +4,7 @@ import * as followsService from "@/services/follows.ts";
 import * as followRequestsService from "@/services/followRequests.ts";
 import * as postsService from "@/services/posts.ts";
 import * as usersService from "@/services/users.ts";
+import * as recommendationsService from "@/services/recommendations.ts";
 import * as relationsService from "@/services/relations.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
@@ -168,6 +169,22 @@ userRoutes.get("/:username/posts", async (c) => {
     user.id,
     cursor,
     viewer?.id ?? null,
+  );
+  return c.json({ items: await enrichPosts(items, viewer?.id ?? null), nextCursor });
+});
+
+// A user's "Recommendations" tab (public, cursor-paginated): posts they've
+// recommended, newest-recommended first. Filtered by the viewer's mutes/blocks
+// and the recommended posts' own visibility, same as /:username/posts.
+userRoutes.get("/:username/recommendations", async (c) => {
+  const viewer = c.get("user");
+  const user = await usersRepo.findByUsername(c.req.param("username"));
+  if (!user) throw notFound("User not found.");
+  const cursor = decodeCursor(c.req.query("cursor"));
+  const { items, nextCursor } = await recommendationsService.listByUser(
+    user.id,
+    viewer?.id ?? null,
+    cursor,
   );
   return c.json({ items: await enrichPosts(items, viewer?.id ?? null), nextCursor });
 });

--- a/apps/backend/src/services/engagement.ts
+++ b/apps/backend/src/services/engagement.ts
@@ -2,30 +2,45 @@
 import * as likesRepo from "@/db/repositories/likes.ts";
 import * as commentsRepo from "@/db/repositories/comments.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
-import { postWithAuthor } from "@/routes/serializers.ts";
+import * as recommendationsRepo from "@/db/repositories/recommendations.ts";
+import { postWithAuthor, type RecommendedBy } from "@/routes/serializers.ts";
 import type { PostWithAuthor } from "@/db/repositories/posts.ts";
 
-// Attaches like + comment engagement and tags to serialized posts. Counts (the
-// viewer's own like state) and tags are fetched in batched queries regardless
-// of how many posts are in the list, so feeds stay cheap.
+// Attaches like + comment + recommend engagement and tags to serialized posts.
+// Counts (and the viewer's own like/recommend state) and tags are fetched in
+// batched queries regardless of how many posts are in the list, so feeds stay
+// cheap.
 
-export async function enrichPosts(rows: PostWithAuthor[], viewerId: string | null) {
+// A row carries `recommendedBy` only when it reached the list via a
+// recommendation rather than authorship/follow (see services/feed.ts's merged
+// "For you" stream); every other listing leaves it unset.
+export type EnrichableRow = PostWithAuthor & { recommendedBy?: RecommendedBy | null };
+
+export async function enrichPosts(rows: EnrichableRow[], viewerId: string | null) {
   const ids = rows.map((r) => r.post.id);
-  const [likeStats, commentCounts, tagsByPost] = await Promise.all([
+  const [likeStats, commentCounts, tagsByPost, recommendStats] = await Promise.all([
     likesRepo.statsFor(ids, viewerId),
     commentsRepo.countsFor(ids),
     tagsRepo.tagsForPosts(ids),
+    recommendationsRepo.statsFor(ids, viewerId),
   ]);
   return rows.map((row) =>
-    postWithAuthor(row, {
-      likeCount: likeStats.get(row.post.id)?.count ?? 0,
-      liked: likeStats.get(row.post.id)?.liked ?? false,
-      commentCount: commentCounts.get(row.post.id) ?? 0,
-    }, tagsByPost.get(row.post.id) ?? [])
+    postWithAuthor(
+      row,
+      {
+        likeCount: likeStats.get(row.post.id)?.count ?? 0,
+        liked: likeStats.get(row.post.id)?.liked ?? false,
+        commentCount: commentCounts.get(row.post.id) ?? 0,
+        recommendCount: recommendStats.get(row.post.id)?.count ?? 0,
+        recommended: recommendStats.get(row.post.id)?.recommended ?? false,
+      },
+      tagsByPost.get(row.post.id) ?? [],
+      row.recommendedBy ?? null,
+    )
   );
 }
 
-export async function enrichPost(row: PostWithAuthor, viewerId: string | null) {
+export async function enrichPost(row: EnrichableRow, viewerId: string | null) {
   const [enriched] = await enrichPosts([row], viewerId);
   return enriched;
 }

--- a/apps/backend/src/services/feed.ts
+++ b/apps/backend/src/services/feed.ts
@@ -1,17 +1,162 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import * as postsRepo from "@/db/repositories/posts.ts";
-import { type Cursor, DEFAULT_PAGE_SIZE, encodeCursor } from "@/lib/pagination.ts";
+import * as recommendationsRepo from "@/db/repositories/recommendations.ts";
+import type { EnrichableRow } from "@/services/engagement.ts";
+import { type Cursor, DEFAULT_PAGE_SIZE } from "@/lib/pagination.ts";
 
-// Personalized home timeline: own posts + followed authors, cursor-paginated.
-export async function homeFeed(userId: string, cursor: Cursor | null) {
-  const rows = await postsRepo.listFeed(userId, cursor, DEFAULT_PAGE_SIZE);
-  const hasMore = rows.length > DEFAULT_PAGE_SIZE;
-  const items = hasMore ? rows.slice(0, DEFAULT_PAGE_SIZE) : rows;
-  const last = items.at(-1);
-  return {
-    items,
-    nextCursor: hasMore && last
-      ? encodeCursor({ createdAt: last.post.createdAt.toISOString(), id: last.post.id })
-      : null,
-  };
+// Personalized home timeline ("For you"): own + followed-author posts, merged
+// with posts *recommended* ("boosted") by followed authors — the two halves of
+// the feed's promise (recommendations never appear on Local or Global, only
+// here and on the recommender's profile "Recommendations" tab).
+//
+// The two sources sort on different clocks — a post's own publish time versus
+// the moment someone recommended it — so a single SQL query can't keyset-page
+// them together. Instead each is fetched as its own independently
+// keyset-paginated stream and merged here. The opaque cursor threads both
+// streams' positions (plus whether either is fully drained) so "load more"
+// resumes both correctly without ever re-showing or skipping a row.
+
+type StreamCursor = { cursor: Cursor | null; done: boolean };
+type FeedCursor = { authored: StreamCursor; recommended: StreamCursor };
+
+const START: StreamCursor = { cursor: null, done: false };
+const DONE: StreamCursor = { cursor: null, done: true };
+
+function decodeFeedCursor(raw: string | null): FeedCursor {
+  if (!raw) return { authored: START, recommended: START };
+  try {
+    const parsed = JSON.parse(atob(raw));
+    return { authored: parsed.authored ?? START, recommended: parsed.recommended ?? START };
+  } catch {
+    return { authored: START, recommended: START };
+  }
+}
+
+function encodeFeedCursor(c: FeedCursor): string {
+  return btoa(JSON.stringify(c));
+}
+
+type MergedRow =
+  | { source: "authored"; feedAt: Date; raw: postsRepo.PostWithAuthor }
+  | { source: "recommended"; feedAt: Date; raw: recommendationsRepo.FeedRecommendationRow };
+
+export async function homeFeed(userId: string, cursorRaw: string | null) {
+  const cursor = decodeFeedCursor(cursorRaw);
+  const limit = DEFAULT_PAGE_SIZE;
+
+  const [authoredRows, recommendedRows] = await Promise.all([
+    cursor.authored.done ? [] : postsRepo.listFeed(userId, cursor.authored.cursor, limit),
+    cursor.recommended.done
+      ? []
+      : recommendationsRepo.listFeedFor(userId, cursor.recommended.cursor, limit),
+  ]);
+
+  const authoredHasMore = authoredRows.length > limit;
+  const authoredPage = authoredHasMore ? authoredRows.slice(0, limit) : authoredRows;
+  const recommendedHasMore = recommendedRows.length > limit;
+  const recommendedPage = recommendedHasMore ? recommendedRows.slice(0, limit) : recommendedRows;
+
+  // Both pages are already sorted newest-first on their own clock; merge on
+  // that clock and take the newest `limit`. Array.sort is stable, so equal
+  // timestamps keep their original (authored-before-recommended) order.
+  const merged: MergedRow[] = [
+    ...authoredPage.map((raw): MergedRow => ({
+      source: "authored",
+      feedAt: raw.post.createdAt,
+      raw,
+    })),
+    ...recommendedPage.map((raw): MergedRow => ({
+      source: "recommended",
+      feedAt: raw.recommendedAt,
+      raw,
+    })),
+  ].sort((a, b) => b.feedAt.getTime() - a.feedAt.getTime());
+
+  const page = merged.slice(0, limit);
+
+  // The index of the last (lowest-ranked) row from each source that made it
+  // into this page — a forward scan keeping the latest match lands on it,
+  // since `page` is ordered newest-first.
+  let lastAuthoredIdx = -1;
+  let lastRecommendedIdx = -1;
+  page.forEach((row, i) => {
+    if (row.source === "authored") lastAuthoredIdx = i;
+    else lastRecommendedIdx = i;
+  });
+
+  // A stream's next cursor points right after the last row *of that stream*
+  // consumed this page; a stream that contributed nothing this page keeps its
+  // incoming cursor unchanged, so its untouched rows are re-offered (and
+  // re-merged) once the other stream's fresher rows are exhausted — never
+  // skipped, never duplicated. "Drained" only once the DB confirmed no more
+  // rows exist beyond what was fetched AND every fetched row was consumed.
+  function countSource(rows: MergedRow[], source: MergedRow["source"]): number {
+    return rows.reduce((n, r) => n + (r.source === source ? 1 : 0), 0);
+  }
+
+  function advance(
+    lastIdx: number,
+    source: MergedRow["source"],
+    fetchedCount: number,
+    hasMore: boolean,
+    incoming: StreamCursor,
+    cursorOf: (row: MergedRow) => Cursor,
+  ): StreamCursor {
+    if (lastIdx === -1) {
+      // Nothing from this source made this page. Empty + no more rows behind
+      // it: done. Otherwise its rows are still unconsumed — keep the incoming
+      // cursor so they're re-offered (and re-merged) next time.
+      return !hasMore && fetchedCount === 0 ? DONE : incoming;
+    }
+    // Drained only once the DB confirmed no more rows exist beyond what was
+    // fetched AND every one of those fetched rows was consumed this page —
+    // some may have been deferred to the next page by the merge/limit trim.
+    const drained = !hasMore && countSource(page, source) === fetchedCount;
+    return drained ? DONE : { cursor: cursorOf(page[lastIdx]), done: false };
+  }
+
+  const authored = advance(
+    lastAuthoredIdx,
+    "authored",
+    authoredPage.length,
+    authoredHasMore,
+    cursor.authored,
+    (row) => ({
+      createdAt: (row.raw as postsRepo.PostWithAuthor).post.createdAt.toISOString(),
+      id: (row.raw as postsRepo.PostWithAuthor).post.id,
+    }),
+  );
+  const recommended = advance(
+    lastRecommendedIdx,
+    "recommended",
+    recommendedPage.length,
+    recommendedHasMore,
+    cursor.recommended,
+    (row) => ({
+      createdAt: (row.raw as recommendationsRepo.FeedRecommendationRow).recommendedAt.toISOString(),
+      id: (row.raw as recommendationsRepo.FeedRecommendationRow).recommendationId,
+    }),
+  );
+
+  const nextCursor = authored.done && recommended.done
+    ? null
+    : encodeFeedCursor({ authored, recommended });
+
+  const items: EnrichableRow[] = page.map((row) =>
+    row.source === "authored" ? row.raw : {
+      post: row.raw.post,
+      localAuthor: row.raw.localAuthor,
+      remoteActor: row.raw.remoteActor,
+      recommendedBy: {
+        id: row.raw.recommenderId,
+        username: row.raw.recommenderUsername,
+        displayName: row.raw.recommenderDisplayName,
+        avatarUrl: row.raw.recommenderAvatarUrl,
+        remote: row.raw.recommenderRemote,
+        recommendedAt: row.raw.recommendedAt,
+      },
+    }
+  );
+
+  return { items, nextCursor };
 }

--- a/apps/backend/src/services/notifications.ts
+++ b/apps/backend/src/services/notifications.ts
@@ -15,7 +15,8 @@ export type NotificationType =
   | "like"
   | "comment"
   | "reply"
-  | "comment_like";
+  | "comment_like"
+  | "recommend";
 
 type NotifyParams = {
   recipientId: string;

--- a/apps/backend/src/services/recommendations.ts
+++ b/apps/backend/src/services/recommendations.ts
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import * as recommendationsRepo from "@/db/repositories/recommendations.ts";
+import * as postsRepo from "@/db/repositories/posts.ts";
+import * as relationsRepo from "@/db/repositories/relations.ts";
+import * as notifications from "@/services/notifications.ts";
+import { type Cursor, DEFAULT_PAGE_SIZE, encodeCursor } from "@/lib/pagination.ts";
+import { forbidden, notFound } from "@/lib/http.ts";
+import { queue } from "@/queue/queue.ts";
+
+// Business logic for recommending ("reposting") a post — federates as an
+// ActivityPub Announce/Undo(Announce) to the recommender's remote followers.
+// recommend/unrecommend mirror services/likes.ts: they return fresh stats so
+// the client can update the count + toggle state without a second request.
+
+async function statsOf(
+  postId: string,
+  viewerId: string,
+): Promise<recommendationsRepo.RecommendStats> {
+  const map = await recommendationsRepo.statsFor([postId], viewerId);
+  return map.get(postId) ?? { count: 0, recommended: false };
+}
+
+export async function recommend(userId: string, postId: string) {
+  const post = await postsRepo.findById(postId);
+  if (!post) throw notFound("Post not found.");
+  // A block forbids recommending the other party's post (either direction),
+  // the same rule liking a post follows.
+  const blocked = post.post.authorId
+    ? await relationsRepo.localBlockExists(userId, post.post.authorId)
+    : post.post.remoteActorId
+    ? await relationsRepo.hasRemote("block", userId, post.post.remoteActorId)
+    : false;
+  if (blocked) throw forbidden("You cannot recommend this post.");
+
+  await recommendationsRepo.add(postId, userId);
+  // Notify the post's author (local posts only; a remote post's author has no
+  // local recipient — they get an inbound notification instead, once their
+  // instance's own Announce delivery reaches us, which doesn't apply here).
+  if (post.post.authorId) {
+    await notifications.notify({
+      recipientId: post.post.authorId,
+      type: "recommend",
+      actorId: userId,
+      postId,
+    });
+  }
+  queue.add("send_recommend", { userId, postId });
+  return statsOf(postId, userId);
+}
+
+export async function unrecommend(userId: string, postId: string) {
+  const post = await postsRepo.findById(postId);
+  if (!post) throw notFound("Post not found.");
+  await recommendationsRepo.remove(postId, userId);
+  if (post.post.authorId) {
+    await notifications.unnotify({
+      recipientId: post.post.authorId,
+      type: "recommend",
+      actorId: userId,
+      postId,
+    });
+  }
+  queue.add("send_unrecommend", { userId, postId });
+  return statsOf(postId, userId);
+}
+
+// Cursor-paginated pages of {post, localAuthor, remoteActor, recommendedAt}
+// rows, keyed by the recommendation's own (createdAt, id) — the profile
+// "Recommendations" tab, local or remote.
+function pageOf(rows: recommendationsRepo.RecommendedPostRow[], limit: number) {
+  const hasMore = rows.length > limit;
+  const items = hasMore ? rows.slice(0, limit) : rows;
+  const last = items.at(-1);
+  return {
+    items,
+    nextCursor: hasMore && last
+      ? encodeCursor({ createdAt: last.recommendedAt.toISOString(), id: last.recommendationId })
+      : null,
+  };
+}
+
+export async function listByUser(userId: string, viewerId: string | null, cursor: Cursor | null) {
+  const rows = await recommendationsRepo.listByUser(userId, viewerId, cursor, DEFAULT_PAGE_SIZE);
+  return pageOf(rows, DEFAULT_PAGE_SIZE);
+}
+
+export async function listByRemoteActor(
+  remoteActorId: string,
+  viewerId: string | null,
+  cursor: Cursor | null,
+) {
+  const rows = await recommendationsRepo.listByRemoteActor(
+    remoteActorId,
+    viewerId,
+    cursor,
+    DEFAULT_PAGE_SIZE,
+  );
+  return pageOf(rows, DEFAULT_PAGE_SIZE);
+}

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -38,6 +38,7 @@ import type {
 import { makeApi } from "./client";
 
 type LikeState = { likeCount: number; liked: boolean };
+type RecommendState = { recommendCount: number; recommended: boolean };
 
 // The reader's feed language filter, forwarded to the timeline endpoints as
 // query params (see prefs.svelte.ts `feedLangQuery`).
@@ -225,9 +226,11 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     // Posts to read next, shown under an article (see relatedPosts service).
     relatedPosts: (id: string) => api.get<{ items: Post[] }>(`/posts/${id}/related`),
 
-    // likes + comments
+    // likes + recommends ("reposts", federate as ActivityPub Announce) + comments
     likePost: (id: string) => api.post<LikeState>(`/posts/${id}/like`),
     unlikePost: (id: string) => api.del<LikeState>(`/posts/${id}/like`),
+    recommendPost: (id: string) => api.post<RecommendState>(`/posts/${id}/recommend`),
+    unrecommendPost: (id: string) => api.del<RecommendState>(`/posts/${id}/recommend`),
     comments: (id: string, cursor?: string | null) =>
       api.get<Page<Comment>>(`/posts/${id}/comments${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""}`),
     createComment: (id: string, content: string, parentId?: string | null) =>
@@ -292,6 +295,9 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     profile: (username: string) => api.get<Profile>(`/users/${username}`),
     userPosts: (username: string, cursor?: string | null) =>
       api.get<Page<Post>>(`/users/${username}/posts${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""}`),
+    // A profile's "Recommendations" tab: posts they've recommended ("reposted").
+    userRecommendations: (username: string, cursor?: string | null) =>
+      api.get<Page<Post>>(`/users/${username}/recommendations${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""}`),
     follow: (username: string) => api.post<{ ok: true; state: "requested" | "following" }>(`/users/${username}/follow`),
     unfollow: (username: string) => api.del(`/users/${username}/follow`),
 
@@ -324,6 +330,12 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     remoteUserPosts: (handle: string, cursor?: string | null) =>
       api.get<Page<Post>>(
         `/remote/users/${encodeURIComponent(handle)}/posts${cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""}`,
+      ),
+    remoteUserRecommendations: (handle: string, cursor?: string | null) =>
+      api.get<Page<Post>>(
+        `/remote/users/${encodeURIComponent(handle)}/recommendations${
+          cursor ? `?cursor=${encodeURIComponent(cursor)}` : ""
+        }`,
       ),
     remoteFollow: (handle: string) => api.post(`/remote/users/${encodeURIComponent(handle)}/follow`),
     remoteUnfollow: (handle: string) => api.del(`/remote/users/${encodeURIComponent(handle)}/follow`),

--- a/apps/frontend/src/lib/components/Icon.svelte
+++ b/apps/frontend/src/lib/components/Icon.svelte
@@ -82,6 +82,7 @@
     Rss,
     Bell,
     TriangleAlert,
+    Repeat2,
   } from "@lucide/svelte";
 
   export const icons = {
@@ -164,6 +165,7 @@
     gavel: Gavel,
     table: Table,
     alert: TriangleAlert,
+    recommend: Repeat2,
   } as const;
 
   export type IconName = keyof typeof icons;

--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Icon from "$lib/components/Icon.svelte";
+  import RecommendButton from "$lib/components/RecommendButton.svelte";
   import SaveToListButton from "$lib/components/SaveToListButton.svelte";
   import TagList from "$lib/components/TagList.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
@@ -33,6 +34,19 @@
 </script>
 
 <article class="py-5">
+  {#if post.recommendedBy}
+    <!-- "For you" feed only: this post reached the viewer because someone they
+         follow recommended it, not because of its own author/date — flag that
+         above the byline, Twitter-repost-style, before anything else. -->
+    <Button
+      href={`/@${post.recommendedBy.username}`}
+      variant="plain"
+      class="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+    >
+      <Icon name="recommend" size={14} />
+      {post.recommendedBy.displayName} recommended this
+    </Button>
+  {/if}
   <div class="mb-3 flex items-center gap-2 text-sm text-foreground-alt">
     <Button href={`/@${post.author.username}`} variant="plain" class="flex min-w-0 items-center gap-2 hover:opacity-80">
       <Avatar name={post.author.displayName} src={post.author.avatarUrl ?? undefined} size={24} />
@@ -89,6 +103,9 @@
       <span class="flex items-center gap-1"><Icon name="heart" size={13} /> {post.likeCount}</span>
       <span class="flex items-center gap-1"><Icon name="comment" size={13} /> {post.commentCount}</span>
     </div>
-    <span class="ml-auto shrink-0"><SaveToListButton postId={post.id} {signedIn} /></span>
+    <span class="ml-auto flex shrink-0 items-center gap-1">
+      <RecommendButton postId={post.id} recommended={post.recommended} recommendCount={post.recommendCount} size="xs" />
+      <SaveToListButton postId={post.id} {signedIn} />
+    </span>
   </div>
 </article>

--- a/apps/frontend/src/lib/components/RecommendButton.svelte
+++ b/apps/frontend/src/lib/components/RecommendButton.svelte
@@ -1,0 +1,76 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { goto } from "$app/navigation";
+  import { page } from "$app/state";
+  import { endpoints } from "$lib/api";
+  import Icon from "$lib/components/Icon.svelte";
+  import Button from "$lib/components/ui/Button.svelte";
+  import { untrack } from "svelte";
+
+  // Recommend ("repost") toggle — federates as an ActivityPub
+  // Announce/Undo(Announce) to the signed-in user's remote followers. Mirrors
+  // the post page's Like button (same Button component, same optimistic-update-
+  // then-revert-on-failure shape). Props are re-seeded via `$effect` (not read
+  // once) because both call sites — PostCard in a list and the post detail
+  // page — can have this component's instance reused across a client-side
+  // navigation to a different post.
+  let {
+    postId,
+    recommended: recommendedProp,
+    recommendCount: recommendCountProp,
+    size = "default",
+  }: {
+    postId: string;
+    recommended: boolean;
+    recommendCount: number;
+    size?: "default" | "sm" | "xs";
+  } = $props();
+
+  const iconSize = $derived({ default: 18, sm: 16, xs: 14 }[size]);
+
+  let recommended = $state(untrack(() => recommendedProp));
+  let count = $state(untrack(() => recommendCountProp));
+  let busy = $state(false);
+
+  $effect(() => {
+    recommended = recommendedProp;
+    count = recommendCountProp;
+  });
+
+  async function toggle() {
+    if (!page.data.user) {
+      goto("/login");
+      return;
+    }
+    if (busy) return;
+    busy = true;
+    const was = recommended;
+    // Optimistic update.
+    recommended = !was;
+    count += recommended ? 1 : -1;
+    try {
+      const res = was ? await endpoints().unrecommendPost(postId) : await endpoints().recommendPost(postId);
+      recommended = res.recommended;
+      count = res.recommendCount;
+    } catch {
+      recommended = was;
+      count += was ? 1 : -1;
+    } finally {
+      busy = false;
+    }
+  }
+</script>
+
+<Button
+  onclick={toggle}
+  disabled={busy}
+  variant="ghost"
+  {size}
+  class={recommended ? "text-foreground" : "text-muted-foreground"}
+  aria-pressed={recommended}
+  aria-label={recommended ? "Remove recommendation" : "Recommend"}
+  title={recommended ? "Remove recommendation" : "Recommend"}
+>
+  <Icon name="recommend" size={iconSize} />
+  <span class="tabular-nums">{count}</span>
+</Button>

--- a/apps/frontend/src/lib/components/notifications.ts
+++ b/apps/frontend/src/lib/components/notifications.ts
@@ -21,6 +21,8 @@ export function notificationAction(type: Notification["type"]): string {
       return "replied to your comment";
     case "comment_like":
       return "liked your comment";
+    case "recommend":
+      return "recommended your post";
     default: {
       const exhaustive: never = type;
       return exhaustive;
@@ -43,6 +45,8 @@ export function notificationIcon(type: Notification["type"]): IconName {
       return "comment";
     case "reply":
       return "reply";
+    case "recommend":
+      return "recommend";
     default: {
       const exhaustive: never = type;
       return exhaustive;

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -101,6 +101,27 @@ export type Post = {
   likeCount: number;
   liked: boolean;
   commentCount: number;
+  // "Repost" — federates as ActivityPub Announce. `recommended` is the
+  // signed-in viewer's own state, mirroring `liked`.
+  recommendCount: number;
+  recommended: boolean;
+  // Present only on a "For you" feed item that reached the viewer via a
+  // recommendation from someone they follow, rather than authorship/follow —
+  // null on every other listing (profiles, Local, Global, search, …), and the
+  // signal the card uses to show its "X recommended this" banner.
+  recommendedBy?: RecommendedBy | null;
+};
+
+// Who recommended a post, and when — see `Post.recommendedBy`. Shaped like
+// `PostAuthor` (local-or-remote, `username` a `user@host` handle for a remote
+// recommender) so `/@${username}` resolves either way.
+export type RecommendedBy = {
+  id: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  remote: boolean;
+  recommendedAt: string;
 };
 
 // A publishing token for the content webhook, as shown on the owner's Settings
@@ -170,7 +191,8 @@ export type NotificationType =
   | "like"
   | "comment"
   | "reply"
-  | "comment_like";
+  | "comment_like"
+  | "recommend";
 
 export type Notification = {
   id: string;

--- a/apps/frontend/src/routes/[handle]/+page.server.ts
+++ b/apps/frontend/src/routes/[handle]/+page.server.ts
@@ -12,16 +12,21 @@ export const load: PageServerLoad = async ({ fetch, params }) => {
   const isRemote = handle.includes("@");
   try {
     if (isRemote) {
-      const [profile, posts] = await Promise.all([api.remoteProfile(handle), api.remoteUserPosts(handle)]);
-      return { remote: true as const, profile, page: posts };
+      const [profile, posts, recommendations] = await Promise.all([
+        api.remoteProfile(handle),
+        api.remoteUserPosts(handle),
+        api.remoteUserRecommendations(handle),
+      ]);
+      return { remote: true as const, profile, page: posts, recommendations };
     }
-    const [profile, posts, lists] = await Promise.all([
+    const [profile, posts, lists, recommendations] = await Promise.all([
       api.profile(handle),
       api.userPosts(handle),
       // Public lists (plus the owner's private ones, when they're the viewer).
       api.userLists(handle),
+      api.userRecommendations(handle),
     ]);
-    return { remote: false as const, profile, page: posts, lists: lists.lists };
+    return { remote: false as const, profile, page: posts, lists: lists.lists, recommendations };
   } catch (err) {
     if (err instanceof ApiError && err.status === 404) error(404, "User not found");
     throw err;

--- a/apps/frontend/src/routes/[handle]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/+page.svelte
@@ -63,6 +63,30 @@
     cursor = data.page.nextCursor;
   });
 
+  // "Recommendations" tab: posts this profile has recommended ("reposted").
+  let recommended = $state<Post[]>(untrack(() => data.recommendations.items));
+  let recommendedCursor = $state<string | null>(untrack(() => data.recommendations.nextCursor));
+  let recommendedLoading = $state(false);
+  $effect(() => {
+    recommended = data.recommendations.items;
+    recommendedCursor = data.recommendations.nextCursor;
+  });
+
+  async function loadMoreRecommended() {
+    if (!recommendedCursor) return;
+    recommendedLoading = true;
+    try {
+      const handle = profile.user.username;
+      const next = data.remote
+        ? await endpoints().remoteUserRecommendations(handle, recommendedCursor)
+        : await endpoints().userRecommendations(handle, recommendedCursor);
+      recommended = [...recommended, ...next.items];
+      recommendedCursor = next.nextCursor;
+    } finally {
+      recommendedLoading = false;
+    }
+  }
+
   // The full fediverse address (@user@host). Remote handles already carry the
   // host; for local users the host is the instance we're being served from, so
   // we read it from the browser once mounted (unknown during SSR).
@@ -252,6 +276,13 @@
         >Lists</Tabs.Trigger
       >
     {/if}
+    {#if !locked}
+      <Tabs.Trigger
+        value="recommendations"
+        class="-mb-px inline-flex items-center border-b border-transparent py-3 text-muted-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground"
+        >Recommendations</Tabs.Trigger
+      >
+    {/if}
     <Tabs.Trigger
       value="about"
       class="-mb-px inline-flex items-center border-b border-transparent py-3 text-muted-foreground data-[state=active]:border-foreground data-[state=active]:text-foreground"
@@ -298,6 +329,29 @@
             <ReadingListCard {list} />
           {/each}
         </div>
+      {/if}
+    </Tabs.Content>
+  {/if}
+
+  {#if !locked}
+    <Tabs.Content value="recommendations" class="select-none pt-3">
+      {#if recommended.length === 0}
+        <p class="py-10 text-center text-muted-foreground">
+          {isSelf
+            ? "You haven't recommended anything yet."
+            : `${profile.user.displayName} hasn't recommended anything yet.`}
+        </p>
+      {:else}
+        {#each recommended as post (post.id)}
+          <PostCard {post} />
+        {/each}
+        {#if recommendedCursor}
+          <div class="mt-8 flex justify-center">
+            <Button onclick={loadMoreRecommended} disabled={recommendedLoading} variant="outline">
+              {recommendedLoading ? "Loading…" : "Show more"}
+            </Button>
+          </div>
+        {/if}
       {/if}
     </Tabs.Content>
   {/if}

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -6,6 +6,7 @@
   import Icon from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import PostCard from "$lib/components/PostCard.svelte";
+  import RecommendButton from "$lib/components/RecommendButton.svelte";
   import SaveToListButton from "$lib/components/SaveToListButton.svelte";
   import TagList from "$lib/components/TagList.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
@@ -416,6 +417,7 @@
       <Icon name="comment" size={18} />
       <span class="tabular-nums">{commentCount}</span>
     </a>
+    <RecommendButton postId={post.id} recommended={post.recommended} recommendCount={post.recommendCount} />
     <div class="ml-auto inline-flex h-10 items-center px-2">
       <SaveToListButton postId={post.id} signedIn={!!data.user} />
     </div>


### PR DESCRIPTION
## Summary

Adds a repost/boost feature — ActivityPub `Announce`/`Undo(Announce)`, named "recommend" in the UI. A recommendation deliberately never appears on the Local or Global timelines; it only surfaces on the recommender's followers' "For you" feed and on the recommender's own profile, in a new "Recommendations" tab.

- **Data model**: a `recommendations` table, one row per (post, recommender), where the recommender is a local user or a cached remote actor — the same local-or-remote shape `follows`/`notifications` already use.
- **Federation**: outbound `Announce`/`Undo(Announce)` fan out to the recommender's remote followers; inbound `Announce`/`Undo(Announce)` ingests the boosted Article if not already cached (a shared `ingestArticle` helper was factored out of the existing inbound `Create` handler so both paths resolve the article's real attributed author, not the booster) and records a remote recommendation, notifying the post's local author.
- **Feed**: the "For you" feed now merges two independently keyset-paginated streams — authored/followed posts (existing) and posts recommended by followed accounts (new) — on their own clocks (a post's publish time vs. the moment it was recommended), via a compound opaque cursor that resumes both streams correctly without skipping or duplicating rows.
- **API**: `POST`/`DELETE /posts/:id/recommend`, `GET /users/:username/recommendations`, `GET /remote/users/:handle/recommendations`. Every post payload gains `recommendCount`/`recommended` (mirroring `likeCount`/`liked`); a "For you" item that arrived via a recommendation also carries `recommendedBy`.
- **UI**: a `RecommendButton` (styled like the existing Like button) on `PostCard` and the post detail page; a "recommended by X" banner on feed items that arrived via a recommendation; a "Recommendations" tab on local and remote profiles.

## Test plan

- [x] Backend: `deno check src/main.ts` — clean.
- [x] Backend: `deno test -A` — 149 passed, 0 failed.
- [x] Backend: `deno fmt` / `deno lint` — clean.
- [x] Frontend: `pnpm run svelte-check` — 0 errors, 0 warnings.
- [x] Frontend: `oxlint` / `oxfmt` — clean.
- [ ] Not run: no live Postgres/Redis or a second federated instance in this environment, so the migration and the outbound/inbound Announce exchange were not exercised end-to-end against a real database or a real remote server. The migration SQL is hand-written (idempotent `IF NOT EXISTS`, matching the style of the repo's other hand-written migrations) rather than `drizzle-kit generate`-derived, because this repo's committed `drizzle/meta/` snapshot chain has a pre-existing gap (only migrations 0012 and 0015 have snapshots) that makes `drizzle-kit generate` try to redo migrations 0016–0028; that generated migration was discarded in favor of hand-writing just the new table.

## Deploy notes

Additive-only migration (`0029_recommendations.sql`), applied automatically by the existing migration runner on next boot — no manual step needed.