### PR TITLE
feat(admin): let admins customize the signed-out visitor banner

### DIFF
--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -8,6 +8,7 @@ import * as unsplash from "@/services/unsplash.ts";
 import * as moderation from "@/services/moderation.ts";
 import * as emailSettings from "@/services/emailSettings.ts";
 import * as setup from "@/services/instanceSetup.ts";
+import * as mediaService from "@/services/media.ts";
 import { sendTestEmail } from "@/services/email.ts";
 import { dnsRecords } from "@/services/dkim.ts";
 import { checkOutboundPort25, verifyRecords } from "@/services/emailDns.ts";
@@ -134,6 +135,8 @@ async function instanceSnapshot() {
     federationEnabled: await setup.getFederationEnabled(),
     federationRunning: federationRunning(),
     sessionSecretManaged: sessionSecretManaged(),
+    bannerText: await setup.getBannerText(),
+    bannerImageUrl: await setup.getBannerImageUrl(),
   };
 }
 
@@ -146,12 +149,16 @@ const instanceSchema = z.object({
   appName: z.string().trim().min(1, "An instance name is required.").max(100).optional(),
   appDomain: z.string().trim().max(253).optional(),
   federationEnabled: z.boolean().optional(),
+  // The tagline on the signed-out visitor card. An empty string clears it back
+  // to the built-in default sentence.
+  bannerText: z.string().trim().max(280).optional(),
 });
 
