### PR TITLE
Enforce backend formatting in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
         run: deno task check
       - name: Lint
         run: deno lint
+      # The frontend job already enforces its own formatting (greenly runs
+      # `pnpm fmt:check`); the backend had no equivalent gate, so a file could —
+      # and did — sit unformatted on main indefinitely.
+      - name: Format
+        run: deno fmt --check
       - name: Test
         run: deno task test
       - name: Audit dependencies

--- a/apps/backend/src/services/instanceSetup.ts
+++ b/apps/backend/src/services/instanceSetup.ts
@@ -170,7 +170,14 @@ export async function publicInfo(): Promise<{
     getBannerText(),
     getBannerImageUrl(),
   ]);
-  return { name, domain, federationEnabled: federationRunning(), setupComplete, bannerText, bannerImageUrl };
+  return {
+    name,
+    domain,
+    federationEnabled: federationRunning(),
+    setupComplete,
+    bannerText,
+    bannerImageUrl,
+  };
 }
 
 // Persists the wizard's instance settings and marks setup finished. The admin


### PR DESCRIPTION
## What was wrong

The backend CI job runs `deno task check`, `deno lint` and `deno task test`, but
never `deno fmt --check`. Nothing stopped an unformatted file reaching `main`,
and one had: `apps/backend/src/services/instanceSetup.ts` fails
`deno fmt --check` and has for a while.

The frontend never had this gap — greenly runs `pnpm fmt:check` as the first of
its three checks, so the existing `pnpm check` step already gates it.

## The fix

A `deno fmt --check` step in the backend job, plus the one file `deno fmt`
wanted changed: a long `return` in `publicInfo()` wrapped across lines. No
behaviour change, and the diff is `deno fmt`'s output, not a hand edit.

## Why now and not earlier

This came up during #50, #51 and #52, all of which touched the backend. I left
it alone each time — a drive-by reformat inside an unrelated diff is exactly
what makes a review harder than it needs to be. It gets its own PR instead.

## Verified

`deno fmt --check`, `deno task check`, `deno lint` and `deno task test`
(168 passed) all clean locally. CI now runs the same four.

## Deploy notes

None. Formatting and a CI step.
