### PR TITLE
fix(frontend): mobile alignment on post header

### DIFF
--- a/apps/frontend/src/lib/components/ProfileMenu.svelte
+++ b/apps/frontend/src/lib/components/ProfileMenu.svelte
@@ -59,7 +59,7 @@
     disabled={busy}
     aria-label="More actions"
     title="More actions"
-    class="inline-flex size-10 select-none items-center justify-center rounded-full border border-input text-foreground shadow-btn hover:bg-muted active:scale-[0.98]"
+    class="inline-flex size-10 shrink-0 select-none items-center justify-center rounded-full border border-input text-foreground shadow-btn hover:bg-muted active:scale-[0.98]"
   >
     <Icon name="more" size={18} />
   </DropdownMenu.Trigger>

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -290,7 +290,7 @@
 
     <DropdownMenu.Root>
       <DropdownMenu.Trigger
-        class="ml-auto inline-flex size-9 items-center justify-center rounded-full border border-input text-muted-foreground shadow-btn hover:bg-muted hover:text-foreground active:scale-[0.98]"
+        class="ml-auto inline-flex size-9 shrink-0 items-center justify-center rounded-full border border-input text-muted-foreground shadow-btn hover:bg-muted hover:text-foreground active:scale-[0.98]"
         aria-label="Post options"
       >
         <Icon name="more" size={18} />

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -257,31 +257,22 @@
     <h1 class="mb-4 text-3xl font-bold leading-tight tracking-tight text-foreground sm:text-4xl">{post.title}</h1>
   {/if}
 
-  <div class="flex items-center gap-3 pb-8">
+  <div class="flex items-start gap-3 pb-8">
     <Avatar name={post.author.displayName} src={post.author.avatarUrl ?? undefined} size={44} />
-    <div class="text-sm">
+    <div class="min-w-0 flex-1 text-sm">
       <Button href={`/@${post.author.username}`} variant="plain" class="font-medium text-foreground hover:underline">
         {post.author.displayName}
       </Button>
-      <div class="flex flex-wrap items-center gap-2 text-muted-foreground">
+      <div class="flex flex-col gap-1 text-muted-foreground sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
         <span>{formatDateTime(post.createdAt, $timeZone)}</span>
-        <Separator.Root
-          orientation="vertical"
-          class="shrink-0 bg-border data-[orientation=vertical]:h-3 data-[orientation=vertical]:w-px"
-        />
+        <Separator.Root orientation="vertical" class="hidden shrink-0 bg-border sm:block sm:h-3 sm:w-px" />
         <span class="flex items-center gap-1"><Icon name="clock" size={13} /> {minutes} min read</span>
         {#if post.remote && originInstance}
-          <Separator.Root
-            orientation="vertical"
-            class="shrink-0 bg-border data-[orientation=vertical]:h-3 data-[orientation=vertical]:w-px"
-          />
+          <Separator.Root orientation="vertical" class="hidden shrink-0 bg-border sm:block sm:h-3 sm:w-px" />
           <span class="flex items-center gap-1"><Icon name="globe" size={13} /> {originInstance}</span>
         {/if}
         {#if post.language}
-          <Separator.Root
-            orientation="vertical"
-            class="shrink-0 bg-border data-[orientation=vertical]:h-3 data-[orientation=vertical]:w-px"
-          />
+          <Separator.Root orientation="vertical" class="hidden shrink-0 bg-border sm:block sm:h-3 sm:w-px" />
           <span class="flex items-center gap-1"><Icon name="languages" size={13} /> {languageLabel(post.language)}</span
           >
         {/if}


### PR DESCRIPTION
## Symptom
On some mobile browsers/widths, the post-page "..." options button rendered as an oval instead of a circle, and the byline metadata (date, read time, origin, language) wrapped awkwardly, leaving a vertical separator `|` dangling at the end of a line with its paired text alone on the next line.

## Root cause
- The options-button `DropdownMenu.Trigger` sits in a flex row with a growing text sibling but had no `shrink-0`, unlike `Avatar.svelte` which already sets it for this exact reason. Under a tight mobile width, flexbox compressed the button's width while its height stayed fixed by `size-9`, distorting the circle.
- The metadata row used a single wrapping flex row with `Separator.Root` as standalone flex children between items. When an item didn't fit, it wrapped alone, orphaning the separator before it.

## Fix
- Added `shrink-0` to the post-page trigger and to the equivalent trigger in `ProfileMenu.svelte` (same reusable pattern, same risk).
- Stack the metadata vertically (`flex-col`) below the `sm:` breakpoint, hiding the vertical separators there, and reverting to the original horizontal row with separators at `sm:` and up.
- Aligned the avatar and options-button to the top of the row (`items-start`) instead of centering against a block whose height now varies with how much metadata wraps.

## What was verified
- `svelte-check` (0 errors) and `oxlint`/`oxfmt` pass on the touched files.
- Not verified against the live app: no backend/Postgres is running in this environment and no headless browser was available, so this hasn't been screenshotted against real post data on an actual mobile viewport. The change is a straightforward, well-scoped Tailwind flex/breakpoint adjustment following an existing pattern in the codebase, but should get a quick look on a real device before merging.

## Deploy notes
None — frontend-only styling change, no env/config/API changes.