### PR TITLE
fix(nav): stop the mobile top bar overlapping the wordmark

### DIFF
--- a/apps/frontend/src/lib/components/Nav.svelte
+++ b/apps/frontend/src/lib/components/Nav.svelte
@@ -74,9 +74,13 @@
 
 <header class="sticky top-0 z-20 bg-background/80 backdrop-blur-sm">
   <nav class="relative mx-auto flex max-w-6xl items-center justify-between px-4 py-3">
-    <Button href="/" variant="plain" class="flex items-center gap-2 text-foreground hover:opacity-80">
-      <img src={logo} alt="" width="28" height="28" class="h-7 w-auto" />
-      <span class="text-xl font-bold tracking-tight">{appName}</span>
+    <!-- `min-w-0` + `truncate`: the instance name is operator-chosen and can be
+         long, and a narrow phone leaves the row barely wider than its contents.
+         Without them the name refuses to give up width and the right-hand
+         controls ride over it instead. -->
+    <Button href="/" variant="plain" class="flex min-w-0 items-center gap-2 text-foreground hover:opacity-80">
+      <img src={logo} alt="" width="28" height="28" class="h-7 w-auto shrink-0" />
+      <span class="truncate text-xl font-bold tracking-tight">{appName}</span>
     </Button>
 
     {#if !minimal}
@@ -86,7 +90,7 @@
       </div>
     {/if}
 
-    <div class="flex items-center gap-1.5">
+    <div class="flex shrink-0 items-center gap-1.5">
       {#if !minimal}
         <!-- Icon-only search fallback (below sm) -->
         <Button href="/search" variant="icon" class="border-0! shadow-none! sm:hidden" aria-label="Search">

--- a/apps/frontend/src/lib/components/ui/Button.svelte
+++ b/apps/frontend/src/lib/components/ui/Button.svelte
@@ -38,11 +38,23 @@
     plain: "",
   };
 
+  // A caller's own display utility has to win over ours. Tailwind v4 emits the
+  // display utilities alphabetically — `.hidden` lands *before* `.inline-flex` —
+  // so the `inline-flex` in the strings above beats a `hidden` passed in by the
+  // caller whichever order the class attribute lists them in, and a button asked
+  // to disappear renders anyway. Dropping ours when the caller sets its own makes
+  // `class="hidden sm:inline-flex"` behave the way it reads.
+  const DISPLAY_UTILITY = /^(block|contents|flex|grid|hidden|inline|inline-block|inline-flex|inline-grid|table)$/;
+  const callerSetsDisplay = $derived(className.split(/\s+/).some((c) => DISPLAY_UTILITY.test(c)));
+  const ownDisplay = (s: string) => (callerSetsDisplay ? s.replace(/(^|\s)inline-flex(?=\s|$)/g, "$1") : s);
+
   // icon/link/plain are self-contained; the rest compose base + size + variant.
   const classes = $derived(
-    variant === "icon" || variant === "link" || variant === "plain"
-      ? `${variants[variant]} ${className}`
-      : `${base} ${sizes[size]} ${variants[variant]} ${className}`,
+    `${ownDisplay(
+      variant === "icon" || variant === "link" || variant === "plain"
+        ? variants[variant]
+        : `${base} ${sizes[size]} ${variants[variant]}`,
+    )} ${className}`,
   );
 </script>
 


### PR DESCRIPTION
## Symptom

On a phone the top bar's icons ride over the site name — the search magnifier
sits on top of the "n" in "Omicron", with no gap between the wordmark and the
controls. Reported at a 360px viewport (a common Android width), signed in.

## Root cause

Two faults stacked.

**The "Write" button was never hidden below `sm`.** `Nav.svelte` asks for
`class="hidden … sm:inline-flex"`, but `ui/Button.svelte` composes the variant's
own string before the caller's, and every text variant's base carries
`inline-flex`. Tailwind v4 emits the display utilities alphabetically:

```css
.block{…}.contents{…}.flex{…}.grid{…}.hidden{display:none}.inline{…}.inline-flex{display:inline-flex}
```

`.hidden` lands *before* `.inline-flex`, both are single-class selectors, so the
later rule wins — regardless of the order the class attribute lists them in.
Tailwind v3 sorted `hidden` last, so the same markup worked until the v4 upgrade
in 75fb987. The guest "Sign in" button has the same bug.

**That fifth control overflowed the row.** At 360px: logo ~137 + search 40 +
theme 40 + bell 36 + Write 50 + avatar 34 + gaps + padding ≈ 381px. With
`justify-between` there is no free space left to distribute, and the wordmark is
a single unbreakable word that will not shrink, so the cluster overlaps it.

Measuring the reported screenshot against known sizes confirms the mechanism
rather than assuming it: the avatar renders 34px (its `size` prop), fixing the
scale at a 360px viewport, and the icon centre-to-centre distances come out
44 / 49 / 48px — exactly `search·theme·bell·write·avatar` at their real widths.

## The fix

- `ui/Button.svelte` — drop our own `inline-flex` when the caller passes an
  unprefixed display utility, so `class="hidden sm:inline-flex"` behaves the way
  it reads. Fixing it here rather than at the call site closes the whole class of
  bug; the trap is invisible at the call site and would be walked into again.
- `Nav.svelte` — `min-w-0` on the logo link, `truncate` on the name, `shrink-0`
  on the mark and the control cluster. The instance name is operator-configurable,
  so a long one ("The JK Labs Journal") would collide even with Write correctly
  hidden. Now it ellipsizes instead of being ridden over.

## Verified

- Rendered the nav markup against this project's own compiled `app.css` in
  headless Chrome at 320 / 360 / 390 / 640 / 768px, signed-in and guest, plus a
  long instance name. Before: the collision reproduces at 360px. After: no
  overlap at any width, and Write plus its label reappear at ≥640px alongside the
  centred search pill.
- Checked every call site passing a display class to `Button` (`PostCard`,
  `drafts`): all three are `variant="plain"`, whose variant string is empty, so
  nothing else changes.
- `svelte-check` 0 errors, `oxfmt --check` and `oxlint` clean, `vite build`
  succeeds.

Not verified: this was a static reproduction using the real compiled CSS and the
exact rendered class strings — I did not drive the live app in a signed-in
session against the backend.

Known and left alone: at 320px a *guest* still truncates to "Omic…", because
search + theme + "Get started" leaves ~153px for the logo. It degrades cleanly
rather than overlapping; giving the full wordmark room there means shrinking the
"Get started" button below `sm`, which is a design call, not a bug fix.

## Deploy notes

None — a plain rebuild picks it up.