### PR TITLE
test: run the visibility rules against a real database in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,27 @@ jobs:
     defaults:
       run:
         working-directory: apps/backend
+    # A throwaway Postgres for the integration suite. The unit tests need no
+    # database; the visibility rules live in SQL predicates, which nothing can
+    # assert on without one — which is how #41 and the five gaps in #55 all
+    # reached main. Scrapped with the runner.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: omicron
+          POSTGRES_PASSWORD: omicron
+          POSTGRES_DB: omicron_test
+        ports:
+          - 5432:5432
+        # Steps start as soon as the container is up, which is before Postgres
+        # is accepting connections; without a healthcheck the first test races
+        # the server and fails intermittently.
+        options: >-
+          --health-cmd "pg_isready -U omicron -d omicron_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v7
       - uses: denoland/setup-deno@v2
@@ -36,6 +57,13 @@ jobs:
         run: deno fmt --check
       - name: Test
         run: deno task test
+      # Runs the committed migrations against the service container above, then
+      # asserts on who can see what. Every case is a leak that shipped.
+      - name: Integration tests (visibility)
+        env:
+          DATABASE_URL: postgres://omicron:omicron@localhost:5432/omicron_test
+          SESSION_SECRET: ci-integration-test-secret-not-a-real-key
+        run: deno task test:integration
       - name: Audit dependencies
         # Surface every advisory in the log for visibility, then fail only on a
         # high/critical one — so a serious CVE in a dependency blocks the merge,

