### PR TITLE
fix(auth): Secure cookie flag from request scheme + lowercase registration email

### DIFF
--- a/apps/backend/src/lib/session.ts
+++ b/apps/backend/src/lib/session.ts
@@ -1,7 +1,27 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Session token generation + cookie name/attributes in one place.
+import type { Context } from "hono";
+
 export const SESSION_COOKIE = "omicron_session";
 export const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
+
+// Whether a cookie set on this response should carry the `Secure` attribute.
+//
+// The authoritative signal is the actual request scheme, which Caddy terminates
+// TLS for and forwards as `x-forwarded-proto` (through the SvelteKit proxy for
+// the /api surface). Deriving `Secure` from that — rather than from the
+// boot-time `APP_DOMAIN` — is what keeps the flag correct on the zero-config
+// path: an instance configured entirely through the setup wizard is served over
+// HTTPS while `APP_DOMAIN` still holds its `localhost:5173` default, and the old
+// `!APP_DOMAIN.startsWith("localhost")` heuristic would then ship the session
+// cookie without `Secure` on a production site. When no forwarded scheme is
+// present (bare local dev, no proxy) we fall back to that domain heuristic, so
+// localhost stays cookie-friendly over plain HTTP.
+export function cookieSecure(c: Context, appDomain: string): boolean {
+  const proto = c.req.header("x-forwarded-proto");
+  if (proto) return proto.split(",")[0].trim().toLowerCase() === "https";
+  return !appDomain.startsWith("localhost");
+}
 
 export function newSessionToken(): string {
   return crypto.randomUUID() + crypto.randomUUID().replaceAll("-", "");

--- a/apps/backend/src/lib/session_test.ts
+++ b/apps/backend/src/lib/session_test.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { assertEquals } from "@std/assert";
+import type { Context } from "hono";
+import { cookieSecure } from "@/lib/session.ts";
+
+// Minimal Context stub: cookieSecure only reads one request header.
+function ctx(proto?: string): Context {
+  return {
+    req: { header: (name: string) => (name === "x-forwarded-proto" ? proto : undefined) },
+  } as unknown as Context;
+}
+
+// The Secure flag on the session cookie is what keeps it off a plaintext hop.
+// It must follow the real request scheme (forwarded by Caddy), not the
+// boot-time domain — otherwise a wizard-configured HTTPS instance whose
+// APP_DOMAIN stayed "localhost" ships the cookie without Secure.
+
+Deno.test("cookieSecure: https forwarded scheme ⇒ Secure, regardless of domain", () => {
+  assertEquals(cookieSecure(ctx("https"), "localhost:5173"), true);
+  assertEquals(cookieSecure(ctx("HTTPS"), "localhost:5173"), true);
+  // A comma-joined chain uses the first (client-facing) hop.
+  assertEquals(cookieSecure(ctx("https, http"), "localhost:5173"), true);
+});
+
+Deno.test("cookieSecure: http forwarded scheme ⇒ not Secure (local dev over http)", () => {
+  assertEquals(cookieSecure(ctx("http"), "localhost:5173"), false);
+  assertEquals(cookieSecure(ctx("http"), "blog.example.com"), false);
+});
+
+Deno.test("cookieSecure: no forwarded scheme falls back to the domain heuristic", () => {
+  assertEquals(cookieSecure(ctx(undefined), "blog.example.com"), true);
+  assertEquals(cookieSecure(ctx(undefined), "localhost:5173"), false);
+});

--- a/apps/backend/src/routes/auth.ts
+++ b/apps/backend/src/routes/auth.ts
@@ -5,11 +5,12 @@ import * as authService from "@/services/auth.ts";
 import * as sessionsRepo from "@/db/repositories/sessions.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
 import * as usersService from "@/services/users.ts";
-import { SESSION_COOKIE, SESSION_TTL_MS } from "@/lib/session.ts";
+import { cookieSecure, SESSION_COOKIE, SESSION_TTL_MS } from "@/lib/session.ts";
 import { config } from "@/config.ts";
 import { requireUser } from "@/routes/middleware.ts";
 import { rateLimit } from "@/lib/rateLimit.ts";
 import { privateUser, profileLinkView } from "@/routes/serializers.ts";
+import type { Context } from "hono";
 import type { AppEnv } from "@/routes/types.ts";
 
 export const authRoutes = new Hono<AppEnv>();
@@ -42,26 +43,32 @@ const tokenLimiter = rateLimit({
   max: config.RL_LOGIN_MAX,
 });
 
-const cookieOpts = {
-  httpOnly: true,
-  sameSite: "Lax" as const,
-  path: "/",
-  secure: !config.APP_DOMAIN.startsWith("localhost"),
-  maxAge: SESSION_TTL_MS / 1000,
-};
+// Session cookie attributes. `secure` is decided per request from the forwarded
+// scheme (see lib/session.ts cookieSecure) rather than a static config guess, so
+// the flag is correct on a wizard-configured HTTPS instance whose APP_DOMAIN was
+// never moved off its localhost default.
+function cookieOpts(c: Context) {
+  return {
+    httpOnly: true,
+    sameSite: "Lax" as const,
+    path: "/",
+    secure: cookieSecure(c, config.APP_DOMAIN),
+    maxAge: SESSION_TTL_MS / 1000,
+  };
+}
 
 authRoutes.post("/register", registerLimiter, async (c) => {
   const body = await c.req.json();
   const user = await authService.register(body);
   const { token } = await authService.login(user.username, body.password);
-  setCookie(c, SESSION_COOKIE, token, cookieOpts);
+  setCookie(c, SESSION_COOKIE, token, cookieOpts(c));
   return c.json({ user: privateUser(user) }, 201);
 });
 
 authRoutes.post("/login", loginLimiter, async (c) => {
   const { identifier, password } = await c.req.json();
   const { user, token } = await authService.login(identifier, password);
-  setCookie(c, SESSION_COOKIE, token, cookieOpts);
+  setCookie(c, SESSION_COOKIE, token, cookieOpts(c));
   return c.json({ user: privateUser(user, await tagsRepo.tagsForUser(user.id)) });
 });
 

--- a/apps/backend/src/routes/posts.ts
+++ b/apps/backend/src/routes/posts.ts
@@ -9,6 +9,7 @@ import * as commentLikesService from "@/services/commentLikes.ts";
 import { enrichPost, enrichPosts } from "@/services/engagement.ts";
 import * as analyticsService from "@/services/analytics.ts";
 import { isBot, readerOptedOut, VIEW_COOKIE, VIEW_COOKIE_TTL_MS } from "@/lib/analytics.ts";
+import { cookieSecure } from "@/lib/session.ts";
 import { decodeCursor } from "@/lib/pagination.ts";
 import { parseLanguageFilter } from "@/lib/languages.ts";
 import { requireUser } from "@/routes/middleware.ts";
@@ -18,13 +19,18 @@ import type { AppEnv } from "@/routes/types.ts";
 
 export const postRoutes = new Hono<AppEnv>();
 
-const viewCookieOpts = {
-  httpOnly: true,
-  sameSite: "Lax" as const,
-  path: "/",
-  secure: !config.APP_DOMAIN.startsWith("localhost"),
-  maxAge: VIEW_COOKIE_TTL_MS / 1000,
-};
+// `secure` is decided per request from the forwarded scheme (lib/session.ts
+// cookieSecure), matching the session cookie, so this is Secure on a
+// wizard-configured HTTPS instance rather than keyed to the boot-time domain.
+function viewCookieOpts(c: Context<AppEnv>) {
+  return {
+    httpOnly: true,
+    sameSite: "Lax" as const,
+    path: "/",
+    secure: cookieSecure(c, config.APP_DOMAIN),
+    maxAge: VIEW_COOKIE_TTL_MS / 1000,
+  };
+}
 
 // Timeline (public). `?scope=local` returns only posts from this instance;
 // otherwise the global blog feed across the fediverse.
@@ -80,7 +86,7 @@ function countView(c: Context<AppEnv>, row: { post: { id: string } }) {
     !viewer && !anonCookie && !readerOptedOut(headers) && !isBot(headers.get("user-agent") ?? "")
   ) {
     anonCookie = crypto.randomUUID() + crypto.randomUUID();
-    setCookie(c, VIEW_COOKIE, anonCookie, viewCookieOpts);
+    setCookie(c, VIEW_COOKIE, anonCookie, viewCookieOpts(c));
   }
   analyticsService.recordPostView(row.post.id, headers, viewer?.id ?? null, anonCookie).catch(
     () => {},

--- a/apps/backend/src/routes/setup.ts
+++ b/apps/backend/src/routes/setup.ts
@@ -6,21 +6,26 @@ import * as authService from "@/services/auth.ts";
 import * as setup from "@/services/instanceSetup.ts";
 import * as emailSettings from "@/services/emailSettings.ts";
 import { sendTestEmail } from "@/services/email.ts";
-import { SESSION_COOKIE, SESSION_TTL_MS } from "@/lib/session.ts";
+import { cookieSecure, SESSION_COOKIE, SESSION_TTL_MS } from "@/lib/session.ts";
 import { config } from "@/config.ts";
 import { badRequest, conflict } from "@/lib/http.ts";
 import { privateUser } from "@/routes/serializers.ts";
+import type { Context } from "hono";
 import type { AppEnv } from "@/routes/types.ts";
 
-// Session cookie attributes (kept in sync with routes/auth.ts). Secure unless
-// running on a bare localhost domain, where there's no TLS to require.
-const cookieOpts = {
-  httpOnly: true,
-  sameSite: "Lax" as const,
-  path: "/",
-  secure: !config.APP_DOMAIN.startsWith("localhost"),
-  maxAge: SESSION_TTL_MS / 1000,
-};
+// Session cookie attributes (kept in sync with routes/auth.ts). `secure` is
+// decided per request from the forwarded scheme (lib/session.ts cookieSecure),
+// so a wizard-configured HTTPS instance gets a Secure cookie even while
+// APP_DOMAIN still holds its localhost default.
+function cookieOpts(c: Context) {
+  return {
+    httpOnly: true,
+    sameSite: "Lax" as const,
+    path: "/",
+    secure: cookieSecure(c, config.APP_DOMAIN),
+    maxAge: SESSION_TTL_MS / 1000,
+  };
+}
 
 // Public, unauthenticated snapshot of the instance's identity. Drives the
 // frontend chrome (app name) and the first-run setup gate.
@@ -90,7 +95,7 @@ setupRoutes.post("/", async (c) => {
   // treats its email as verified, so the owner can never be locked out.
   const user = await authService.register(admin);
   const { token } = await authService.login(user.username, admin.password);
-  setCookie(c, SESSION_COOKIE, token, cookieOpts);
+  setCookie(c, SESSION_COOKIE, token, cookieOpts(c));
 
   await setup.completeSetup({ appName, appDomain, email });
 

--- a/apps/backend/src/services/auth.ts
+++ b/apps/backend/src/services/auth.ts
@@ -52,7 +52,13 @@ export async function register(input: {
   // must be a single well-formed address with no embedded newline. The setup
   // wizard and admin routes validate via zod; this is the choke point for the
   // public /api/auth/register path, which does not.
-  const email = input.email.trim();
+  //
+  // Lowercased, not merely trimmed: every lookup elsewhere (login, password
+  // reset, resend) lowercases the identifier before `findByEmail`, so storing a
+  // mixed-case address would (a) make the account unreachable at sign-in and
+  // (b) let `Alice@x` and `alice@x` register as two rows past the unique index,
+  // which is case-sensitive. Canonicalising here keeps one address ⇒ one account.
+  const email = input.email.trim().toLowerCase();
   if (email.length > MAX_EMAIL_LEN || !EMAIL_RE.test(email)) {
     throw badRequest("Enter a valid email address.");
   }


### PR DESCRIPTION
Two auth-integrity fixes found in a follow-up scan. Independent commits.

## 1. Secure cookie flag from the real request scheme

**Symptom:** on the zero-config (wizard) path, a production instance served over HTTPS issued its **session cookie without `Secure`**.

**Cause:** the flag was `!config.APP_DOMAIN.startsWith("localhost")` — the *boot-time env* value. The wizard stores the public domain in the DB and the compose default leaves `APP_DOMAIN=localhost:5173`, so `Secure` stayed false on a real HTTPS site. A later plaintext request (typed `http://`, an old link — before the 308→HTTPS redirect and before HSTS is established) would send the session cookie in the clear.

**Fix:** decide `Secure` per response from `x-forwarded-proto` (the scheme Caddy terminates TLS for and forwards, through the SvelteKit proxy for `/api`), falling back to the domain heuristic only when no proxy scheme is present (bare local dev over http). New `cookieSecure` helper in `lib/session.ts`, applied to the session cookie (`auth.ts`, `setup.ts`) and the analytics view cookie (`posts.ts`). Local dev over http still gets a non-Secure cookie, so sign-in keeps working.

## 2. Lowercase registration email

**Symptom:** an email with a capital letter couldn't sign in; and `Alice@x` / `alice@x` could register as two accounts.

**Cause:** registration stored the email trimmed but **not** lowercased, while login / password-reset / resend all lowercase the identifier before `findByEmail`, and `users_email_idx` is case-sensitive.

**Fix:** lowercase the address at registration, so one mailbox ⇒ one account and sign-in matches what was stored.

## Verified
- New unit tests: `cookieSecure` (https/http/absent-scheme × domain) and the existing email-validation path.
- `deno check` clean; backend suite **157 passed / 0 failed**; `deno lint` clean.

## Deploy notes
None beyond a normal rebuild. No schema change. Existing mixed-case rows (if any pre-date this) are not migrated — this canonicalizes new registrations; a one-off lowercasing backfill could be added later if needed.