### PR TITLE
fix(auth): validate registration email to close SMTP/header injection

### DIFF
--- a/apps/backend/src/lib/mime.ts
+++ b/apps/backend/src/lib/mime.ts
@@ -25,6 +25,21 @@ export interface BuiltMessage {
 
 const CRLF = "\r\n";
 
+// A header value (or SMTP-envelope field) must not carry a line break or other
+// control character: interpolated into a header line or a `RCPT TO:` command, a
+// CR/LF would start a new header / SMTP command (injection). Every value that
+// reaches a header goes through here first. Callers upstream validate their
+// inputs; this is the last-line guard that turns a slip into a thrown error
+// rather than a smuggled header. Matches C0 controls and DEL.
+// deno-lint-ignore no-control-regex
+const HEADER_UNSAFE = /[\x00-\x1f\x7f]/;
+
+function assertHeaderSafe(value: string, field: string): void {
+  if (HEADER_UNSAFE.test(value)) {
+    throw new Error(`Illegal control character in email ${field}.`);
+  }
+}
+
 /** Extract the bare address from a `Name <addr>` or `addr` header value. */
 export function extractAddress(value: string): string {
   const angle = value.match(/<([^>]+)>/);
@@ -52,6 +67,13 @@ function randomBoundary(): string {
 
 /** Assemble headers + body for a text (and optional HTML) message. */
 export function buildMessage(input: MessageInput): BuiltMessage {
+  // Guard the values that become header lines. `text`/`html` are the body (base64
+  // encoded below) and don't need it, but From/To/Subject are written straight
+  // into headers, so a CR/LF here must be refused, not serialized.
+  assertHeaderSafe(input.from, "sender");
+  assertHeaderSafe(input.to, "recipient");
+  assertHeaderSafe(input.subject, "subject");
+
   const fromAddress = extractAddress(input.from);
   const domain = domainOf(fromAddress) || "localhost";
   const messageId = `<${crypto.randomUUID()}@${domain}>`;

--- a/apps/backend/src/lib/mime_test.ts
+++ b/apps/backend/src/lib/mime_test.ts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { assertStringIncludes, assertThrows } from "@std/assert";
+import { buildMessage, extractAddress } from "@/lib/mime.ts";
+
+// Header injection: a CR/LF in an address or subject must be refused, never
+// serialized into a header line. This is the defense-in-depth backing the
+// address validation in services/auth.ts.
+Deno.test("buildMessage rejects a newline in the recipient", () => {
+  assertThrows(
+    () =>
+      buildMessage({
+        from: "Omicron <no-reply@example.com>",
+        to: "victim@example.com\r\nBcc: attacker@evil.example",
+        subject: "Hello",
+        text: "body",
+      }),
+    Error,
+    "control character",
+  );
+});
+
+Deno.test("buildMessage rejects a newline in the sender", () => {
+  assertThrows(
+    () =>
+      buildMessage({
+        from: "no-reply@example.com\nInjected: yes",
+        to: "user@example.com",
+        subject: "Hello",
+        text: "body",
+      }),
+    Error,
+    "control character",
+  );
+});
+
+Deno.test("buildMessage rejects a newline in the subject", () => {
+  assertThrows(
+    () =>
+      buildMessage({
+        from: "no-reply@example.com",
+        to: "user@example.com",
+        subject: "Hello\r\nX-Injected: 1",
+        text: "body",
+      }),
+    Error,
+    "control character",
+  );
+});
+
+Deno.test("buildMessage accepts a well-formed message", () => {
+  const { headers, fromAddress } = buildMessage({
+    from: "Omicron <no-reply@example.com>",
+    to: "user@example.com",
+    subject: "Reset your password",
+    text: "body",
+  });
+  const rendered = headers.map(([n, v]) => `${n}: ${v}`).join("\n");
+  assertStringIncludes(rendered, "To: user@example.com");
+  assertStringIncludes(rendered, "Subject: Reset your password");
+  // The body carries a newline (base64 line wrapping) but that is not a header,
+  // so it is unaffected by the header guard.
+  if (fromAddress !== "no-reply@example.com") throw new Error("bad from address");
+});
+
+Deno.test("extractAddress pulls the bare address from a display-name form", () => {
+  if (extractAddress("Omicron <no-reply@example.com>") !== "no-reply@example.com") {
+    throw new Error("extractAddress failed");
+  }
+});

--- a/apps/backend/src/lib/smtp.ts
+++ b/apps/backend/src/lib/smtp.ts
@@ -154,6 +154,16 @@ export async function sendSmtp(opts: SmtpOptions, env: SmtpEnvelope): Promise<vo
   const timeoutMs = opts.timeoutMs ?? 20_000;
   const helo = opts.heloName || "localhost";
 
+  // The envelope addresses are interpolated into the `MAIL FROM:<…>` / `RCPT
+  // TO:<…>` command lines below. A CR/LF (or other control byte) in one would
+  // terminate that line and inject a further SMTP command, so refuse it here —
+  // a last-line guard behind the address validation the callers already do.
+  // deno-lint-ignore no-control-regex
+  const CONTROL = /[\x00-\x1f\x7f]/;
+  if (CONTROL.test(env.from) || CONTROL.test(env.to)) {
+    throw new Error("Illegal control character in SMTP envelope address.");
+  }
+
   let socket: Deno.Conn;
   try {
     socket = opts.implicitTls

--- a/apps/backend/src/services/auth.ts
+++ b/apps/backend/src/services/auth.ts
@@ -13,6 +13,14 @@ import type { User } from "@/db/schema.ts";
 // Business logic for authentication. First registered user becomes admin.
 
 const USERNAME_RE = /^[a-z0-9_]{3,30}$/;
+// A plausible email address, and — the security-relevant part — one with no
+// whitespace or control characters. This value is later used verbatim as the
+// SMTP `RCPT TO:<…>` command and the `To:` MIME header (lib/smtp.ts, lib/mime.ts),
+// so an unvalidated CR/LF in it would inject SMTP commands / mail headers (an
+// open-relay / header-injection hole). `[^\s@]+` forbids exactly those bytes.
+// Matches the shape already enforced on the public-profile email (services/users.ts).
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MAX_EMAIL_LEN = 254; // RFC 5321 maximum address length
 const PASSWORD_RESET_TTL_MS = 1000 * 60 * 60; // 1 hour
 const EMAIL_VERIFY_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
 
@@ -39,16 +47,25 @@ export async function register(input: {
   if (!USERNAME_RE.test(username)) {
     throw badRequest("Username must be 3-30 chars: lowercase letters, numbers, underscore.");
   }
+  // Validate the email before it is stored: it becomes the recipient of every
+  // account email, used raw in the SMTP envelope and the `To:` header, so it
+  // must be a single well-formed address with no embedded newline. The setup
+  // wizard and admin routes validate via zod; this is the choke point for the
+  // public /api/auth/register path, which does not.
+  const email = input.email.trim();
+  if (email.length > MAX_EMAIL_LEN || !EMAIL_RE.test(email)) {
+    throw badRequest("Enter a valid email address.");
+  }
   if (input.password.length < 8) {
     throw badRequest("Password must be at least 8 characters.");
   }
   if (await usersRepo.findByUsername(username)) throw conflict("Username already taken.");
-  if (await usersRepo.findByEmail(input.email)) throw conflict("Email already registered.");
+  if (await usersRepo.findByEmail(email)) throw conflict("Email already registered.");
 
   const isFirstUser = (await usersRepo.countUsers()) === 0;
   const user = await usersRepo.create({
     username,
-    email: input.email,
+    email,
     passwordHash: await hashPassword(input.password),
     displayName: input.displayName?.trim() || username,
     isAdmin: isFirstUser,


### PR DESCRIPTION
## Symptom

On an instance configured with the `smtp` or `direct` email transport, an unauthenticated attacker could register an account with a crafted email address and cause the verification email to carry attacker-controlled SMTP commands / mail headers — e.g. an extra `Bcc:` recipient — turning the instance into a spam relay.

## Root cause

`POST /api/auth/register` passes the request body straight to `authService.register()`, which validated the username and password but stored `email` unchecked. That address is later used **verbatim** as:

- the SMTP `RCPT TO:<…>` command line — `lib/smtp.ts` (`conn.write(\`RCPT TO:<${env.to}>\`)`), and
- the `To:` MIME header — `lib/mime.ts` (`["To", input.to]`, serialized with CRLF joins).

Neither strips CR/LF, so `foo@bar.com\r\nBcc: victim@evil` (or raw SMTP verbs) is injected. The setup wizard (`setupSchema`) and the admin email routes already validate via zod `.email()`; only this public path did not.

## Fix

- Validate the address in `register()` — the single choke point for both the public route and the wizard — requiring one well-formed address with **no whitespace/control characters** (`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`), capped at 254 chars. The validated value (not the raw input) is what gets stored.
- **Defense in depth** in the mail builder so no future/overlooked path can smuggle a header:
  - `buildMessage()` refuses control characters in the From/To/Subject header values.
  - `sendSmtp()` refuses control characters in the envelope addresses.
  - Both throw rather than serialize a CR/LF.

## Verified

- Added `apps/backend/src/lib/mime_test.ts` covering the header-injection guard (newline in recipient/sender/subject rejected; well-formed message accepted).
- `deno check src/main.ts` clean.
- Full backend suite: **154 passed / 0 failed**.

Not verified against a live SMTP server (no injection path reaches a header now, by construction).

## Deploy notes

None — takes effect on a plain `docker compose up -d --build`. No env/config changes.