### PR TITLE
fix(feed): keep a post card's meta row aligned on a phone

### DIFF
--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -7,7 +7,7 @@
   import TagList from "$lib/components/TagList.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
-  import { excerpt, formatDateTime, readTime } from "$lib/format";
+  import { excerpt, formatDate, formatTime, readTime } from "$lib/format";
   import { postPath } from "$lib/links";
   import { timeZone } from "$lib/timezone";
   import type { Post } from "$lib/types";
@@ -96,13 +96,23 @@
     <TagList tags={post.tags} class="mt-3" />
   {/if}
 
-  <div class="mt-4 flex items-center gap-3">
-    <div class="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
-      <span>{formatDateTime(post.createdAt, $timeZone)}</span>
-      <span class="flex items-center gap-1"><Icon name="clock" size={13} /> {minutes} min read</span>
-      <span class="flex items-center gap-1"><Icon name="heart" size={13} /> {post.likeCount}</span>
-      <span class="flex items-center gap-1"><Icon name="comment" size={13} /> {post.commentCount}</span>
-    </div>
+  <!-- Meta and actions share one wrapping row rather than sitting in two
+       columns: on a phone the meta needs two lines, and a fixed action column
+       beside it then floats in the gap between them, aligned to neither. In one
+       row the buttons stay on the meta's line while there is room and drop to
+       their own right-aligned line when there is not. -->
+  <div class="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
+    <!-- The clock time is what pushes this row past a phone's width, and a card
+         in a feed is a "when", not a timestamp — the post itself still carries
+         the exact one. -->
+    <span
+      >{formatDate(post.createdAt, $timeZone)}<span class="hidden sm:inline"
+        >, {formatTime(post.createdAt, $timeZone)}</span
+      ></span
+    >
+    <span class="flex items-center gap-1"><Icon name="clock" size={13} /> {minutes} min read</span>
+    <span class="flex items-center gap-1"><Icon name="heart" size={13} /> {post.likeCount}</span>
+    <span class="flex items-center gap-1"><Icon name="comment" size={13} /> {post.commentCount}</span>
     <span class="ml-auto flex shrink-0 items-center gap-1">
       <RecommendButton postId={post.id} recommended={post.recommended} recommendCount={post.recommendCount} size="xs" />
       <SaveToListButton postId={post.id} {signedIn} />

--- a/apps/frontend/src/lib/format.ts
+++ b/apps/frontend/src/lib/format.ts
@@ -89,14 +89,19 @@ export function timeAgo(iso: string, timeZone?: string): string {
   return formatDate(iso, timeZone);
 }
 
-// Date plus 24h hh:mm time, e.g. "Jul 8, 2026, 14:05".
-export function formatDateTime(iso: string, timeZone?: string): string {
-  const date = new Date(iso);
-  const time = date.toLocaleTimeString(LOCALE, {
+// 24h hh:mm clock time, e.g. "14:05". Separate from `formatDateTime` so a
+// caller that has room for the day but not the time — a feed card on a phone —
+// can drop just the time rather than reformatting the whole stamp.
+export function formatTime(iso: string, timeZone?: string): string {
+  return new Date(iso).toLocaleTimeString(LOCALE, {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
     timeZone,
   });
-  return `${formatDate(iso, timeZone)}, ${time}`;
+}
+
+// Date plus 24h hh:mm time, e.g. "Jul 8, 2026, 14:05".
+export function formatDateTime(iso: string, timeZone?: string): string {
+  return `${formatDate(iso, timeZone)}, ${formatTime(iso, timeZone)}`;
 }


### PR DESCRIPTION
## Symptom

On a phone the footer of a feed card breaks apart: the date / read time / like
count fill the first line, the comment count is orphaned on a second, and the
recommend + save buttons hang on the right level with neither row.

## Root cause

The footer was two flex columns — a wrapping meta group, and a fixed-width
action group beside it — held together by `items-center`. At a 360px viewport
the meta needs two lines, and centring the action column against a two-line
block puts it in the gap between them. Nothing is misaligned in isolation;
the two columns simply have different heights and no shared baseline.

What pushes the meta over the edge is the timestamp. At 360px the card has
328px of content width, and `Aug 18, 2026, 17:40` + `1 min read` + the two
counts + the actions come to roughly 370px.

## The fix

- Meta and actions share one wrapping row, with `ml-auto` on the actions. They
  stay on the meta's line while there is room and drop to their own
  right-aligned line when there is not — never stranded between two rows.
- Below `sm`, show the date without the clock time. It is the widest item in the
  row, and a card in a feed answers "when", not "at what minute"; the post page
  itself still carries the exact stamp (its byline already stacks for mobile and
  is untouched).
- `formatTime` splits out of `formatDateTime` so the time can be hidden on its
  own — one span, `{date}<span class="hidden sm:inline">, {time}</span>`, rather
  than two alternate copies of the stamp that a screen reader would read twice.

## What was verified

Rendered the footer against this project's own compiled `app.css` in headless
Chrome, before and after, at 320 / 360 / 390 / 640px:

- 360px (the reported width): before, two lines with the actions floating;
  after, everything on one line.
- 320px: after, meta on one line and the actions on their own right-aligned
  line — the degradation is deliberate rather than accidental.
- 640px: the clock time returns, single line, unchanged from today.

Also checked the compiled server output to confirm the date/time span emits no
stray whitespace before the comma. `svelte-check` 0 errors, `oxfmt --check`
clean, `vite build` succeeds.

Not verified: a static reproduction using the real compiled CSS and the exact
rendered class strings, not the live app against a running backend.

## Deploy notes

None — a plain rebuild picks it up. Independent of #48; either can land first.