### PR TITLE
Note the backend install the frontend typecheck needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ cd apps/backend && deno task dev              # http://localhost:8000
 cd apps/frontend && pnpm install && pnpm dev  # http://localhost:5173
 ```
 
+Run the backend at least once before the frontend's `pnpm check`, even when
+working only on the frontend. The frontend typecheck reads the backend's
+serializers to verify its own API types still match them
+(`apps/frontend/src/lib/api/contract.ts`), so it needs the backend's npm
+dependencies on disk. `deno task dev` installs them as a side effect; `deno
+install` in `apps/backend` does it on its own. Skip this and `pnpm check`
+reports `Cannot find module 'drizzle-orm'` against backend files rather than
+anything you changed.
+
 See the [local setup guide](https://docs.omicron.blog/development/local-setup/)
 for the full picture.
 


### PR DESCRIPTION
Follow-up to #50, closing the one gap that PR introduced and did not cover.

**Symptom.** A contributor working only on the frontend clones, runs
`pnpm install && pnpm check`, and gets 45 errors — all
`Cannot find module 'drizzle-orm'` and the implicit `any`s cascading from it,
reported against files under `apps/backend/` they have never opened. Nothing on
screen connects that to anything they did or skipped.

**Cause.** Since #50 the frontend typecheck reads the backend's serializers to
verify its own API types still match them, so it resolves what that source
imports. Those dependencies live in `apps/backend/node_modules`, which Deno
materializes via `nodeModulesDir: auto` as a side effect of running the backend.
CI installs them explicitly. A frontend-only local checkout never does.

**Fix.** A note in the Development section. `deno install` is called out
separately from `deno task dev` because the latter needs Postgres running, which
a frontend-only contributor has no other reason to start.

**Verified.** `rm -rf apps/backend/node_modules && deno install` in
`apps/backend`, then `pnpm check` in `apps/frontend` — 5204 files, 0 errors.
That is the exact path the note describes.

Docs-only; no code, no behaviour change.
