### PR TITLE
fix(frontend): only show post-page hero for an explicit cover

### DIFF
--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -22,10 +22,16 @@
   let { data }: { data: PageData } = $props();
   const post = $derived(data.post);
   const minutes = $derived(readTime(post.contentHtml));
-  // A cover lives on whoever sent it; drop it rather than render a broken image.
+  // The hero above the article only renders for an explicit cover choice, not
+  // `bannerUrl`'s body-image fallback (see backend lib/cover.ts's `bannerOf`)
+  // — this is the one surface that also renders the full body, so promoting
+  // an arbitrary body image to a hero would either duplicate it (if it's
+  // already the post's opening element) or visually remove it from where the
+  // author placed it (if it isn't). Feed cards, share cards, and RSS still use
+  // `bannerUrl` as-is; they never show the body alongside it.
   let coverFailed = $state(false);
   $effect(() => {
-    void post.bannerUrl;
+    void post.coverUrl;
     coverFailed = false;
   });
   // Origin instance (host) parsed from a remote author's `user@host` handle.
@@ -324,7 +330,7 @@
     </DropdownMenu.Root>
   </div>
 
-  {#if post.bannerUrl && !coverFailed}
+  {#if post.coverUrl && !coverFailed}
     <!-- The cover is almost always this page's largest element, so it is what
          the browser (and Google's Core Web Vitals) times the load by.
 
@@ -342,7 +348,7 @@
     <div class="mb-8 aspect-[16/9] max-h-[28rem] w-full overflow-hidden rounded-card border border-border">
       <!-- Decorative: the headline above it already names the post. -->
       <img
-        src={post.bannerUrl}
+        src={post.coverUrl}
         alt=""
         fetchpriority="high"
         decoding="async"


### PR DESCRIPTION
## Symptom

On a post with no explicit cover image, the post page showed its own opening image twice: once as the hero banner above the title, and again immediately below as part of the article body.

## Root cause

`bannerOf()` (`apps/backend/src/lib/cover.ts`) resolves a post's `bannerUrl` as the author's explicit `coverUrl`, or failing that, the first `<img>` found anywhere in `contentHtml`. That fallback is deliberate and correct for surfaces that never render the body — feed cards, share/OG cards, RSS — where *some* representative image beats none.

The post detail page (`apps/frontend/src/routes/[handle]/[slug]/+page.svelte`) is different: it renders `bannerUrl` as a hero **and** the full `contentHtml` body via `{@html}` right below it, with nothing coordinating the two. When there was no explicit cover, both were pulling from the same source image — the fallback banner *is* the body's own opening picture, still present in the untouched body HTML.

(It's also not just a duplication issue: `firstBodyImage` matches the first `<img>` anywhere in the document, not necessarily the very first element. A post with a paragraph before its first image would have that image promoted to the top as the "banner" while it stayed rendered in its original spot further down — visually correct as a duplicate, but conceptually the image is shown out of the position the author put it in.)

## The fix

Gate the post page's hero block on `post.coverUrl` (the author's explicit choice) instead of `post.bannerUrl` (the derived fallback). A post with no explicit cover now just renders its body normally — any images appear once, wherever the author placed them, with no synthesized hero. `bannerUrl` itself, and every other surface that uses it (feed cards, share cards, RSS), is unchanged.

## What was verified

- `pnpm run svelte-check` — 0 errors/warnings across 4788 files.
- `pnpm exec oxfmt --check` / `pnpm exec oxlint` on the changed file — clean.
- Manually reasoned through both cases: post with an explicit cover (hero still shows, using `coverUrl` directly), and post with no cover (hero is gone, body renders its own images in place, no duplication).

Not run: an actual browser check against a live instance — I don't have one running here.

## Deploy notes

None — pure frontend template change, no new env vars, no API/schema changes, no docs-visible behavior change worth a docs update (the fallback banner used on feed cards/share previews/RSS is unchanged; this only affects layout on the post's own page).