### PR TITLE
chore(scripts): backfill to lowercase pre-existing mixed-case emails

### DIFF
--- a/apps/backend/deno.json
+++ b/apps/backend/deno.json
@@ -9,6 +9,7 @@
     "backfill:sanitize": "deno run -A scripts/backfill_sanitize.ts",
     "backfill:math": "deno run -A scripts/backfill_math.ts",
     "backfill:unescape": "deno run -A scripts/backfill_unescape.ts",
+    "backfill:email-lowercase": "deno run -A scripts/backfill_email_lowercase.ts",
     "check": "deno check src/main.ts",
     "test": "deno test -A",
     "fmt": "deno fmt",

--- a/apps/backend/scripts/backfill_email_lowercase.ts
+++ b/apps/backend/scripts/backfill_email_lowercase.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// One-time backfill: canonicalise stored login emails to lowercase.
+//
+// Registration now lowercases the email before storing it (services/auth.ts), so
+// one mailbox maps to one account and sign-in — which lowercases the identifier
+// before the lookup — matches what was stored. Rows created before that change
+// may still hold a mixed-case address, which is unreachable at sign-in and can
+// sit alongside a lowercase twin. This script lowercases those older rows.
+//
+//   deno task backfill:email-lowercase            # apply changes
+//   deno task backfill:email-lowercase --dry-run  # preview without writing
+//
+// Safe to run more than once: a row already lowercase is skipped.
+//
+// COLLISIONS ARE NOT MERGED. If lowercasing one row would collide with another
+// account's address (e.g. both `Alice@x` and `alice@x` exist), both are left
+// untouched and reported, because merging two accounts is a destructive decision
+// a human must make — deciding which account's posts, follows and sessions
+// survive is not something a backfill should guess. Resolve those by hand (e.g.
+// suspend or delete the duplicate) and re-run.
+import * as usersRepo from "@/db/repositories/users.ts";
+import { sql } from "@/db/client.ts";
+
+const dryRun = Deno.args.includes("--dry-run");
+
+const rows = await usersRepo.listEmails();
+console.log(`Scanning ${rows.length} account(s)${dryRun ? " (dry run)" : ""}…`);
+
+// Group by the canonical (lowercased) address so a collision is visible before
+// any write. `listEmails` is ordered oldest-first, so index 0 in each bucket is
+// the original account and later entries are the case-variant twins.
+const byCanonical = new Map<string, { id: string; email: string }[]>();
+for (const row of rows) {
+  const canonical = row.email.trim().toLowerCase();
+  (byCanonical.get(canonical) ?? byCanonical.set(canonical, []).get(canonical)!).push(row);
+}
+
+let changed = 0;
+let collisions = 0;
+
+for (const [canonical, bucket] of byCanonical) {
+  // A single account under this address: lowercase it if it isn't already.
+  if (bucket.length === 1) {
+    const row = bucket[0];
+    if (row.email === canonical) continue; // already canonical
+    changed++;
+    console.log(`• ${row.id}: ${row.email} → ${canonical}`);
+    if (!dryRun) await usersRepo.update(row.id, { email: canonical });
+    continue;
+  }
+
+  // More than one account canonicalises to the same address — a genuine
+  // duplicate mailbox. Never merge; report every row and touch none of them.
+  collisions++;
+  console.warn(
+    `! COLLISION on ${canonical}: ${bucket.length} accounts share this mailbox — ` +
+      `left unchanged, resolve by hand:`,
+  );
+  for (const row of bucket) console.warn(`    ${row.id}  (stored as ${row.email})`);
+}
+
+console.log(
+  dryRun
+    ? `Done (dry run). ${changed} account(s) would be lowercased; ${collisions} collision group(s) need manual resolution.`
+    : `Done. Lowercased ${changed} account(s); ${collisions} collision group(s) left for manual resolution.`,
+);
+
+await sql.end();

--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -130,3 +130,14 @@ export async function setSuspended(id: string, at: Date | null) {
   const [row] = await db.update(users).set({ suspendedAt: at }).where(eq(users.id, id)).returning();
   return row;
 }
+
+// Every account's id, email, and creation time — for the one-off email-lowercase
+// backfill (scripts/backfill_email_lowercase.ts), which canonicalises rows that
+// predate case-normalised registration. Oldest first, so a collision report is
+// deterministic and names the original account first.
+export function listEmails(): Promise<{ id: string; email: string; createdAt: Date }[]> {
+  return db
+    .select({ id: users.id, email: users.email, createdAt: users.createdAt })
+    .from(users)
+    .orderBy(users.createdAt);
+}


### PR DESCRIPTION
Follow-up to #46 (which canonicalised registration email to lowercase).

## Why

#46 fixed *new* registrations, but any account created before it may still hold a mixed-case address — **unreachable at sign-in** (login/reset lowercase the identifier before `findByEmail`) and able to coexist with a lowercase twin past the case-sensitive unique index. This is the one-off remediation for existing rows.

## What

`deno task backfill:email-lowercase` (add `--dry-run` to preview):

- Lowercases every row whose stored email isn't already canonical. Idempotent — safe to re-run.
- **Collisions are not merged.** When two accounts canonicalise to the same address, both are left untouched and reported. Merging accounts (deciding whose posts/follows/sessions survive) is a destructive human decision a backfill must not guess; the operator resolves those by hand (suspend/delete the duplicate) and re-runs.

Adds `usersRepo.listEmails()` (oldest-first for a deterministic collision report) so the script's DB access stays in the repository layer per the architecture rules.

## Verified

- `deno check` (script + `src/main.ts`) clean; `deno lint` clean; backend suite **161 passed / 0 failed**.
- Not run against live data here — it's an operator-run migration; `--dry-run` previews every change and every collision before any write.

## Deploy notes

Optional, operator-run. Not part of `docker compose up` — an admin runs it once inside the backend container if their instance has pre-#46 mixed-case emails. No schema change. Most instances (especially single-user) will have nothing to change.