-// Update the app name / public domain / federation toggle. A domain change
-// reaches ActivityPub only after a restart (federation identity binds at boot),
-// as does flipping federation on/off (the Fedify mount and queue handlers bind at
-// boot); app-level name/URLs update at once. The UI surfaces those caveats.
+// Update the app name / public domain / federation toggle / banner tagline. A
+// domain change reaches ActivityPub only after a restart (federation identity
+// binds at boot), as does flipping federation on/off (the Fedify mount and
+// queue handlers bind at boot); app-level name/URLs/banner text update at
+// once. The UI surfaces those caveats.
 adminRoutes.put("/instance", async (c) => {
   requireAdmin(c);
   const parsed = instanceSchema.safeParse(await c.req.json().catch(() => null));
@@ -162,6 +169,27 @@ adminRoutes.put("/instance", async (c) => {
   if (parsed.data.federationEnabled !== undefined) {
     await setup.setFederationEnabled(parsed.data.federationEnabled);
   }
+  return c.json(await instanceSnapshot());
+});
+
+// Upload the banner image shown on the signed-out visitor card. Reuses the same
+// validated, size-capped, magic-byte-checked disk storage as post/avatar
+// uploads (see services/media.ts); the browser has already downscaled and
+// re-encoded the image before it reaches here (see lib/editor/image.ts), so
+// this layer only validates and persists.
+adminRoutes.post("/instance/banner", async (c) => {
+  requireAdmin(c);
+  const contentType = (c.req.header("content-type") ?? "").split(";")[0].trim();
+  const bytes = new Uint8Array(await c.req.arrayBuffer());
+  const url = await mediaService.saveImage(bytes, contentType);
+  await setup.setBannerImageUrl(url);
+  return c.json(await instanceSnapshot(), 201);
+});
+
+// Revert the banner image to the bundled default artwork.
+adminRoutes.delete("/instance/banner", async (c) => {
+  requireAdmin(c);
+  await setup.setBannerImageUrl(null);
   return c.json(await instanceSnapshot());
 });
 

--- a/apps/backend/src/services/instanceSetup.ts
+++ b/apps/backend/src/services/instanceSetup.ts
@@ -17,6 +17,8 @@ export const SETUP_KEYS = {
   appDomain: "instance.appDomain",
   federationEnabled: "instance.federationEnabled",
   emailMode: "email.mode",
+  bannerText: "instance.bannerText",
+  bannerImageUrl: "instance.bannerImageUrl",
 } as const;
 
 // Setup is complete once the wizard has finished — or, as a fallback, once any
@@ -111,15 +113,45 @@ export async function isTlsDomainAllowed(domain: string): Promise<boolean> {
 // Update the instance identity from the admin page (runtime config). Mirrors the
 // wizard, but usable after setup. An empty domain is stored as-is and falls back
 // to the env/default in getAppDomain, so clearing it reverts to the boot value.
+// `bannerText` follows the same clear-to-revert rule: an explicit empty string
+// is stored (falls back to the built-in sentence in the UI), `undefined` leaves
+// the current value untouched.
 export async function setInstanceIdentity(input: {
   appName?: string;
   appDomain?: string;
+  bannerText?: string;
 }): Promise<void> {
   const name = input.appName?.trim();
   if (name) await settingsRepo.set(SETUP_KEYS.appName, name);
   if (input.appDomain !== undefined) {
     await settingsRepo.set(SETUP_KEYS.appDomain, input.appDomain.trim());
   }
+  if (input.bannerText !== undefined) {
+    await settingsRepo.set(SETUP_KEYS.bannerText, input.bannerText.trim());
+  }
+}
+
+// The admin-set tagline for the signed-out visitor card, or null when unset —
+// callers fall back to the built-in "An independent <name> instance in the
+// fediverse." sentence in that case, so an unconfigured instance still reads
+// naturally.
+export async function getBannerText(): Promise<string | null> {
+  const fromDb = await settingsRepo.get<string>(SETUP_KEYS.bannerText);
+  return fromDb?.trim() || null;
+}
+
+// The admin-uploaded banner image URL for the signed-out visitor card, or null
+// when unset — callers fall back to the bundled default artwork.
+export async function getBannerImageUrl(): Promise<string | null> {
+  const fromDb = await settingsRepo.get<string>(SETUP_KEYS.bannerImageUrl);
+  return fromDb?.trim() || null;
+}
+
+// Persist (or, with `null`, clear) the banner image URL. Clearing only drops
+// the setting — the uploaded file itself is left on disk, same as removing an
+// avatar, since nothing else references it for cleanup.
+export async function setBannerImageUrl(url: string | null): Promise<void> {
+  await settingsRepo.set(SETUP_KEYS.bannerImageUrl, url ?? "");
 }
 
 // A public snapshot of the instance's identity, safe to expose unauthenticated.
@@ -128,13 +160,17 @@ export async function publicInfo(): Promise<{
   domain: string;
   federationEnabled: boolean;
   setupComplete: boolean;
+  bannerText: string | null;
+  bannerImageUrl: string | null;
 }> {
-  const [name, domain, setupComplete] = await Promise.all([
+  const [name, domain, setupComplete, bannerText, bannerImageUrl] = await Promise.all([
     getAppName(),
     getAppDomain(),
     isSetupComplete(),
+    getBannerText(),
+    getBannerImageUrl(),
   ]);
-  return { name, domain, federationEnabled: federationRunning(), setupComplete };
+  return { name, domain, federationEnabled: federationRunning(), setupComplete, bannerText, bannerImageUrl };
 }
 
 // Persists the wizard's instance settings and marks setup finished. The admin

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -100,10 +100,18 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
 
     // admin instance identity (name + domain + federation toggle, restart-applied)
     adminInstance: () => api.get<AdminInstance>("/admin/instance"),
-    setAdminInstance: (body: { appName?: string; appDomain?: string; federationEnabled?: boolean }) =>
-      api.put<AdminInstance>("/admin/instance", body),
+    setAdminInstance: (body: {
+      appName?: string;
+      appDomain?: string;
+      federationEnabled?: boolean;
+      bannerText?: string;
+    }) => api.put<AdminInstance>("/admin/instance", body),
     // Rotate the auto-managed session secret (takes effect on restart, signs out).
     rotateSessionSecret: () => api.post<{ ok: true }>("/admin/instance/rotate-secret", {}),
+    // Signed-out visitor card banner image: upload a new one, or revert to default.
+    uploadInstanceBanner: (blob: Blob, contentType: string) =>
+      api.postRaw<AdminInstance>("/admin/instance/banner", blob, contentType),
+    removeInstanceBanner: () => api.del<AdminInstance>("/admin/instance/banner"),
 
     // admin security: the AI-scraper shield (Anubis), toggled live via Caddy.
     adminSecurity: () => api.get<SecuritySettings>("/admin/security"),

--- a/apps/frontend/src/lib/components/AdminInstanceSettings.svelte
+++ b/apps/frontend/src/lib/components/AdminInstanceSettings.svelte
@@ -3,24 +3,33 @@
   import { endpoints, ApiError } from "$lib/api";
   import Icon from "$lib/components/Icon.svelte";
   import Button from "$lib/components/ui/Button.svelte";
+  import { INSTANCE_BANNER_MAX_DIMENSION, isAcceptedImage, prepareImage } from "$lib/editor/image";
   import type { AdminInstance } from "$lib/types";
   import { Dialog, Label, Switch } from "bits-ui";
 
-  // Runtime instance identity: app name + public domain + the federation toggle,
-  // all editable after setup so an operator never returns to a config file. The
-  // domain change and the federation toggle bind at boot, so both apply on the
-  // next restart — surfaced inline. Admin-only (mounted from the admin page).
+  // Runtime instance identity: app name + public domain + the federation toggle
+  // + the signed-out visitor card (banner text + image), all editable after
+  // setup so an operator never returns to a config file or a hardcoded string.
+  // The domain change and the federation toggle bind at boot, so both apply on
+  // the next restart — surfaced inline. Admin-only (mounted from the admin
+  // page).
   let appName = $state("");
   let appDomain = $state("");
   // Desired federation state (what applies on restart) vs what's running now.
   let federationEnabled = $state(false);
   let federationRunning = $state(false);
   let sessionSecretManaged = $state(false);
+  let bannerText = $state("");
+  let bannerImageUrl = $state<string | null>(null);
 
   let loading = $state(true);
   let saving = $state(false);
   let error = $state("");
   let saved = $state(false);
+
+  let bannerFileInput = $state<HTMLInputElement | null>(null);
+  let bannerUploading = $state(false);
+  let bannerError = $state("");
 
   // Rotate-secret dialog state.
   let rotateOpen = $state(false);
@@ -42,6 +51,8 @@
     federationEnabled = s.federationEnabled;
     federationRunning = s.federationRunning;
     sessionSecretManaged = s.sessionSecretManaged;
+    bannerText = s.bannerText ?? "";
+    bannerImageUrl = s.bannerImageUrl;
   }
 
   $effect(() => {
@@ -62,6 +73,7 @@
           appName: appName.trim(),
           appDomain: appDomain.trim(),
           federationEnabled,
+          bannerText: bannerText.trim(),
         }),
       );
       saved = true;
@@ -69,6 +81,42 @@
       error = e instanceof ApiError ? e.message : "Failed to save.";
     } finally {
       saving = false;
+    }
+  }
+
+  async function onBannerFile(e: Event) {
+    const file = (e.target as HTMLInputElement).files?.[0];
+    // Reset the input so re-picking the same file fires `change` again.
+    (e.target as HTMLInputElement).value = "";
+    if (!file) return;
+    if (!isAcceptedImage(file)) {
+      bannerError = "Unsupported image type. Use PNG, JPEG, WebP, or GIF.";
+      return;
+    }
+    bannerError = "";
+    bannerUploading = true;
+    try {
+      const { blob, type } = await prepareImage(file, INSTANCE_BANNER_MAX_DIMENSION);
+      // Only take the image URL from the response, not the whole snapshot —
+      // the rest of this form (name/domain/banner text) may hold unsaved edits
+      // that a full `apply()` here would silently overwrite.
+      bannerImageUrl = (await endpoints().uploadInstanceBanner(blob, type)).bannerImageUrl;
+    } catch (e) {
+      bannerError = e instanceof ApiError ? e.message : "Failed to upload the banner image.";
+    } finally {
+      bannerUploading = false;
+    }
+  }
+
+  async function removeBanner() {
+    bannerError = "";
+    bannerUploading = true;
+    try {
+      bannerImageUrl = (await endpoints().removeInstanceBanner()).bannerImageUrl;
+    } catch (e) {
+      bannerError = e instanceof ApiError ? e.message : "Failed to remove the banner image.";
+    } finally {
+      bannerUploading = false;
     }
   }
 
@@ -107,6 +155,73 @@
       Used for links in email and share cards. A change applies to app URLs at once, but reaches ActivityPub only after
       a restart (federation identity binds at boot).
     </p>
+  </div>
+
+  <div class="flex flex-col gap-3 rounded-card border border-border bg-background-alt p-3.5">
+    <div class="flex flex-col gap-0.5">
+      <span class={labelClass}>Signed-out visitor card</span>
+      <p class="text-xs text-muted-foreground">
+        Shown to signed-out visitors alongside "Create account" / "Sign in". Left blank, the tagline defaults to "An
+        independent {appName || "Omicron"} instance in the fediverse." and the image to the bundled artwork.
+      </p>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <Label.Root for="admin-bannerText" class={labelClass}>Banner text</Label.Root>
+      <input
+        id="admin-bannerText"
+        bind:value={bannerText}
+        disabled={loading}
+        maxlength={280}
+        placeholder="An independent {appName || 'Omicron'} instance in the fediverse."
+        class={field}
+      />
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <span class={labelClass}>Banner image</span>
+      <div class="flex items-center gap-3">
+        <div
+          class="aspect-[2/1] w-32 shrink-0 overflow-hidden rounded-card border border-border bg-background {bannerImageUrl
+            ? ''
+            : 'flex items-center justify-center text-muted-foreground'}"
+        >
+          {#if bannerImageUrl}
+            <img src={bannerImageUrl} alt="" class="h-full w-full object-cover" />
+          {:else}
+            <Icon name="image" size={18} />
+          {/if}
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <div class="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onclick={() => bannerFileInput?.click()}
+              disabled={bannerUploading}
+            >
+              <Icon name="image" size={15} />
+              {bannerUploading ? "Uploading…" : "Upload"}
+            </Button>
+            {#if bannerImageUrl}
+              <Button type="button" variant="ghost" size="sm" onclick={removeBanner} disabled={bannerUploading}>
+                <Icon name="close" size={15} /> Reset to default
+              </Button>
+            {/if}
+          </div>
+          <p class="text-xs text-muted-foreground">Resized and re-encoded to WebP automatically for fast loading.</p>
+        </div>
+      </div>
+      {#if bannerError}<p class="text-sm text-destructive">{bannerError}</p>{/if}
+      <input
+        bind:this={bannerFileInput}
+        type="file"
+        accept="image/png,image/jpeg,image/webp,image/gif"
+        onchange={onBannerFile}
+        class="hidden"
+      />
+    </div>
   </div>
 
   <div class="flex items-start justify-between gap-3 rounded-card border border-border bg-background-alt px-3.5 py-3">

--- a/apps/frontend/src/lib/components/SideNav.svelte
+++ b/apps/frontend/src/lib/components/SideNav.svelte
@@ -75,12 +75,14 @@
          the bottom (mt-auto) and sticky with the rest of the rail, so it stays
          on screen rather than scrolling away with the hero. -->
     <div class="mt-auto flex flex-col overflow-hidden rounded-card border border-border bg-background-alt text-xs">
-      <img src={welcomeBanner} alt="" class="aspect-[2/1] w-full object-cover" />
+      <img src={instance?.bannerImageUrl || welcomeBanner} alt="" class="aspect-[2/1] w-full object-cover" />
 
       <div class="flex flex-col gap-2.5 p-3">
         <div>
           <p class="text-sm font-semibold text-foreground">{instance?.domain || appName}</p>
-          <p class="mt-0.5 text-muted-foreground">An independent {appName} instance in the fediverse.</p>
+          <p class="mt-0.5 text-muted-foreground">
+            {instance?.bannerText || `An independent ${appName} instance in the fediverse.`}
+          </p>
         </div>
 
         <div class="flex flex-col gap-1.5">

--- a/apps/frontend/src/lib/editor/image.ts
+++ b/apps/frontend/src/lib/editor/image.ts
@@ -11,6 +11,10 @@ const MAX_DIMENSION = 1600;
 // feeds); 160px covers that at 2x retina without shipping an oversized photo that
 // Lighthouse flags as larger than its displayed dimensions.
 export const AVATAR_MAX_DIMENSION = 160;
+// The signed-out visitor card banner (SideNav) renders at sidebar width, well
+// under 300px wide even on a wide desktop; 800px covers that at 2x-3x density
+// without shipping a full-bleed-sized photo for a thumbnail-sized slot.
+export const INSTANCE_BANNER_MAX_DIMENSION = 800;
 // WebP quality — a good size/quality trade-off for photographic content.
 const WEBP_QUALITY = 0.82;
 

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -381,6 +381,10 @@ export type InstanceInfo = {
   domain: string;
   federationEnabled: boolean;
   setupComplete: boolean;
+  // Admin-customizable signed-out visitor card; null means "use the built-in
+  // default" (a generated sentence / the bundled artwork).
+  bannerText: string | null;
+  bannerImageUrl: string | null;
 };
 
 // Web-managed email settings. `EmailInput` is what the wizard/admin form sends
@@ -441,6 +445,8 @@ export type AdminInstance = {
   federationEnabled: boolean;
   federationRunning: boolean;
   sessionSecretManaged: boolean;
+  bannerText: string | null;
+  bannerImageUrl: string | null;
 };
 
 // ── moderation (admin only) ──


### PR DESCRIPTION
## Symptom

The signed-out visitor card added in #36 shows a hardcoded tagline ("An
independent \<name\> instance in the fediverse.") and a bundled default
image on every instance, with no way for an admin to make it their own.

## The fix

Adds `bannerText` / `bannerImageUrl` to the instance settings (same
key/value store as the rest of `instanceSetup.ts`), each nullable so an
unset value falls back to the previous default sentence / artwork —
existing instances are unaffected until an admin opts in.

- `PUT /admin/instance` gains an optional `bannerText` field, alongside
  the existing app name/domain/federation fields.
- New `POST` / `DELETE /admin/instance/banner` upload/reset the banner
  image, reusing the existing validated, size-capped, magic-byte-checked
  `services/media.ts` storage path used by post/avatar uploads.
- The uploaded image is optimized automatically: the browser downscales
  and re-encodes it to WebP before it's sent (same `prepareImage()`
  pipeline already used for avatars and post banners), so no extra
  server-side image library was needed.
- `Admin → Instance` gets a new "Signed-out visitor card" section with a
  text field and an upload/reset control for the image.
- `SideNav.svelte`'s visitor card now renders the admin's text/image
  when set.

## What was verified

Ran the full stack locally (podman) and drove it with Playwright:
logged in as an admin, set a custom tagline, uploaded a banner image,
confirmed both persisted via `GET /admin/instance` and the public
`GET /instance`, and confirmed the signed-out card renders the custom
text/image in place of the defaults. `deno check` and `svelte-check`
both pass.

While testing, found and fixed a bug in the new admin form itself: the
image-upload handler originally called `apply()` on the full settings
snapshot the upload endpoint returned, which silently overwrote any
unsaved edit to the banner-text field made before the upload finished.
Fixed by having upload/remove only update `bannerImageUrl` locally.

Not verified: the mobile layout, since the visitor card only renders at
`lg:` and up (pre-existing, unrelated to this change).

## Deploy notes

No new env vars, no migration (uses the existing `instance_settings`
key/value table), no Caddyfile change. A plain `git pull && docker
compose up -d --build` picks it up.