### PR TITLE
Stop public reading lists disclosing drafts and private-account posts

### DIFF
--- a/apps/backend/src/db/repositories/readingLists.ts
+++ b/apps/backend/src/db/repositories/readingLists.ts
@@ -10,7 +10,13 @@ import {
   remoteActors,
   users,
 } from "@/db/schema.ts";
-import type { PostWithAuthor } from "@/db/repositories/posts.ts";
+import {
+  isPublished,
+  notHidden,
+  notSuspended,
+  type PostWithAuthor,
+  visibleToViewer,
+} from "@/db/repositories/posts.ts";
 import { type Cursor, DEFAULT_PAGE_SIZE } from "@/lib/pagination.ts";
 
 // Reading-list DB access. Adding a post is idempotent via the unique
@@ -123,13 +129,32 @@ export async function removeItem(listId: string, postId: string): Promise<void> 
 }
 
 // Item count per list, for the list cards. Batched over many lists in one query.
-export async function itemCountsFor(listIds: string[]): Promise<Map<string, number>> {
+//
+// Counts only what this viewer could actually read, using the same predicates
+// as `listItems`. A raw count would otherwise report items the reader is not
+// allowed to see — a list showing "5 posts" and returning 4 tells a stranger a
+// hidden post exists, which is a smaller version of the disclosure the filter
+// on the read path closes.
+export async function itemCountsFor(
+  listIds: string[],
+  viewerId: string | null,
+): Promise<Map<string, number>> {
   const map = new Map<string, number>();
   if (listIds.length === 0) return map;
   const rows = await db
     .select({ listId: readingListItems.listId, count: sql<number>`count(*)::int` })
     .from(readingListItems)
-    .where(inArray(readingListItems.listId, listIds))
+    .innerJoin(posts, eq(readingListItems.postId, posts.id))
+    .leftJoin(users, eq(posts.authorId, users.id))
+    .where(
+      and(
+        inArray(readingListItems.listId, listIds),
+        isPublished,
+        notSuspended,
+        notHidden(viewerId),
+        visibleToViewer(viewerId),
+      ),
+    )
     .groupBy(readingListItems.listId);
   for (const r of rows as { listId: string; count: number }[]) map.set(r.listId, r.count);
   return map;
@@ -155,12 +180,24 @@ export async function listIdsContaining(
 // newest-added first to match the on-site list order.
 export type ItemRef = { id: string; apId: string | null; remote: boolean };
 
+// Filtered as an anonymous stranger sees it: this collection is served to any
+// instance that asks for it, so a draft or a private author's post must not
+// appear even as a bare URI. `visibleToViewer(null)` and `notSuspended` read
+// `users`, hence the left join.
 export async function itemRefs(listId: string): Promise<ItemRef[]> {
   const rows = await db
     .select({ id: posts.id, apId: posts.apId, remote: posts.remote })
     .from(readingListItems)
     .innerJoin(posts, eq(readingListItems.postId, posts.id))
-    .where(eq(readingListItems.listId, listId))
+    .leftJoin(users, eq(posts.authorId, users.id))
+    .where(
+      and(
+        eq(readingListItems.listId, listId),
+        isPublished,
+        notSuspended,
+        visibleToViewer(null),
+      ),
+    )
     .orderBy(desc(readingListItems.createdAt), desc(readingListItems.id));
   return rows as ItemRef[];
 }
@@ -186,8 +223,16 @@ function beforeItemCursor(cursor: Cursor | null) {
 
 // A list's posts, most recently added first, keyset-paginated. Fetches
 // `limit + 1` so the service can derive the next cursor.
+//
+// Carries the same visibility predicates as every other listing (timelines,
+// profiles, tags, search). Being *in* a list grants a post no exemption: a
+// draft, a suspended author's post, and a private author's post are each
+// withheld here exactly as they are everywhere else, however the item came to
+// be saved. Without this a public list re-published anything it held — the post
+// could 404 on its own permalink and still be served in full from here.
 export async function listItems(
   listId: string,
+  viewerId: string | null,
   cursor: Cursor | null,
   limit = DEFAULT_PAGE_SIZE,
 ): Promise<ListItemRow[]> {
@@ -213,7 +258,16 @@ export async function listItems(
     .innerJoin(posts, eq(readingListItems.postId, posts.id))
     .leftJoin(users, eq(posts.authorId, users.id))
     .leftJoin(remoteActors, eq(posts.remoteActorId, remoteActors.id))
-    .where(and(eq(readingListItems.listId, listId), beforeItemCursor(cursor)))
+    .where(
+      and(
+        eq(readingListItems.listId, listId),
+        isPublished,
+        notSuspended,
+        notHidden(viewerId),
+        visibleToViewer(viewerId),
+        beforeItemCursor(cursor),
+      ),
+    )
     .orderBy(desc(readingListItems.createdAt), desc(readingListItems.id))
     .limit(limit + 1);
   return rows as unknown as ListItemRow[];

--- a/apps/backend/src/services/readingLists.ts
+++ b/apps/backend/src/services/readingLists.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import * as listsRepo from "@/db/repositories/readingLists.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
+import * as postsService from "@/services/posts.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import type { ReadingList } from "@/db/schema.ts";
 import { type Cursor, DEFAULT_PAGE_SIZE, encodeCursor } from "@/lib/pagination.ts";
@@ -22,8 +23,11 @@ function normalizeVisibility(v: unknown): "public" | "private" {
 }
 
 // Attaches item counts to a batch of lists in one query.
-async function withCounts(lists: ReadingList[]): Promise<ListWithCount[]> {
-  const counts = await listsRepo.itemCountsFor(lists.map((l) => l.id));
+async function withCounts(
+  lists: ReadingList[],
+  viewerId: string | null,
+): Promise<ListWithCount[]> {
+  const counts = await listsRepo.itemCountsFor(lists.map((l) => l.id), viewerId);
   return lists.map((l) => ({ ...l, itemCount: counts.get(l.id) ?? 0 }));
 }
 
@@ -31,7 +35,7 @@ async function withCounts(lists: ReadingList[]): Promise<ListWithCount[]> {
 // exist (created lazily here so the list is always present in the UI).
 export async function myLists(userId: string): Promise<ListWithCount[]> {
   await listsRepo.ensureReadLater(userId);
-  return withCounts(await listsRepo.listForUser(userId, false));
+  return withCounts(await listsRepo.listForUser(userId, false), userId);
 }
 
 // A named user's lists for their profile. The owner sees everything; everyone
@@ -44,12 +48,12 @@ export async function listsForProfile(
   if (!owner) throw notFound("User not found.");
   const isOwner = viewerId === owner.id;
   if (isOwner) await listsRepo.ensureReadLater(owner.id);
-  return withCounts(await listsRepo.listForUser(owner.id, !isOwner));
+  return withCounts(await listsRepo.listForUser(owner.id, !isOwner), viewerId);
 }
 
 export async function readLater(userId: string): Promise<ListWithCount> {
   const list = await listsRepo.ensureReadLater(userId);
-  const [withCount] = await withCounts([list]);
+  const [withCount] = await withCounts([list], userId);
   return withCount;
 }
 
@@ -101,7 +105,7 @@ export async function getList(
   { list: ListWithCount; isOwner: boolean; owner: { username: string; displayName: string } }
 > {
   const list = await readableList(listId, viewerId);
-  const [withCount] = await withCounts([list]);
+  const [withCount] = await withCounts([list], viewerId);
   const owner = await usersRepo.findById(list.userId);
   return {
     list: withCount,
@@ -114,7 +118,7 @@ export async function listItems(listId: string, viewerId: string | null, cursor:
   // `listId` may be a short id-prefix from a canonical URL; resolve to the full
   // row first, then query items by its real UUID.
   const list = await readableList(listId, viewerId);
-  const rows = await listsRepo.listItems(list.id, cursor, DEFAULT_PAGE_SIZE);
+  const rows = await listsRepo.listItems(list.id, viewerId, cursor, DEFAULT_PAGE_SIZE);
   const hasMore = rows.length > DEFAULT_PAGE_SIZE;
   const items = hasMore ? rows.slice(0, DEFAULT_PAGE_SIZE) : rows;
   const last = items.at(-1);
@@ -153,7 +157,7 @@ export async function updateList(
   if (input.visibility !== undefined) patch.visibility = normalizeVisibility(input.visibility);
 
   const updated = Object.keys(patch).length ? await listsRepo.update(list.id, patch) : list;
-  const [withCount] = await withCounts([updated]);
+  const [withCount] = await withCounts([updated], userId);
   return withCount;
 }
 
@@ -166,7 +170,16 @@ export async function deleteList(userId: string, listId: string): Promise<void> 
 
 export async function addItem(userId: string, listId: string, postId: string): Promise<void> {
   const list = await ownedList(listId, userId);
-  if (!(await postsRepo.findById(postId))) throw notFound("Post not found.");
+  // Only a post this user can actually see may be saved. `getPost` applies the
+  // same rule a permalink does — drafts to their author, private authors to
+  // approved followers, blocks both ways — and throws not-found otherwise, so
+  // an id alone is never enough to pull a post into a list.
+  //
+  // The read path filters too, so this is the second of two gates rather than
+  // the only one. It matters because the read filter is evaluated against
+  // whoever is *reading*: without this, a post the saver could never see would
+  // sit in the list waiting for someone who can.
+  await postsService.getPost(postId, userId);
   await listsRepo.addItem(list.id, postId);
   // Public lists federate an Add to the owner's remote followers; private and
   // Read-later-while-private lists stay local.
@@ -192,6 +205,6 @@ export async function listsForPost(
   await listsRepo.ensureReadLater(userId);
   const lists = await listsRepo.listForUser(userId, false);
   const containing = await listsRepo.listIdsContaining(lists.map((l) => l.id), postId);
-  const withCount = await withCounts(lists);
+  const withCount = await withCounts(lists, userId);
   return withCount.map((l) => ({ ...l, contains: containing.has(l.id) }));
 }


### PR DESCRIPTION
Fixes #41. Reported by @Kozirr, whose analysis was accurate — including the
federation path.

## The symptom

A post saved to a public reading list is served to anyone who asks for that
list, whether or not they are allowed to see the post. Reproduced on a live
instance, both variants. In each, the post is correctly `404` on its own
permalink and absent from the global timeline, yet an **anonymous**
`GET /api/lists/{id}/items` returns it in full, `contentHtml` included:

| Anonymous request | Draft variant | Private-account variant |
| --- | --- | --- |
| `GET /api/posts/{id}` | 404 ✓ | 404 ✓ |
| `GET /api/posts` (timeline) | absent ✓ | absent ✓ |
| `GET /api/lists/{id}/items` | **full body, `"status":"draft"`** ✗ | **full body** ✗ |

No attacker is needed. "Publish, someone saves it, later unpublish" is ordinary
user behaviour, and the post silently stays world-readable.

## The root cause

The invariant already exists and is documented — `isPublished`, `notSuspended`,
`notHidden` and `visibleToViewer` in `db/repositories/posts.ts:450-505`, the
last carrying the comment *"a private author's posts must never show to a
logged-out viewer."* Every timeline, profile, tag and search query applies them.

`listItems` applied none. Its entire WHERE clause was the list id plus the
pagination cursor (`db/repositories/readingLists.ts:216`). `readableList` gates
access to the *list*; nothing gated the *items*. This is one query that missed a
rule the rest of the codebase follows — not a design gap.

## The fix

Four paths, because read-time filtering alone leaves the other three:

1. **`listItems`** takes the viewer and applies all four predicates. The route
   already passed a viewer id to the service; the service was dropping it before
   the query.
2. **`itemRefs`** — which builds the federated `OrderedCollection` at
   `/users/{id}/lists/{listId}`, served to any instance that asks — filters as
   an anonymous stranger, so a draft does not leak off-instance even as a bare
   URI.
3. **`itemCountsFor`** counts only what the viewer can read. Found while
   verifying the fix: a list reporting "1 post" while returning none still tells
   a stranger something hidden is in there.
4. **`addItem`** requires the post to be visible to the person saving it, via
   `postsService.getPost`. Without it an unreadable post can be parked in a list
   waiting for a reader who *is* allowed to see it.

`updateList` needs no change — it does not federate existing items on a
public transition, and the collection is generated on demand from `itemRefs`,
which now filters. That covers the "public-transition" path in the report.

### Consequence worth knowing

The filter is per reader, so an item disappears and returns as its post's status
or its author's privacy changes. The row is never deleted, so republishing
restores it. Notably an author does **not** see their own draft in someone
else's list — consistent with the global timeline, where drafts are also hidden
from their author and appear only under `/posts/drafts`.

## Verified

Rerun of the reproduction against the patched build, on a live instance:

```
baseline: anonymous sees published item        1  (want 1)
baseline: itemCount                            1  (want 1)
-- author unpublishes the post --
anonymous list items                           0  (want 0)
list owner's list items                        0  (want 0)
itemCount no longer leaks it                   0  (want 0)
post's own endpoint                          404  (want 404)
republished -> item returns                    1  (want 1)
-- author switches account to private --
anonymous list items                           0  (want 0)
itemCount                                      0  (want 0)
-- adding a post the saver cannot see --
add another user's draft by id               404  (want 404)
```

`deno task check`, `deno lint`, `deno fmt --check`, `deno task test` (168
passed) all clean.

**Not verified over the wire:** the federated collection. Federation was off in
the test instance, so `itemRefs` is confirmed by the predicates being in the
query, not by fetching the collection from another server.

**No regression test.** The suite is pure unit tests and CI has no database, so
a fix living in SQL predicates has nothing to assert against without adding DB
fixtures — a materially larger change than this one, and not something to
bundle into a security fix. Worth doing separately; this class of bug is exactly
what an integration test would have caught.

## Deploy notes

None — no migration, no config. Takes effect on restart.

Existing list rows are untouched: items that should never have been visible are
now filtered at read time rather than deleted, so nothing is lost if a post is
later republished or an account goes public again.
