### PR TITLE
fix(federation): reject cross-origin post attribution (impersonation)

### DIFF
--- a/apps/backend/src/federation/mod.ts
+++ b/apps/backend/src/federation/mod.ts
@@ -44,6 +44,7 @@ import { cacheActor } from "@/federation/remote.ts";
 import { origin } from "@/config.ts";
 import { normalizeTags } from "@/lib/tags.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
+import { sameOrigin } from "@/lib/domain.ts";
 import type { Post } from "@/db/schema.ts";
 
 // ── ActivityPub wiring (isolated) ────────────────────────────────────────
@@ -234,6 +235,16 @@ async function ingestArticle(
   if (!article.attributionId) return undefined;
   const author = await ctx.lookupObject(article.attributionId);
   if (!isActor(author) || !author.id) return undefined;
+
+  // Authority check: a post may only be attributed to an actor on the same
+  // origin as the post's own id. Without this, a hostile instance can deliver an
+  // Article on its own domain that claims `attributedTo` an account on another
+  // server, and we would store its content under that victim's name (fediverse
+  // impersonation). Fedify already refetches an embedded object from the origin
+  // of its id, so this closes the remaining gap where the id and the attributed
+  // actor disagree.
+  if (!sameOrigin(article.id, author.id)) return undefined;
+
   const actor = await cacheActor(author);
 
   const post = await postsRepo.upsertRemotePost({

--- a/apps/backend/src/federation/remote.ts
+++ b/apps/backend/src/federation/remote.ts
@@ -11,6 +11,7 @@ import * as tagsRepo from "@/db/repositories/tags.ts";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
 import { normalizeTags } from "@/lib/tags.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
+import { sameOrigin } from "@/lib/domain.ts";
 import type { RemoteActor } from "@/db/schema.ts";
 
 // Resolving and caching remote fediverse actors + their posts. This is the
@@ -115,6 +116,11 @@ export async function fetchOutboxPosts(handle: string, remoteActorId: string): P
       // Long-form only: keep Articles, skip microblog Notes (Mastodon, …).
       if (!(obj instanceof Article)) continue;
       if (!obj.id) continue;
+      // Authority check: only cache a post whose id shares the actor's origin.
+      // An actor's outbox listing a post on another server's domain would
+      // otherwise let us store that post under this actor's name — the same
+      // cross-origin impersonation the inbox path guards against.
+      if (!sameOrigin(obj.id, actor.id)) continue;
       await postsRepo.upsertRemotePost({
         remoteActorId,
         apId: obj.id.href,

--- a/apps/backend/src/lib/domain.ts
+++ b/apps/backend/src/lib/domain.ts
@@ -34,3 +34,15 @@ export function hostMatchesDomain(host: string, domain: string): boolean {
   host = host.trim().toLowerCase();
   return host === domain || host.endsWith(`.${domain}`);
 }
+
+// Whether two ActivityPub ids come from the same origin (scheme + host + port).
+//
+// The authority check for federated ingest: a server may only speak for objects
+// on its own origin. A remote Article whose `id` lives on one host but whose
+// `attributedTo` actor lives on another is an impersonation attempt — one
+// instance publishing a post under an account it does not control — so the two
+// origins must match before we store the post under that author. Matches
+// Mastodon's same-origin rule for an object and its attributed actor.
+export function sameOrigin(a: URL | null | undefined, b: URL | null | undefined): boolean {
+  return a != null && b != null && a.origin === b.origin;
+}

--- a/apps/backend/src/lib/domain_test.ts
+++ b/apps/backend/src/lib/domain_test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { assertEquals } from "@std/assert";
-import { hostMatchesDomain, normalizeDomain } from "@/lib/domain.ts";
+import { hostMatchesDomain, normalizeDomain, sameOrigin } from "@/lib/domain.ts";
 
 // The defederation blocklist is a moderation/safety control. If normalization
 // accepts junk or matching misses a subdomain, an admin's block silently fails
@@ -41,4 +41,37 @@ Deno.test("hostMatchesDomain: siblings and look-alikes do NOT match", () => {
   assertEquals(hostMatchesDomain("notexample.com", "example.com"), false);
   assertEquals(hostMatchesDomain("example.com.evil.com", "example.com"), false);
   assertEquals(hostMatchesDomain("example.org", "example.com"), false);
+});
+
+// sameOrigin gates federated ingest: a post may only be attributed to an actor
+// on its own origin. A miss here reopens the cross-origin impersonation hole, so
+// pin the accept/reject cases the ingest paths depend on.
+Deno.test("sameOrigin: identical origin matches", () => {
+  assertEquals(
+    sameOrigin(new URL("https://a.example/posts/1"), new URL("https://a.example/users/alice")),
+    true,
+  );
+});
+
+Deno.test("sameOrigin: different host is refused (the impersonation case)", () => {
+  assertEquals(
+    sameOrigin(new URL("https://evil.example/posts/1"), new URL("https://victim.example/users/x")),
+    false,
+  );
+});
+
+Deno.test("sameOrigin: scheme or port differences are a different origin", () => {
+  assertEquals(
+    sameOrigin(new URL("http://a.example/1"), new URL("https://a.example/2")),
+    false,
+  );
+  assertEquals(
+    sameOrigin(new URL("https://a.example:8443/1"), new URL("https://a.example/2")),
+    false,
+  );
+});
+
+Deno.test("sameOrigin: a null id never matches", () => {
+  assertEquals(sameOrigin(null, new URL("https://a.example/2")), false);
+  assertEquals(sameOrigin(new URL("https://a.example/1"), undefined), false);
 });


### PR DESCRIPTION
## Symptom

A post authored on one instance could appear on this instance **under a different account's name** — an account on a *third* server that never wrote it. It shows up on that victim's cached profile/feeds here as if they published it.

## Root cause

`ingestArticle` (inbox `Create`/`Announce`) and `fetchOutboxPosts` (outbox backfill) stored a remote Article under whatever actor its `attributedTo` named, with **no check that the post and the actor share an origin**.

Fedify's default cross-origin handling refetches an embedded object from the origin of its own `id`, which blocks the obvious attack (forging content under someone else's object-id). But it does **not** block the reverse: `evil.example` delivers `Create(actor=evil)` wrapping `Article(id=evil.example/1, attributedTo=victim.example/users/alice)`. The article and activity are same-origin (evil), so Fedify trusts the embedded article; we then resolve `attributedTo`, fetch victim's *real* actor, and store evil's content under victim's name.

## Fix

New `sameOrigin(a, b)` authority helper in `lib/domain.ts`: a post is stored only when its `id` and its attributed actor's `id` share an origin (scheme+host+port). Applied on **both** ingest paths:

- `mod.ts` `ingestArticle` — reject when `article.id` and the resolved author differ in origin.
- `remote.ts` `fetchOutboxPosts` — skip an outbox entry whose `id` is on a different origin than the actor whose outbox it is (an actor can't claim authorship of another server's post).

Mirrors Mastodon's object/`attributedTo` same-origin rule.

## Verified

- New unit tests for `sameOrigin` (accept same-origin; reject different host / scheme / port / null).
- `deno check` clean; backend suite **158 passed / 0 failed** (was 154); `deno lint` clean.
- Not exercised against a live hostile peer — the guard is a pure origin comparison on ids Fedify already parses.

## Deploy notes
None beyond a normal rebuild. No schema or config change. Existing already-cached mis-attributed posts (if any) are not retroactively purged; this stops new ones.