### PR TITLE
ci: audit dependencies for known advisories on every push and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,14 @@ jobs:
         run: deno lint
       - name: Test
         run: deno task test
+      - name: Audit dependencies
+        # Surface every advisory in the log for visibility, then fail only on a
+        # high/critical one — so a serious CVE in a dependency blocks the merge,
+        # while an unfixable low can't wedge the pipeline. Runs against the deps
+        # the steps above already resolved.
+        run: |
+          deno audit || true
+          deno audit --level=high
 
   frontend:
     name: Frontend (svelte-check)
@@ -61,6 +69,14 @@ jobs:
 
       - name: Run Checks
         run: pnpm check
+
+      - name: Audit dependencies
+        # Same policy as the backend: print all advisories, fail only on
+        # high/critical. `--prod` ignores devDependencies (build-time only, not
+        # shipped in the runtime image).
+        run: |
+          pnpm audit --prod || true
+          pnpm audit --prod --audit-level high
 
   docker-build:
     name: Docker images build


### PR DESCRIPTION
## Why

A dependency CVE could reach self-hosters on their next `git pull && docker compose up` with nothing in CI to catch it — advisories only surfaced when someone ran an audit by hand (which is how the recent `cookie` low was found). This wires automatic detection into the pipeline.

## What

Adds a **dependency-audit step to each existing job** (they already resolve the dependency graph, so no separate job re-resolving everything), using each ecosystem's native tool — no third-party actions:

- **backend (Deno):** `deno audit`
- **frontend (pnpm):** `pnpm audit --prod` (devDependencies are build-time only, not shipped in the runtime image)

Each step **prints every advisory** for visibility, then **fails only on high/critical** (`--level=high` / `--audit-level high`). Rationale: block a serious CVE from landing on `main`, but don't let an unfixable low-severity advisory (often no upstream patch yet) wedge the pipeline — lower findings stay visible in the job log for a maintainer to weigh.

## Verified

- YAML parses; both gate commands exit 0 on the current (clean) tree.
- `deno audit` / `pnpm audit --prod` → no known vulnerabilities.

## Deploy notes

None — CI-only change.