### PR TITLE
Fail the build when frontend API types drift from the backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,20 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
+      # The typecheck reads the backend's serializers to prove this app's API
+      # types still match them (apps/frontend/src/lib/api/contract.ts), so it
+      # resolves the backend's own npm dependencies — drizzle-orm above all,
+      # which every `db/schema.ts` type flows from. Deno materializes them into
+      # apps/backend/node_modules (`nodeModulesDir: auto` in deno.json). Without
+      # this step svelte-check fails with 45 "Cannot find module 'drizzle-orm'"
+      # errors on backend source, none of which are the frontend's fault.
+      - uses: denoland/setup-deno@v2
+        with:
+          deno-version: v2.x
+      - name: Install backend dependencies (for the cross-app typecheck)
+        working-directory: apps/backend
+        run: deno install
+
       - name: Run Checks
         run: pnpm check
 

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -150,7 +150,7 @@ export const posts = pgTable("posts", {
   // Publication state. `draft` posts are private to their author (never federated,
   // never surfaced in any public feed or profile) until published. Remote posts
   // are always `published`. Existing rows default to `published` on migration.
-  status: text("status").notNull().default("published"),
+  status: text("status").$type<"draft" | "published">().notNull().default("published"),
   // BCP-47 primary language subtag the author wrote this post in (e.g. "en",
   // "tr"), lowercased, or null when unspecified. Drives the reader's per-language
   // feed filter and federates as the Article content's language tag. Remote posts
@@ -468,7 +468,7 @@ export const readingLists = pgTable("reading_lists", {
   userId: uuid("user_id").notNull().references(() => users.id, { onDelete: "cascade" }),
   title: text("title").notNull(),
   description: text("description").notNull().default(""),
-  visibility: text("visibility").notNull().default("public"), // "public" | "private"
+  visibility: text("visibility").$type<"public" | "private">().notNull().default("public"),
   isReadLater: boolean("is_read_later").notNull().default(false),
   createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
 }, (t) => [

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -1,5 +1,12 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import type { Post, ProfileLink, RemoteActor, User, WebhookToken } from "@/db/schema.ts";
+import type {
+  Post,
+  ProfileLink,
+  ReadingList as ReadingListRow,
+  RemoteActor,
+  User,
+  WebhookToken,
+} from "@/db/schema.ts";
 import type { PostWithAuthor } from "@/db/repositories/posts.ts";
 import type { CommentWithAuthor } from "@/db/repositories/comments.ts";
 import type { NotificationRow } from "@/db/repositories/notifications.ts";
@@ -325,7 +332,7 @@ export function readingListView(
     id: string;
     title: string;
     description: string;
-    visibility: string;
+    visibility: ReadingListRow["visibility"];
     isReadLater: boolean;
     createdAt: Date;
     itemCount: number;

--- a/apps/frontend/src/deno-globals.d.ts
+++ b/apps/frontend/src/deno-globals.d.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Minimal declarations for the Deno globals the backend source touches.
+//
+// `src/lib/types.ts` derives the API payload types from the backend's own
+// serializers (see the `@` alias in svelte.config.js). TypeScript typechecks
+// every module in that import graph, and a few of them — config.ts most of all —
+// read `Deno.env` at module scope. This app runs on Node and has no Deno types,
+// so without these declarations the frontend typecheck fails on backend source
+// it only ever reads types from.
+//
+// Deliberately narrow: it covers exactly the surface the imported graph uses,
+// not the whole Deno API. If a future backend change pulls in more, add it here
+// — the typecheck will say which. Nothing here reaches the bundle; the backend
+// is only ever imported with `import type`, which is erased at build time.
+declare namespace Deno {
+  export const env: {
+    get(key: string): string | undefined;
+    set(key: string, value: string): void;
+    has(key: string): boolean;
+    toObject(): Record<string, string>;
+  };
+  export function exit(code?: number): never;
+  export function mkdirSync(path: string, options?: { recursive?: boolean }): void;
+  export function readTextFileSync(path: string): string;
+  export function writeTextFileSync(path: string, data: string, options?: { mode?: number }): void;
+}
+
+// The backend imports hono through the `jsr:` import map in deno.json, which
+// this app's Node-style resolver cannot follow. It surfaces here because
+// `routes/serializers.ts` imports `lib/cover.ts`, which imports `lib/http.ts`,
+// whose only use of hono is `import type { Context }` in signatures nothing on
+// this side ever reads. A shorthand ambient declaration (no body — every import
+// from it is `any`) is therefore enough to let that module typecheck, and keeps
+// the real hono types out of this app entirely. This app does not use hono
+// itself, so nothing else is affected.
+declare module "hono" {
+  // Only ever appears as a parameter annotation inside backend modules; no
+  // type information from it is read on this side. Structural-any keeps the
+  // members those modules call (`c.json`, `c.req`) resolvable.
+  // oxlint-disable-next-line no-explicit-any
+  export type Context = Record<string, any>;
+}

--- a/apps/frontend/src/lib/api/contract.ts
+++ b/apps/frontend/src/lib/api/contract.ts
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Compile-time proof that `$lib/types` still matches what the backend sends.
+//
+// The types in `$lib/types` are hand-written on purpose: they carry the
+// reader's half of the documentation (which field to link with, which is null
+// when, which endpoint omits which), which a mechanically derived type cannot.
+// The cost of writing them by hand is that they can drift from the backend's
+// serializers without anything noticing until it breaks at runtime.
+//
+// This file removes that cost. It imports the backend's serializers as types
+// only (through the `@` alias — see svelte.config.js) and asserts that every
+// payload the backend produces is assignable to the type this app declares for
+// it. Nothing imports this module; it exists to be typechecked. It emits no
+// runtime code at all, so it never reaches the bundle.
+//
+// A serializer change that breaks a frontend type now fails `pnpm svelte-check`
+// with the offending pair named, instead of shipping.
+//
+// ── direction of the assertion ──
+// The check is one-way: backend payload → frontend type. That is deliberate,
+// not a weakened equality check.
+//   • backend changes a field's type      → fails ✔ (the frontend would misread it)
+//   • backend stops sending a field       → fails ✔ (the frontend expects it)
+//   • frontend declares a field never sent → fails ✔ (undefined at runtime)
+//   • backend adds a field the UI ignores → passes ✔ (genuinely harmless)
+// Requiring equality instead would flag that last case, which is normal and
+// safe, and would break every frontend type that deliberately widens across
+// several endpoints (`Post.status` is optional because `barePost` omits it).
+
+import type {
+  AdminUser,
+  Comment,
+  CoverCredit,
+  Notification,
+  Post,
+  PostAuthor,
+  ProfileLink,
+  ReadingList,
+  RecommendedBy,
+  RelationActor,
+  RemoteProfile,
+  Tag,
+  User,
+  WebhookToken,
+} from "$lib/types";
+import type {
+  adminUserView,
+  commentView,
+  notificationView,
+  postWithAuthor,
+  profileLinkView,
+  publicUser,
+  readingListView,
+  RecommendedBy as BackendRecommendedBy,
+  relationActorLocal,
+  relationActorRemote,
+  remoteProfile,
+  TagSummary,
+  webhookTokenView,
+} from "@/routes/serializers.ts";
+
+// What `c.json()` does to a serializer's return value on the way out: `Date`
+// becomes an ISO string, everything else keeps its shape. Applied to the
+// backend side of every assertion below so the two sides are compared as they
+// actually meet — over the wire — rather than as they look in Deno's memory.
+type Serialized<T> = T extends Date
+  ? string
+  : T extends (infer U)[]
+    ? Serialized<U>[]
+    : T extends object
+      ? { [K in keyof T]: Serialized<T[K]> }
+      : T;
+
+// Yields `true` when the backend payload fits the frontend type, and otherwise
+// an object type naming both sides — which `Assert` then rejects, putting both
+// in the compiler's error message.
+type Fits<Payload, Declared> = Payload extends Declared
+  ? true
+  : {
+      ERROR: "Backend payload no longer matches the type this app declares for it.";
+      payload: Payload;
+      declared: Declared;
+    };
+
+type Assert<T extends true> = T;
+
+type Wire<F extends (...args: never[]) => unknown> = Serialized<ReturnType<F>>;
+
+// ── assertions ──
+// Each line reads: the payload this serializer produces fits the type the
+// frontend declares for it.
+
+type _Tag = Assert<Fits<Serialized<TagSummary>, Tag>>;
+type _ProfileLink = Assert<Fits<Wire<typeof profileLinkView>, ProfileLink>>;
+// Reached through `postWithAuthor` rather than imported from `@/lib/cover.ts`
+// directly: that module imports `@/lib/http.ts`, which imports hono — a jsr
+// specifier this app's resolver cannot see. Going through the serializer keeps
+// the backend type graph reachable from here free of any runtime dependency.
+type _CoverCredit = Assert<Fits<NonNullable<Wire<typeof postWithAuthor>["coverCredit"]>, CoverCredit>>;
+
+type _User = Assert<Fits<Wire<typeof publicUser>, User>>;
+type _AdminUser = Assert<Fits<Wire<typeof adminUserView>, AdminUser>>;
+
+type _Post = Assert<Fits<Wire<typeof postWithAuthor>, Post>>;
+type _PostAuthor = Assert<Fits<Wire<typeof postWithAuthor>["author"], PostAuthor>>;
+type _RecommendedBy = Assert<Fits<Serialized<BackendRecommendedBy>, RecommendedBy>>;
+
+type _Comment = Assert<Fits<Wire<typeof commentView>, Comment>>;
+type _Notification = Assert<Fits<Wire<typeof notificationView>, Notification>>;
+type _WebhookToken = Assert<Fits<Wire<typeof webhookTokenView>, WebhookToken>>;
+type _ReadingList = Assert<Fits<Wire<typeof readingListView>, ReadingList>>;
+
+type _RemoteProfile = Assert<Fits<Wire<typeof remoteProfile>, RemoteProfile>>;
+type _RelationActorLocal = Assert<Fits<Wire<typeof relationActorLocal>, RelationActor>>;
+type _RelationActorRemote = Assert<Fits<Wire<typeof relationActorRemote>, RelationActor>>;

--- a/apps/frontend/svelte.config.js
+++ b/apps/frontend/svelte.config.js
@@ -11,6 +11,23 @@ const config = {
     // render-blocking CSS and JS transfer sizes.
     adapter: adapter({ precompress: true }),
 
+    // `@` resolves to the backend's source tree, mirroring the `@/` import map
+    // in apps/backend/deno.json so a path written there means the same thing
+    // here. It exists so `src/lib/types.ts` can derive the API payload types
+    // from the backend's own serializers instead of re-declaring them by hand —
+    // a serializer change then fails this app's typecheck instead of silently
+    // shipping a wrong type. Declared here rather than as a `paths` entry in
+    // tsconfig.json because SvelteKit generates `paths` itself; overriding that
+    // object wholesale would drop the `$lib`/`$app` aliases it puts there.
+    //
+    // Every import through this alias MUST be `import type`. The backend is
+    // Deno and its modules are not resolvable at runtime here; type-only
+    // imports are erased at build time (verbatimModuleSyntax), so nothing from
+    // the backend ever reaches the bundle.
+    alias: {
+      "@": "../backend/src",
+    },
+
     // Content-Security-Policy. `auto` makes SvelteKit hash/nonce its own inline
     // hydration script, so we can keep `script-src 'self'` with NO
     // `unsafe-inline` — an injected inline <script> (e.g. from any future

--- a/apps/frontend/svelte.config.js
+++ b/apps/frontend/svelte.config.js
@@ -24,6 +24,11 @@ const config = {
     // Deno and its modules are not resolvable at runtime here; type-only
     // imports are erased at build time (verbatimModuleSyntax), so nothing from
     // the backend ever reaches the bundle.
+    //
+    // Consequently `pnpm build` does not need ../backend to exist at all —
+    // which is what lets the Dockerfile keep building from this directory alone
+    // as its context. Only the typecheck reads through this alias, and it needs
+    // the backend's own npm dependencies resolvable (see the CI frontend job).
     alias: {
       "@": "../backend/src",
     },

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -7,6 +7,10 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,
+    // The backend writes its imports with explicit ".ts" extensions (Deno
+    // requires them), so resolving its source through the `@` alias needs this.
+    // Permitted only because this project never emits JS from tsc (noEmit).
+    "allowImportingTsExtensions": true,
     "skipLibCheck": true,
     "sourceMap": true,
     "types": ["node"],


### PR DESCRIPTION
Opened off the discussion in #16.

## The symptom

`apps/frontend/src/lib/types.ts` declares 51 types that mirror the backend's
serializers, kept in step by hand. Nothing checks them. A serializer can change
shape — a renamed field, a narrowed type, a field dropped — and both apps still
compile. The mismatch shows up as a runtime bug in whichever component reads the
field, at which point the type that lied is several files away from the crash.

## The root cause

There is no link between the two sides. `types.ts` says
`commentCount: number`; `routes/serializers.ts` says
`commentCount: engagement?.commentCount ?? 0`. Those two facts are related only
by whoever last edited both.

## The fix

`apps/frontend/src/lib/api/contract.ts` imports the backend serializers as types
only, applies the JSON round-trip the wire performs (`Date` → string), and
asserts each payload is assignable to the type this app declares for it. It is
imported by nothing and emits no runtime code; it exists to be typechecked.

The assertion is one-way, backend payload → frontend type:

| change | result | |
|---|---|---|
| backend changes a field's type | fails | the frontend would misread it |
| backend stops sending a field | fails | the frontend expects it |
| frontend declares a field never sent | fails | `undefined` at runtime |
| backend adds a field the UI ignores | passes | genuinely harmless |

Equality instead of assignability would flag that last row, which is normal, and
would break every type that deliberately widens across endpoints — `Post.status`
is optional precisely because `barePost` omits it.

### Why not derive the types, or use Hono RPC

Deriving `types.ts` from the serializers was the first plan. Reading both sides
killed it: the frontend comments carry the *reader's* half of the documentation
("Build links with `postPath`, never by hand"; which field is null when; which
endpoint omits which) and the backend comments carry the producer's half. They
are not duplicate prose, and a generated type holds neither. The duplication was
never the problem — the duplication going unchecked was.

Full Hono RPC (the original suggestion in #16) would also solve this, and costs
much more: all 134 handlers rewritten as single chains, `zValidator` added to 34
bare `c.req.json()` calls, and 141 call sites converted from a throwing
`ApiError` to checking a `Response` — plus coupling the frontend build to every
backend route signature, and Hono's type inference is a known problem at that
route count. This gets the drift protection without any of it. Worth saying
plainly: RPC would cover more surface than this does.

## What this found

Two real mismatches, both fixed in the first commit:

- `posts.status` — `text` column, inferred `string`; frontend declared
  `"draft" | "published"`
- `readingLists.visibility` — same, and the schema comment beside it already
  read `// "public" | "private"`

Both are now `$type<>()` on the column: compile-time only, no migration, no data
change. `deno check` and the full test suite pass untouched, which confirms
nothing depended on the wider type. `readingListView` takes its `visibility`
from the column type now rather than restating `string`, so they cannot drift
apart again.

## Mechanics

- `@` is aliased to the backend source via `kit.alias` in `svelte.config.js`, so
  SvelteKit generates the tsconfig `paths` itself. Writing `paths` directly in
  `tsconfig.json` would replace the object SvelteKit puts `$lib` and `$app` in.
- `src/deno-globals.d.ts` declares the small Deno surface the imported graph
  touches (`config.ts` reads `Deno.env` at module scope), plus a stub for hono —
  reachable only because `serializers.ts` imports `lib/cover.ts`, which imports
  `lib/http.ts`, whose only use of hono is `import type { Context }`.
- Every backend import is `import type`, erased by `verbatimModuleSyntax`.

## Verified

- Deleted `commentCount` from `postWithAuthor`, re-ran `svelte-check`: **fails**
  and names the pair. Before this branch the same deletion built clean on both
  sides. Restored.
- `svelte-check`: 5204 files, 0 errors, 0 warnings
- `pnpm check` (greenly): passed
- backend `deno check` + `deno test -A`: 161 passed, 0 failed
- `pnpm build` succeeds; grepped the output for backend source and for
  `contract.ts` — neither appears anywhere in the bundle

Not verified: no instance was run against this. Nothing here changes runtime
behaviour — the `$type<>()` narrowing is erased at compile time and the contract
file is never imported — but that reasoning, not an actual boot, is the basis
for saying so.

## Known gaps

- **Coverage is 15 assertions over 14 of the 51 types** — the ones a named
  serializer produces. The rest (`InstanceSettings`, `SearchResults`,
  `SitemapContents`, `AdminInstance`, `EmailSettings`, …) are built inline in
  route handlers with no named backend type, so there is nothing to assert
  against. Covering them means naming those shapes in the backend first.
- **The write path is still unchecked.** `$type<>()` constrains what the backend
  reads out of the DB, not what goes in: `createPost` takes
  `await c.req.json()` as `any`, so an invalid `status` still typechecks. Only 3
  of the 9 route files calling `c.req.json()` validate with zod. Adding
  `zValidator` to the rest is the natural follow-up and is worth doing on its
  own merits.
- The frontend typecheck now reads backend source, so a Deno-only API added to
  anything in that import graph can break this app's build. The graph is small
  and the shim says what to add when it happens, but it is a new coupling.

## CI

The frontend job now installs the backend's npm dependencies before the
typecheck. Reading backend source means resolving what backend source imports,
and drizzle-orm — which every `db/schema.ts` type flows from — lives in
`apps/backend/node_modules`, materialized by Deno's `nodeModulesDir: auto`.
That directory exists locally as a side effect of ever having run the backend,
and never on a fresh CI checkout. Caught by moving it aside before pushing:
svelte-check went 0 → 45 errors, every one of them against backend files.
`deno install` in `apps/backend` restores it.

Only the typecheck needs this. `pnpm build` resolves nothing through the `@`
alias, since the sole importer is type-only and erased — verified by building
the frontend image, whose context is `apps/frontend` alone and contains no
`../backend` at all.

## Deploy notes

None. No migration, no config, no environment variables.

`apps/backend/src/services/instanceSetup.ts` fails `deno fmt --check` on `main`
already; left alone rather than mixing an unrelated reformat into this branch.

