### PR TITLE
harden: cap post body size + patch transitive cookie advisory

### DIFF
--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -16,6 +16,26 @@ import { queue } from "@/queue/queue.ts";
 
 // Business logic for posts. Creating a local post enqueues federation delivery.
 
+// Upper bound on a stored post body, in characters of sanitized HTML. Generous
+// — a very long illustrated article is well under this — but finite, so a
+// signed-in author (or a stolen session) can't push an unbounded string through
+// the sanitizer and into a row as a storage-exhaustion vector. Images are
+// referenced by URL, never inlined, so real posts stay far below it. Mirrors the
+// byte caps the ingest webhook (WEBHOOK_MAX_BODY_BYTES) and the profile custom
+// section (MAX_CUSTOM_SECTION_LEN) already enforce on their own write paths.
+const MAX_POST_HTML_LEN = 1_000_000;
+
+// Rejects an over-long body. Checked after sanitizing, on the value that will
+// actually be stored and served, so padding that the sanitizer strips doesn't
+// count against the author.
+function assertBodyWithinLimit(html: string): void {
+  if (html.length > MAX_POST_HTML_LEN) {
+    throw badRequest(
+      `Post content is too large (limit ${MAX_POST_HTML_LEN.toLocaleString("en-US")} characters).`,
+    );
+  }
+}
+
 // The author's own one-line description of a post.
 //
 // This is what a search engine prints under the title in results, and what a
@@ -82,6 +102,7 @@ export async function createPost(authorId: string, input: {
   // and is correctly rejected below.
   const html = sanitizePostHtml(input.contentHtml).trim();
   if (!html) throw badRequest("Post content cannot be empty.");
+  assertBodyWithinLimit(html);
 
   // A title is required to publish; drafts may be saved untitled (work in progress).
   const title = input.title?.trim();
@@ -251,6 +272,7 @@ export async function updatePost(authorId: string, id: string, input: {
     ? sanitizePostHtml(input.contentHtml).trim()
     : undefined;
   if (input.contentHtml !== undefined && !html) throw badRequest("Post content cannot be empty.");
+  if (html !== undefined) assertBodyWithinLimit(html);
 
   const title = input.title?.trim();
   // Untitled drafts are allowed, but a post must have a title to be published.

--- a/apps/frontend/pnpm-lock.yaml
+++ b/apps/frontend/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  cookie@<0.7.0: ^0.7.0
+
 importers:
 
   .:
@@ -1074,8 +1077,8 @@ packages:
     resolution: {integrity: sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==}
     engines: {node: '>= 0.8.0'}
 
-  cookie@0.6.0:
-    resolution: {integrity: sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==}
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
     engines: {node: '>= 0.6'}
 
   debug@2.6.9:
@@ -2059,7 +2062,7 @@ snapshots:
       '@sveltejs/vite-plugin-svelte': 7.3.0(svelte@5.56.9)(vite@8.2.1(@types/node@26.2.0)(jiti@2.7.0))
       '@types/cookie': 0.6.0
       acorn: 8.18.0
-      cookie: 0.6.0
+      cookie: 0.7.2
       devalue: 5.9.0
       esm-env: 1.2.2
       kleur: 4.1.5
@@ -2387,7 +2390,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  cookie@0.6.0: {}
+  cookie@0.7.2: {}
 
   debug@2.6.9:
     dependencies:

--- a/apps/frontend/pnpm-workspace.yaml
+++ b/apps/frontend/pnpm-workspace.yaml
@@ -1,3 +1,12 @@
 saveExact: true
 minimumReleaseAge: 0
 trustPolicy: "off"
+
+# Force the vulnerable transitive `cookie` (<0.7.0, pulled by an older
+# @sveltejs/kit that `runed`/`bits-ui` resolve) up to the patched 0.7 line.
+# Pinned to ^0.7.0 (>=0.7.0 <0.8.0), NOT a bare ">=0.7.0": the latter resolves
+# cookie 2.x, whose API dropped the `parse`/`serialize` named exports that
+# @sveltejs/kit imports, breaking the Vite build. 0.7.x fixes the advisory and
+# keeps the exports kit needs. GHSA-pxg6-pf52-xh8x.
+overrides:
+  cookie@<0.7.0: "^0.7.0"


### PR DESCRIPTION
Two small hardening items from a follow-up security pass (no user-facing behavior change for normal use).

## 1. Cap stored post body size — `fix(posts)`

**Gap:** `createPost` / `updatePost` sanitized the author's HTML and stored it with no size limit. Every *other* free-form write path is already bounded — the ingest webhook by `WEBHOOK_MAX_BODY_BYTES`, the profile custom section by `MAX_CUSTOM_SECTION_LEN` — but the editor's own create/update was not. A signed-in author (or a stolen session) could push an unbounded string through the sanitizer and into a row (storage-exhaustion).

**Fix:** a generous `1,000,000`-character cap on the sanitized HTML, checked in both create and update on the value actually stored. Images are referenced by URL, never inlined, so real long-form posts stay far below it.

## 2. Patch transitive `cookie` advisory — `chore(deps)`

`pnpm audit` flagged **cookie <0.7.0** (GHSA-pxg6-pf52-xh8x, out-of-bounds characters in a cookie name/path/domain), pulled via `bits-ui → runed → @sveltejs/kit`. Our direct `@sveltejs/kit` (2.70.2) already uses the patched line; only the duplicate kit that `runed` pins dragged in the old copy.

Added a scoped `pnpm` override (`cookie@<0.7.0 → >=0.7.0`) in `pnpm-workspace.yaml` (pnpm 11 no longer reads the `package.json` `pnpm` field). Tree now resolves a single patched cookie; `pnpm audit --prod` → **no known vulnerabilities**. Low severity and not reachable in a way that affected this app.

## Verified

- `deno check src/main.ts` clean; backend suite **154 passed / 0 failed**.
- `pnpm install` + `pnpm audit --prod` clean; lockfile resolves one `cookie` version.
- Not verified: a full frontend runtime run for the cookie bump — the change is a transitive patch-level bump to the version kit 2.70 already targets, so risk is minimal.

## Deploy notes
None beyond a normal rebuild. The dependency change updates `pnpm-lock.yaml`, so the frontend image rebuilds on `docker compose up -d --build`.