### PR TITLE
chore(deploy): auto-prune build cache on install and upgrade

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,11 @@
 # them from files, so no credentials are ever hardcoded or hand-typed.
 #
 # Upgrades:
-#   git pull && docker compose up -d --build
+#   git pull && docker compose up -d --build && docker image prune -f && docker builder prune -f
 # Migrations run automatically on backend startup; data lives in the `pgdata`
 # volume and secrets in the `secrets` volume, so upgrades never lose content.
+# `image prune`/`builder prune` only drop untagged image layers and build
+# cache — they never touch a named volume, so this is safe to run every time.
 
 services:
   # Generates any missing secrets once, then exits. Postgres, the backend and

--- a/install.sh
+++ b/install.sh
@@ -88,8 +88,17 @@ log "Building and starting the stack (first run compiles images; this can take a
 # shellcheck disable=SC2086
 $COMPOSE up -d --build
 
+# Drop dangling image layers and build cache left behind by the rebuild.
+# `image prune`/`builder prune` only ever remove untagged, unused layers — never
+# a named volume, so pgdata/uploads/secrets/etc. (and any running container)
+# are untouched. Runs on every install and upgrade so cache never piles up.
+log "Clearing build cache…"
+"$ENGINE" image prune -f >/dev/null 2>&1 || true
+"$ENGINE" builder prune -f >/dev/null 2>&1 || true
+
 log "Done. Omicron is starting."
 printf '  • Local:   http://localhost%s\n' "$([ -n "${HTTP_PORT:-}" ] && [ "${HTTP_PORT}" != "80" ] && printf ':%s' "$HTTP_PORT")"
 printf '  • Public:  point a DNS A record at this host, then finish the web wizard — HTTPS is automatic.\n'
 printf '  • Logs:    (cd %s && %s logs -f)\n' "$OMICRON_DIR" "$COMPOSE"
-printf '  • Upgrade: (cd %s && git pull && %s up -d --build)\n' "$OMICRON_DIR" "$COMPOSE"
+printf '  • Upgrade: (cd %s && git pull && %s up -d --build && %s image prune -f && %s builder prune -f)\n' \
+  "$OMICRON_DIR" "$COMPOSE" "$ENGINE" "$ENGINE"


### PR DESCRIPTION
## Symptom
Every `compose up -d --build` (initial install or upgrade) leaves the previous image's now-untagged layers and the engine's build cache behind on disk. There's no built-in way to reclaim it — an operator has to know to run `docker/podman image prune` / `builder prune` by hand, and nothing prompts them to.

## Fix
`install.sh` now runs `"$ENGINE" image prune -f` and `"$ENGINE" builder prune -f` right after `$COMPOSE up -d --build`, so cache never accumulates whether this is a first install or a re-run for an upgrade. The `docker-compose.yml` header comment and the script's printed "Upgrade:" hint are updated to the same two extra commands, so anyone upgrading by hand (not re-running install.sh) gets the same behavior.

**Why not put this in the Dockerfiles**, which is what was first asked for: a `Dockerfile` only defines what happens inside one image's build context — it has no visibility into the host's other images, containers, or the engine's build-cache store, so a prune command inside `RUN` would either no-op or (with a mounted host socket) be actively dangerous. The prune has to run on the host, after the build, which is what `install.sh` now does automatically.

## What was verified
- `sh -n install.sh` — syntax OK.
- Manually confirmed `image prune`/`builder prune` on both `docker` and `podman` only ever remove untagged image layers and build-cache blobs — they never touch a named volume, so `pgdata`, `uploads`, `secrets`, `redis_data`, `caddy_data`, `caddy_config` are untouched regardless of engine.
- Not run against a live `compose up -d --build` end to end in this environment (no full stack running here) — the two prune commands are standard, well-documented flags for both engines, but worth a real upgrade run to confirm output/log ordering looks right.

## Deploy notes
Pure script/doc change — nothing to redeploy. Existing instances pick this up next time they re-run `install.sh` or `git pull` and run the (now updated) upgrade command from the compose file's comment.

## Docs
`../omicron-docs/src/content/docs/self-hosting/upgrading.mdx` (and a few other pages) show the old `git pull && docker compose up -d --build` upgrade command without the prune step — flagging separately per CLAUDE.md, not touching it here.