### PR TITLE
feat(recommendations): randomize who-to-follow suggestions

### DIFF
--- a/apps/backend/src/services/users.ts
+++ b/apps/backend/src/services/users.ts
@@ -170,9 +170,30 @@ export async function setPrivacy(userId: string, isPrivate: boolean): Promise<Us
 // "Who to follow" suggestions for the discovery rail. Each suggestion carries
 // the actor summary (so `/@username` links + Follow work) plus a follower count
 // for a little social proof.
-export async function suggestedFollows(viewerId: string | null, limit = 5) {
-  const rows = await usersRepo.suggested(viewerId, limit);
-  return rows.map((r) => ({ ...relationActorLocal(r), followerCount: r.followerCount }));
+//
+// Drawn from a bounded pool of the most-followed eligible accounts (same
+// indexed query as before, just a bigger LIMIT) and shuffled in memory, so
+// every visitor doesn't see the identical three people. That's cheaper than
+// `ORDER BY random()` in the query itself, which can't use an index and forces
+// Postgres to sort the whole matching set on every request.
+const SUGGESTION_POOL_SIZE = 20;
+
+export async function suggestedFollows(viewerId: string | null, count = 3) {
+  const pool = await usersRepo.suggested(viewerId, SUGGESTION_POOL_SIZE);
+  const picked = sampleRandom(pool, count);
+  return picked.map((r) => ({ ...relationActorLocal(r), followerCount: r.followerCount }));
+}
+
+// Partial Fisher-Yates: only shuffles the first `count` positions, so picking
+// a handful out of the pool stays O(count) rather than O(pool).
+function sampleRandom<T>(items: T[], count: number): T[] {
+  const pool = [...items];
+  const n = Math.min(count, pool.length);
+  for (let i = 0; i < n; i++) {
+    const j = i + Math.floor(Math.random() * (pool.length - i));
+    [pool[i], pool[j]] = [pool[j], pool[i]];
+  }
+  return pool.slice(0, n);
 }
 
 // A user's profile links, for the public profile and the settings editor.


### PR DESCRIPTION
## Summary

The "who to follow" rail on the right sidebar always showed the same top-5-by-follower-count accounts to every visitor — a fixed leaderboard with no rotation.

## Root cause

`suggestedFollows` (`apps/backend/src/services/users.ts`) fetched a deterministic `ORDER BY followerCount DESC, createdAt DESC LIMIT 5` from `usersRepo.suggested` and returned it as-is, so the result was identical for every request (modulo the viewer-specific exclusions).

## Fix

Instead of adding `ORDER BY random()` to the SQL query — which can't use an index and forces Postgres to sort the whole matching set on every request, getting slower as the `users`/`follows` tables grow — the service now:

- calls the same repo query with a larger `LIMIT 20` (bounded pool of the most-followed eligible accounts, still index-friendly)
- does a partial Fisher-Yates shuffle in memory to pick 3, an O(count) operation regardless of table size

This keeps suggestions biased toward accounts with real social proof while no longer showing the identical three people to everyone.

The `/users/suggested` route and response shape are unchanged; the frontend's existing `.slice(0, 3)` cap in `+layout.server.ts` still applies harmlessly.

## What was verified

- `deno check src/services/users.ts` passes
- Manually reasoned through the exclusion logic (viewer, already-followed, blocks, suspended) — untouched, still applied in the repo query before pooling/shuffling
- Not verified: no automated test added for the randomization itself (would need to seed >20 eligible accounts and assert distribution, which felt like overkill for a UI randomization tweak)

## Deploy notes

None — plain code change, no new env vars, no migration.