--- a/README.md
+++ b/README.md
@@ -93,6 +93,30 @@ install` in `apps/backend` does it on its own. Skip this and `pnpm check`
 reports `Cannot find module 'drizzle-orm'` against backend files rather than
 anything you changed.
 
+### Tests
+
+```bash
+cd apps/backend
+deno task test              # unit tests — no database needed
+deno task test:integration  # visibility rules — needs a throwaway database
+```
+
+The integration suite runs the committed migrations and asserts on who can see
+what: drafts, private accounts, suspended authors, across feeds, tag pages,
+reading lists and the sitemap. It reads `DATABASE_URL` and **truncates every
+table it touches**, so point it at a scratch database, never a real one:
+
+```bash
+docker run -d --name omicron-test-db -p 55432:5432 \
+  -e POSTGRES_USER=omicron -e POSTGRES_PASSWORD=omicron \
+  -e POSTGRES_DB=omicron_test postgres:16-alpine
+
+DATABASE_URL=postgres://omicron:omicron@localhost:55432/omicron_test \
+SESSION_SECRET=test-secret deno task test:integration
+```
+
+CI runs both on every push and PR against its own Postgres service.
+
 See the [local setup guide](https://docs.omicron.blog/development/local-setup/)
 for the full picture.
 

--- a/apps/backend/deno.json
+++ b/apps/backend/deno.json
@@ -11,7 +11,8 @@
     "backfill:unescape": "deno run -A scripts/backfill_unescape.ts",
     "backfill:email-lowercase": "deno run -A scripts/backfill_email_lowercase.ts",
     "check": "deno check src/main.ts",
-    "test": "deno test -A",
+    "test": "deno test -A src/",
+    "test:integration": "deno test -A tests/integration/",
     "fmt": "deno fmt",
     "lint": "deno lint"
   },

--- a/apps/backend/tests/integration/harness.ts
+++ b/apps/backend/tests/integration/harness.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Test harness for the integration suite: a real Postgres, real migrations,
+// real SQL. Unit tests cover the pure functions; these cover the queries, which
+// is where the visibility rules actually live and where unit tests cannot
+// reach.
+//
+// Requires DATABASE_URL to point at a THROWAWAY database — `resetDb()` truncates
+// every table it touches. See `deno task test:integration` and the `postgres`
+// service in .github/workflows/ci.yml.
+import { sql } from "@/db/client.ts";
+import { db } from "@/db/client.ts";
+import { runMigrations } from "@/db/migrate.ts";
+import {
+  follows,
+  posts,
+  postTags,
+  readingListItems,
+  readingLists,
+  recommendations,
+  tagFollows,
+  tags,
+  users,
+} from "@/db/schema.ts";
+
+let migrated = false;
+
+// Applies migrations once per test process, then hands back a clean database.
+// Every test starts from empty so ordering between tests can never matter.
+export async function resetDb(): Promise<void> {
+  if (!migrated) {
+    await runMigrations();
+    migrated = true;
+  }
+  // `restart identity cascade` reaches the tables that reference these; the
+  // suite asserts on the listed ones only.
+  await sql`
+    truncate users, posts, tags, post_tags, tag_follows, follows,
+             recommendations, reading_lists, reading_list_items
+    restart identity cascade`;
+}
+
+// Closes the pool so `deno test` does not report a leaked resource. Call from
+// the last step of each test file.
+export async function closeDb(): Promise<void> {
+  await sql.end();
+}
+
+// ── fixtures ────────────────────────────────────────────────────────────
+// Deliberately terse: a visibility test should read as a sentence about who
+// can see what, not as twenty lines of insert boilerplate.
+
+export type UserOpts = { isPrivate?: boolean; suspended?: boolean };
+
+export async function mkUser(username: string, opts: UserOpts = {}) {
+  const [row] = await db.insert(users).values({
+    username,
+    email: `${username}@example.test`,
+    passwordHash: "not-a-real-hash",
+    displayName: username,
+    isPrivate: opts.isPrivate ?? false,
+    suspendedAt: opts.suspended ? new Date() : null,
+  }).returning();
+  return row;
+}
+
+export type PostOpts = { status?: "draft" | "published"; apType?: string; remote?: boolean };
+
+export async function mkPost(authorId: string, slug: string, opts: PostOpts = {}) {
+  const [row] = await db.insert(posts).values({
+    authorId,
+    title: slug,
+    contentHtml: `<p>${slug}</p>`,
+    slug,
+    status: opts.status ?? "published",
+    apType: opts.apType ?? "Article",
+    remote: opts.remote ?? false,
+  }).returning();
+  return row;
+}
+
+export async function mkTag(slug: string) {
+  const [row] = await db.insert(tags).values({ slug, name: slug }).returning();
+  return row;
+}
+
+export async function tagPost(postId: string, tagId: string) {
+  await db.insert(postTags).values({ postId, tagId });
+}
+
+export async function followTag(userId: string, tagId: string) {
+  await db.insert(tagFollows).values({ userId, tagId });
+}
+
+// `approved: false` models a pending request to a private account — the case
+// that must not leak anything.
+export async function follow(followerId: string, followeeId: string, approved = true) {
+  await db.insert(follows).values({ followerId, followeeId, approved });
+}
+
+export async function recommend(userId: string, postId: string) {
+  await db.insert(recommendations).values({ userId, postId });
+}
+
+export async function mkList(userId: string, title: string, visibility: "public" | "private") {
+  const [row] = await db.insert(readingLists).values({ userId, title, visibility }).returning();
+  return row;
+}
+
+export async function addToList(listId: string, postId: string) {
+  await db.insert(readingListItems).values({ listId, postId });
+}
+
+// ── assertion helper ────────────────────────────────────────────────────
+
+// The suite asserts on "is this post in this result", never on ordering or
+// counts, so a change to pagination or ranking cannot make a visibility test
+// fail for an unrelated reason.
+export function includesPost(rows: readonly { post: { id: string } }[], postId: string): boolean {
+  return rows.some((r) => r.post.id === postId);
+}

--- a/apps/backend/tests/integration/visibility_test.ts
+++ b/apps/backend/tests/integration/visibility_test.ts
@@ -135,20 +135,21 @@ Deno.test("public listings exclude drafts and suspended authors", opts, async (t
   const rust = await mkTag("rust");
   for (const p of [draft, live, bySuspended, byPrivate]) await tagPost(p.id, rust.id);
 
-  const global = await postsRepo.listGlobal(null, null) as unknown as Rows;
-  const byTag = await postsRepo.listByTag("rust", null, null) as unknown as Rows;
+  const hiddenFromEveryone = [draft, bySuspended, byPrivate];
 
   await t.step("listGlobal shows only the one publishable post", async () => {
-    assertEquals(includesPost(global, live.id), true);
-    for (const hidden of [draft, bySuspended, byPrivate]) {
-      assertFalse(includesPost(global, hidden.id), `leaked ${hidden.slug}`);
+    const rows = await postsRepo.listGlobal(null, null) as unknown as Rows;
+    assertEquals(includesPost(rows, live.id), true);
+    for (const hidden of hiddenFromEveryone) {
+      assertFalse(includesPost(rows, hidden.id), `leaked ${hidden.slug}`);
     }
   });
 
   await t.step("listByTag agrees with it", async () => {
-    assertEquals(includesPost(byTag, live.id), true);
-    for (const hidden of [draft, bySuspended, byPrivate]) {
-      assertFalse(includesPost(byTag, hidden.id), `leaked ${hidden.slug}`);
+    const rows = await postsRepo.listByTag("rust", null, null) as unknown as Rows;
+    assertEquals(includesPost(rows, live.id), true);
+    for (const hidden of hiddenFromEveryone) {
+      assertFalse(includesPost(rows, hidden.id), `leaked ${hidden.slug}`);
     }
   });
 

--- a/apps/backend/tests/integration/visibility_test.ts
+++ b/apps/backend/tests/integration/visibility_test.ts
@@ -1,0 +1,250 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Visibility regression suite.
+//
+// Every case here is a bug that actually shipped. #41 (public reading lists
+// serving drafts and private-account posts) and the five gaps found auditing
+// every `posts` query afterwards (#55) were all found by inspection, because
+// nothing in CI could execute a SQL predicate. This is that missing check.
+//
+// The invariant under test: any listing that can reach another user's post
+// must apply `isPublished`, `notSuspended`, `notHidden(viewer)` and
+// `visibleToViewer(viewer)`. A leak is a listing returning a post it should
+// have filtered.
+//
+// Each case asserts both directions. A predicate that hides everything would
+// pass a leak test and fail the "still visible" one, which is the mistake this
+// suite is most likely to be asked to catch in future.
+import { assertEquals, assertFalse } from "@std/assert";
+import * as postsRepo from "@/db/repositories/posts.ts";
+import * as recsRepo from "@/db/repositories/recommendations.ts";
+import * as listsRepo from "@/db/repositories/readingLists.ts";
+import * as tagsRepo from "@/db/repositories/tags.ts";
+import {
+  addToList,
+  closeDb,
+  follow,
+  followTag,
+  includesPost,
+  mkList,
+  mkPost,
+  mkTag,
+  mkUser,
+  recommend,
+  resetDb,
+  tagPost,
+} from "./harness.ts";
+
+const opts = { sanitizeResources: false, sanitizeOps: false };
+
+// A cast shared by the assertions: the repo functions return rows whose `post`
+// is the full column set, and the helper only needs the id.
+type Rows = readonly { post: { id: string } }[];
+
+Deno.test("feeds: a private author reaches only approved followers", opts, async (t) => {
+  await resetDb();
+
+  const priv = await mkUser("priv", { isPrivate: true });
+  const pub = await mkUser("pub");
+  const approved = await mkUser("approved");
+  const pending = await mkUser("pending");
+  const stranger = await mkUser("stranger");
+
+  const privPost = await mkPost(priv.id, "private-post");
+  const pubPost = await mkPost(pub.id, "public-post");
+
+  // Everyone follows #rust; nobody follows the private author except
+  // `approved`, whose follow is approved, and `pending`, whose is not.
+  const rust = await mkTag("rust");
+  await tagPost(privPost.id, rust.id);
+  await tagPost(pubPost.id, rust.id);
+  for (const u of [priv, approved, pending, stranger]) await followTag(u.id, rust.id);
+  await follow(approved.id, priv.id, true);
+  await follow(pending.id, priv.id, false);
+
+  const feed = (id: string) => postsRepo.listFeed(id, null) as unknown as Promise<Rows>;
+
+  await t.step("the followed-tag branch does not leak a private author's post", async () => {
+    assertFalse(includesPost(await feed(stranger.id), privPost.id));
+  });
+
+  await t.step("a pending follow request leaks nothing", async () => {
+    assertFalse(includesPost(await feed(pending.id), privPost.id));
+  });
+
+  await t.step("an approved follower still receives it", async () => {
+    assertEquals(includesPost(await feed(approved.id), privPost.id), true);
+  });
+
+  await t.step("the author still sees their own post via the tag branch", async () => {
+    assertEquals(includesPost(await feed(priv.id), privPost.id), true);
+  });
+
+  await t.step("a public author's post still reaches a stranger by tag", async () => {
+    assertEquals(includesPost(await feed(stranger.id), pubPost.id), true);
+  });
+});
+
+Deno.test("feeds: recommending cannot widen a post's audience", opts, async (t) => {
+  await resetDb();
+
+  const priv = await mkUser("priv", { isPrivate: true });
+  const pub = await mkUser("pub");
+  const booster = await mkUser("booster");
+  const stranger = await mkUser("stranger");
+  const approved = await mkUser("approved");
+
+  const privPost = await mkPost(priv.id, "private-post");
+  const pubPost = await mkPost(pub.id, "public-post");
+
+  // `booster` recommends both. `stranger` and `approved` follow `booster`;
+  // only `approved` is also an approved follower of the private author.
+  await recommend(booster.id, privPost.id);
+  await recommend(booster.id, pubPost.id);
+  await follow(stranger.id, booster.id, true);
+  await follow(approved.id, booster.id, true);
+  await follow(approved.id, priv.id, true);
+
+  const recFeed = (id: string) => recsRepo.listFeedFor(id, null) as unknown as Promise<Rows>;
+
+  await t.step("a boost of a private author's post does not reach a non-follower", async () => {
+    assertFalse(includesPost(await recFeed(stranger.id), privPost.id));
+  });
+
+  await t.step("it does reach a follower of that author", async () => {
+    assertEquals(includesPost(await recFeed(approved.id), privPost.id), true);
+  });
+
+  await t.step("a boost of a public post reaches everyone following the booster", async () => {
+    assertEquals(includesPost(await recFeed(stranger.id), pubPost.id), true);
+  });
+});
+
+Deno.test("public listings exclude drafts and suspended authors", opts, async (t) => {
+  await resetDb();
+
+  const author = await mkUser("author");
+  const suspended = await mkUser("suspended", { suspended: true });
+  const priv = await mkUser("priv", { isPrivate: true });
+
+  const draft = await mkPost(author.id, "draft-post", { status: "draft" });
+  const live = await mkPost(author.id, "live-post");
+  const bySuspended = await mkPost(suspended.id, "suspended-post");
+  const byPrivate = await mkPost(priv.id, "private-post");
+
+  const rust = await mkTag("rust");
+  for (const p of [draft, live, bySuspended, byPrivate]) await tagPost(p.id, rust.id);
+
+  const global = await postsRepo.listGlobal(null, null) as unknown as Rows;
+  const byTag = await postsRepo.listByTag("rust", null, null) as unknown as Rows;
+
+  await t.step("listGlobal shows only the one publishable post", async () => {
+    assertEquals(includesPost(global, live.id), true);
+    for (const hidden of [draft, bySuspended, byPrivate]) {
+      assertFalse(includesPost(global, hidden.id), `leaked ${hidden.slug}`);
+    }
+  });
+
+  await t.step("listByTag agrees with it", async () => {
+    assertEquals(includesPost(byTag, live.id), true);
+    for (const hidden of [draft, bySuspended, byPrivate]) {
+      assertFalse(includesPost(byTag, hidden.id), `leaked ${hidden.slug}`);
+    }
+  });
+
+  await t.step("the tag's advertised count matches the listing it labels", async () => {
+    // A count taken over a wider set than the list beneath it tells the reader
+    // how many posts are being withheld (#55).
+    assertEquals(await tagsRepo.postCount(rust.id, null), 1);
+  });
+
+  await t.step("trending ranks the tag by visible posts only", async () => {
+    assertEquals((await tagsRepo.trending(5))[0]?.postCount, 1);
+  });
+});
+
+Deno.test("reading lists: a public list is filtered like any other listing", opts, async (t) => {
+  await resetDb();
+
+  const owner = await mkUser("owner");
+  const author = await mkUser("author");
+  const priv = await mkUser("priv", { isPrivate: true });
+  const suspended = await mkUser("suspended", { suspended: true });
+  const stranger = await mkUser("stranger");
+
+  const live = await mkPost(author.id, "live-post");
+  const draft = await mkPost(author.id, "draft-post", { status: "draft" });
+  const byPrivate = await mkPost(priv.id, "private-post");
+  const bySuspended = await mkPost(suspended.id, "suspended-post");
+
+  const list = await mkList(owner.id, "Saved", "public");
+  for (const p of [live, draft, byPrivate, bySuspended]) await addToList(list.id, p.id);
+
+  await t.step("an anonymous reader sees only the publishable post (#41)", async () => {
+    const rows = await listsRepo.listItems(list.id, null, null) as unknown as Rows;
+    assertEquals(includesPost(rows, live.id), true);
+    for (const hidden of [draft, byPrivate, bySuspended]) {
+      assertFalse(includesPost(rows, hidden.id), `leaked ${hidden.slug}`);
+    }
+  });
+
+  await t.step("a signed-in stranger sees the same", async () => {
+    const rows = await listsRepo.listItems(list.id, stranger.id, null) as unknown as Rows;
+    assertEquals(rows.length, 1);
+  });
+
+  await t.step("the item count does not leak what the list is hiding", async () => {
+    const counts = await listsRepo.itemCountsFor([list.id], null);
+    assertEquals(counts.get(list.id), 1);
+  });
+
+  await t.step("the federated collection filters as anonymous", async () => {
+    const refs = await listsRepo.itemRefs(list.id);
+    assertEquals(refs.length, 1);
+    assertEquals(refs[0].id, live.id);
+  });
+
+  await t.step("the owner's own draft is not exempted", async () => {
+    // The owner may read their draft on its own page; a *public* list is a
+    // published surface, so it filters for them too.
+    const rows = await listsRepo.listItems(list.id, owner.id, null) as unknown as Rows;
+    assertFalse(includesPost(rows, draft.id));
+  });
+});
+
+Deno.test("the sitemap publishes nothing a crawler cannot read", opts, async (t) => {
+  await resetDb();
+
+  const author = await mkUser("author");
+  const priv = await mkUser("priv", { isPrivate: true });
+  const suspended = await mkUser("suspended", { suspended: true });
+
+  const live = await mkPost(author.id, "live-post");
+  const draft = await mkPost(author.id, "draft-post", { status: "draft" });
+  const byPrivate = await mkPost(priv.id, "private-post");
+  const bySuspended = await mkPost(suspended.id, "suspended-post");
+
+  const entries = await postsRepo.listSitemapEntries();
+  const ids = new Set(entries.map((e) => e.id));
+
+  await t.step("only the publishable post is listed", () => {
+    assertEquals(ids.has(live.id), true);
+    for (const hidden of [draft, byPrivate, bySuspended]) {
+      assertFalse(ids.has(hidden.id), `leaked ${hidden.slug}`);
+    }
+  });
+
+  await t.step("the count matches what is listed", async () => {
+    assertEquals(await postsRepo.countSitemapEntries(), 1);
+  });
+
+  await t.step("private and suspended authors get no profile entry", async () => {
+    const profiles = (await postsRepo.listSitemapProfiles()).map((p) => p.username);
+    assertEquals(profiles, ["author"]);
+  });
+});
+
+// Runs last: closes the shared pool so the process exits cleanly.
+Deno.test("teardown", opts, async () => {
+  await closeDb();
+});


### PR DESCRIPTION
Closes the gap I flagged in #55. This is the check that would have caught both #41 and the five gaps in #55 before they shipped.

## Why

Two rounds of data-disclosure bugs, both found by reading code:

- **#41** — public reading lists served drafts and private accounts' posts to anonymous callers. Found by a reporter.
- **#55** — five more of the same class across feeds, tag pages and the sitemap. Found by auditing every `posts` query afterwards.

Neither could have been caught by a check, because there was none capable of it. The visibility rules live in SQL predicates; the suite is 168 pure unit tests; CI had no database. Every fix in both PRs was verified by hand against a container that no longer exists, and **none of it ever ran again.** Two for two, found by inspection. A third was a matter of time.

## What this adds

A `postgres:16-alpine` service on the backend job, and an integration suite that runs the committed migrations and asserts on who can see what:

| Surface | Covers |
|---|---|
| `posts.listFeed` | the followed-tag branch, and a **pending** follow request to a private account |
| `recommendations.listFeedFor` | a followed account boosting a private author's post |
| `posts.listGlobal` / `listByTag` | drafts, suspended authors, private authors |
| `tags.postCount` / `trending` | the count matching the listing it labels |
| `readingLists` | items, item counts, and the federated `itemRefs` collection |
| `posts.listSitemapEntries` / `Profiles` | drafts, private and suspended authors |

6 tests, 20 steps, ~1s against a warm database.

## Every case asserts both directions

A predicate that hid *everything* would pass every leak test in this file. So each leak case is paired with a case proving the thing that must still work — the author still sees their own post through the tag branch, an approved follower still receives it, a public post still reaches a stranger. That is the failure this suite is most likely to be asked to catch later, and the one a leak-only suite would sail straight past.

## The suite was validated by mutation, not by going green

A test that cannot fail is worth less than no test, because it also removes the impulse to check by hand. So I reverted each fix in turn and confirmed the suite noticed:

| Reverted | Result |
|---|---|
| `visibleToViewer` from `listFeed` | 2 steps failed — the tag branch and the pending-follow case |
| `visibleToViewer` from `listFeedFor` | 1 step failed |
| `is_private` from the sitemap's `publishedLocally()` | 2 steps failed — the listing and the count |
| the predicates from `tags.postCount` | 1 step failed |
| the predicates from `readingLists.listItems` (the original #41) | 3 steps failed |

In every case the failing step was the one named for that bug, and the positive controls stayed green. `src/` was restored to its committed state afterwards and verified identical.

## Layout

`deno task test` is now scoped to `src/` — still 168 tests, still no database, unchanged runtime. `deno task test:integration` runs `tests/integration/` and is a separate CI step.

The harness (`tests/integration/harness.ts`) carries terse fixture builders so a visibility test reads as a sentence about who can see what rather than twenty lines of insert boilerplate. It **truncates every table it touches** — the README documents that with a warning to point it at a scratch database, never a real one.

## What was verified

`deno task check`, `deno lint`, `deno fmt --check` clean; 168 unit tests pass with no database present; 6 integration tests / 20 steps pass against Postgres 16; the five mutations above all caught. CI on this PR is the first real run of the new job.

**Not covered:** this tests at the repository boundary, which is where the bugs were, not over HTTP — a route that calls the right function with the wrong `viewerId` would still pass. The federated `OrderedCollection` is asserted through `itemRefs` rather than fetched from another server, so #55's over-the-wire gap is unchanged.

## Deploy notes

None — CI and tests only, no runtime code touched.