### PR TITLE
refactor(frontend): set prose body text to 1rem

### DIFF
--- a/apps/frontend/src/app.css
+++ b/apps/frontend/src/app.css
@@ -243,11 +243,11 @@ html {
 }
 
 /* Rendered post content (the HTML produced by Tiptap). Its own reading face —
-   Source Sans 3, not the interface's Inter — at a generous size with relaxed
+   Source Sans 3, not the interface's Inter — at 1rem with relaxed
    leading. Code, keys and maths keep their own faces below. Extend as the
    editor grows. */
 .prose-omicron {
-  @apply font-content text-[1.125rem] leading-[1.75] text-foreground sm:text-[1.25rem] sm:leading-[1.8];
+  @apply font-content text-[1rem] leading-[1.75] text-foreground sm:leading-[1.8];
 }
 /* Media never overflows the reading column on narrow screens. */
 .prose-omicron img,
@@ -369,10 +369,10 @@ html {
 }
 
 /* Compact variant for prose shown outside a full article — the profile's custom
-   section. Same elements, tightened to sans-ish reading size so it sits inside a
-   card without dwarfing the surrounding UI. */
+   section. Same elements and size as an article, with tighter leading and
+   spacing so it sits inside a card without dwarfing the surrounding UI. */
 .prose-compact {
-  @apply text-[1rem] leading-[1.7] sm:text-[1.0625rem] sm:leading-[1.75];
+  @apply text-[1rem] leading-[1.7] sm:leading-[1.75];
 }
 .prose-compact > :first-child {
   @apply mt-0;


### PR DESCRIPTION
## Symptom

Article body copy read larger than the rest of the interface — `1.125rem`, and `1.25rem` above the `sm` breakpoint, against Inter at `1rem` everywhere else.

## Change

`.prose-omicron` is now a flat `1rem`. Leading is unchanged (`1.75`, `1.8` at `sm+`), so the content face keeps its relaxed rhythm; headings, code, blockquotes and maths are sized independently and were not touched.

`.prose-compact` loses its `sm:text-[1.0625rem]` bump as a consequence. With the article at `1rem`, the "compact" profile section would otherwise have rendered *larger* than a full article above `sm`. Its tighter leading and block spacing — the things that actually make it compact — stay.

Two stale block comments updated to match ("a generous size", "tightened to sans-ish reading size").

## Why here

`.prose-omicron` is the single definition for both the published post and the Tiptap editor surface (`Editor.svelte:370` applies it to the editable element), so one edit keeps the writing view and the published view identical. No per-route overrides exist.

## Verified

Read the full `.prose-omicron` / `.prose-compact` cascade to confirm nothing else re-declares a body `font-size`, and grepped the frontend for the old arbitrary values — the changed line was the only hit.

Not verified: I did not render the app or eyeball a post at either breakpoint. This is a taste call on type size and worth a visual check before merge.

## Deploy notes

None — CSS only, picked up by a normal frontend build.
