### PR TITLE
fix: close five visibility-predicate gaps found auditing every posts query

### DIFF
--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -718,6 +718,11 @@ export function listByTag(
 export function listFeed(userId: string, cursor: Cursor | null, limit = DEFAULT_PAGE_SIZE) {
   // Only *approved* follows contribute posts: a pending request to a private
   // account must not leak that account's posts into the requester's feed.
+  //
+  // The follow branches below are self-gating that way, but the followed-tag
+  // branch is not — it matches on a tag anyone can apply, so without
+  // `visibleToViewer` a private author's post reaches every reader who follows
+  // one of its tags.
   const followedLocal = sql`(
     select followee_id from follows
     where follower_id = ${userId} and followee_id is not null and approved = true
@@ -744,6 +749,7 @@ export function listFeed(userId: string, cursor: Cursor | null, limit = DEFAULT_
         ),
         notSuspended,
         notHidden(userId),
+        visibleToViewer(userId),
         beforeCursor(cursor),
       ),
     )

--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -294,11 +294,17 @@ export function listAllContent() {
 // fetch and each file would look wholly rewritten to a crawler.
 export const SITEMAP_PAGE_SIZE = 40000;
 
+// Private accounts are excluded for the same reason listSitemapProfiles
+// excludes them: their posts are visible only to approved followers, so a
+// crawler that follows the URL gets nothing — and the entry itself would
+// publish the post's existence, author and slug to anyone who fetches
+// /sitemap.xml.
 const publishedLocally = () =>
   and(
     eq(posts.remote, false),
     eq(posts.status, "published"),
     sql`${users.suspendedAt} is null`,
+    eq(users.isPrivate, false),
   );
 
 export function listSitemapEntries(page = 1) {

--- a/apps/backend/src/db/repositories/recommendations.ts
+++ b/apps/backend/src/db/repositories/recommendations.ts
@@ -200,6 +200,11 @@ export function listFeedFor(userId: string, cursor: Cursor | null, limit = DEFAU
         ),
         notSuspended,
         notHidden(userId),
+        // Gates on the *post's* author, not the recommender. The `or` above
+        // only establishes that the viewer follows whoever boosted it — a
+        // followed account can recommend a private author's post, and without
+        // this that post's body would be served to a non-follower.
+        visibleToViewer(userId),
         beforeCursor(cursor),
       ),
     )

--- a/apps/backend/src/db/repositories/tags.ts
+++ b/apps/backend/src/db/repositories/tags.ts
@@ -1,7 +1,16 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { and, desc, eq, gt, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client.ts";
-import { posts, postTags, remoteActorTags, tagFollows, tags, userTags } from "@/db/schema.ts";
+import {
+  posts,
+  postTags,
+  remoteActorTags,
+  tagFollows,
+  tags,
+  users,
+  userTags,
+} from "@/db/schema.ts";
+import { isPublished, notSuspended, visibleToViewer } from "@/db/repositories/posts.ts";
 
 // Tag DB access. Callers pass already-normalized slugs (see lib/tags.ts); the
 // stored `name` mirrors the slug so display and matching stay consistent.
@@ -55,14 +64,24 @@ export function findBySlug(slug: string) {
   return db.query.tags.findFirst({ where: eq(tags.slug, slug) });
 }
 
-// Count of published Article posts carrying a tag.
-export async function postCount(tagId: string): Promise<number> {
+// Count of published Article posts carrying a tag, as the viewer may see them.
+// Carries the same predicates as the listing (posts.listByTag) — a count taken
+// over a wider set than the list it labels is itself a disclosure: it tells the
+// reader how many posts they are not being shown.
+export async function postCount(tagId: string, viewerId: string | null): Promise<number> {
   const [row] = await db
     .select({ count: sql<number>`count(*)::int` })
     .from(postTags)
     .innerJoin(posts, eq(posts.id, postTags.postId))
+    .leftJoin(users, eq(posts.authorId, users.id))
     .where(
-      and(eq(postTags.tagId, tagId), eq(posts.status, "published"), eq(posts.apType, "Article")),
+      and(
+        eq(postTags.tagId, tagId),
+        eq(posts.apType, "Article"),
+        isPublished,
+        notSuspended,
+        visibleToViewer(viewerId),
+      ),
     );
   return row?.count ?? 0;
 }
@@ -105,8 +124,19 @@ export function trending(limit: number, sinceDays = 14): Promise<TagWithCount[]>
     .from(tags)
     .innerJoin(postTags, eq(postTags.tagId, tags.id))
     .innerJoin(posts, eq(posts.id, postTags.postId))
+    .leftJoin(users, eq(posts.authorId, users.id))
+    // Ranked over what a logged-out reader can see. Trending is a global
+    // ranking, not a personalized one, so it is computed as anonymous rather
+    // than threaded with a viewer — and a suspended or private author must not
+    // push a tag up a board that everyone sees.
     .where(
-      and(eq(posts.status, "published"), eq(posts.apType, "Article"), gt(posts.createdAt, since)),
+      and(
+        eq(posts.apType, "Article"),
+        gt(posts.createdAt, since),
+        isPublished,
+        notSuspended,
+        visibleToViewer(null),
+      ),
     )
     .groupBy(tags.id)
     .orderBy(desc(sql`count(${postTags.postId})`))
@@ -131,7 +161,12 @@ export function listSitemapTags(): Promise<{ slug: string; lastPostAt: Date }[]>
     .from(tags)
     .innerJoin(postTags, eq(postTags.tagId, tags.id))
     .innerJoin(posts, eq(posts.id, postTags.postId))
-    .where(and(eq(posts.status, "published"), eq(posts.remote, false)))
+    .leftJoin(users, eq(posts.authorId, users.id))
+    // A crawler is anonymous, so the ">1 post" threshold below has to be
+    // counted over posts a crawler can actually reach — otherwise a tag whose
+    // only visible post is one becomes exactly the thin page the threshold
+    // exists to keep out of the sitemap.
+    .where(and(eq(posts.remote, false), isPublished, notSuspended, visibleToViewer(null)))
     .groupBy(tags.id)
     .having(sql`count(${postTags.postId}) > 1`)
     .limit(10000) as Promise<{ slug: string; lastPostAt: Date }[]>;

--- a/apps/backend/src/services/tags.ts
+++ b/apps/backend/src/services/tags.ts
@@ -18,7 +18,7 @@ export async function getTag(rawSlug: string, viewerId: string | null) {
   const tag = await tagsRepo.findBySlug(slug);
   if (!tag) throw notFound("Tag not found.");
   const [postCount, followerCount, isFollowing] = await Promise.all([
-    tagsRepo.postCount(tag.id),
+    tagsRepo.postCount(tag.id, viewerId),
     tagsRepo.followerCount(tag.id),
     viewerId ? tagsRepo.isFollowing(viewerId, tag.id) : Promise.resolve(false),
   ]);


### PR DESCRIPTION
Follow-up to #54. That fix closed one instance of a bug class; this is the sweep for the rest of it.

## Why this audit

#41 was not a design flaw. The visibility predicates existed, were documented, and were correct — one query just didn't apply them, and a reporter found it before we did. That is a pattern that repeats, so I checked every query in the repo that reads `posts` against the invariant: **any listing that can reach another user's post must carry `isPublished`, `notSuspended`, `notHidden(viewer)` and `visibleToViewer(viewer)`.**

20 query sites. 5 of them were wrong.

## The symptom

| Query | What leaked | To whom |
|---|---|---|
| `posts.listFeed` | A private account's post, **full body**, via the followed-tag branch | Any reader following one of its tags |
| `recommendations.listFeedFor` | A private account's post, **full body**, when a followed account boosts it | Every follower of the recommender |
| `posts.listSitemapEntries` | Private accounts' post URLs (existence, author, slug≈title) in `/sitemap.xml` | Anyone unauthenticated, plus every crawler |
| `tags.postCount` | How many posts a reader is *not* being shown on a tag page | Anyone viewing the tag page |
| `tags.trending` | Suspended and private authors pushing tags up the public board | Everyone |
| `tags.listSitemapTags` | Thin tag pages clearing the ">1 post" threshold on invisible posts | Crawlers |

The two feed cases are the serious ones — they serve the post body, not just a reference.

## The root cause

Two distinct mistakes, both "a predicate that looked redundant":

**The feeds gate the wrong subject.** `listFeed`'s `or` has four branches; three are approved-follow branches, which *are* what `visibleToViewer` checks, so the predicate genuinely is redundant for those. The fourth matches a followed **tag** — applied by the author, followed by anyone — and admits posts from authors the reader has no relationship with at all. `listFeedFor` is the same error one step removed: its `or` proves the viewer follows the *recommender*, and the predicate set was written as though that settled it. The recommended post belongs to someone else.

**The sitemap and tag queries were never given the predicate.** `listSitemapProfiles` excludes private accounts and explains why in its comment; `listSitemapEntries`, twenty lines above it, does not. The tag aggregates are the same count-versus-listing mismatch as `itemCountsFor` in #54 — the tag page rendered one post under the number 3.

## The fix

`visibleToViewer` on both feed queries; `users.is_private = false` in the shared `publishedLocally()` sitemap helper; the full predicate set on the three tag queries, with `postCount` taking `viewerId` (already in hand in `getTag`) so the count always describes the rows beneath it. Trending and the tag sitemap filter as anonymous — a global ranking isn't personalized, and a crawler is anonymous.

Three commits, one per surface, each independently revertable.

## What was verified

Against a real Postgres (podman), exercising the repository functions directly.

Before the change, with a private author, a suspended author and a public author:

```
1. listFeed (followed tag)            : LEAK
2. listFeedFor (followed recommender) : LEAK
3. listSitemapEntries (private author): LEAK
   control listGlobal                 : ok (correctly filtered)
```

The control matters — it shows `listGlobal` filtering the same post correctly, so the scenario is set up right and the three failures are real.

After, all three are clean, and the positive controls all pass:

```
PASS  own private post in own feed (tag branch)      (want visible)
PASS  private post in approved follower's feed       (want visible)
PASS  private post in stranger's feed                (want hidden)
PASS  public post in stranger's feed (tag branch)    (want visible)
PASS  public post in stranger's feed                 (want visible)
PASS  recommended private post -> stranger           (want hidden)
PASS  recommended public post  -> stranger           (want visible)
PASS  public post in sitemap                         (want visible)
PASS  private post in sitemap                        (want hidden)
```

Tag aggregates: `postCount` 3 → 1 (matching the listing), `trending` 1, tag correctly drops out of the sitemap.

`deno task check`, `deno lint`, `deno fmt --check` clean; 168 tests pass.

**Not verified:** none of this is covered over the wire or through the HTTP layer — it is verified at the repository boundary, which is where the bugs are. The federated `OrderedCollection` from #54 is still unverified against another server.

**No test is added, and that is the real problem here.** The suite is pure unit tests with no database, so nothing in CI can assert on a SQL predicate. Every check in this PR was run by hand and none of it will run again. Two bugs of this exact class have now been found by inspection rather than by CI. Standing up Postgres in CI with fixtures for these scenarios is the follow-up worth doing, and I'd treat it as the actual remediation — this PR only fixes the instances I found.

## Deploy notes

No migration, no config change. Takes effect on restart.

One visible behaviour change worth expecting: tag pages will show lower post counts, and trending may reorder, wherever private or suspended authors were being counted. That is the fix, not a regression.

Fixes the remaining instances of the class reported in #41.