### PR TITLE
fix: stop the schedule dialog freezing the page

### DIFF
--- a/apps/frontend/src/lib/components/ScheduleDialog.svelte
+++ b/apps/frontend/src/lib/components/ScheduleDialog.svelte
@@ -183,7 +183,7 @@
             <Calendar.Grid class="mt-2 w-full border-collapse select-none">
               <Calendar.GridHead>
                 <Calendar.GridRow class="flex w-full justify-between">
-                  {#each weekdays as day (day)}
+                  {#each weekdays as day, i (i)}
                     <Calendar.HeadCell class="w-9 text-xs font-normal text-muted-foreground">
                       {day.slice(0, 2)}
                     </Calendar.HeadCell>
@@ -191,9 +191,9 @@
                 </Calendar.GridRow>
               </Calendar.GridHead>
               <Calendar.GridBody>
-                {#each month.weeks as week (week[0])}
+                {#each month.weeks as week, weekIndex (weekIndex)}
                   <Calendar.GridRow class="flex w-full justify-between">
-                    {#each week as dayValue (dayValue)}
+                    {#each week as dayValue, dayIndex (dayIndex)}
                       <Calendar.Cell date={dayValue} month={month.value} class="p-0">
                         <Calendar.Day class={cellClass} />
                       </Calendar.Cell>
@@ -217,7 +217,11 @@
             class="inline-flex h-10 items-center rounded-input border border-input bg-background px-3 text-sm shadow-btn focus-within:ring-2 focus-within:ring-foreground/20"
           >
             {#snippet children({ segments })}
-              {#each segments as segment (segment.part)}
+              <!-- Keyed by index, not by `part`: a time field emits more than one
+                   `literal` segment, and a duplicate key is a hard render error —
+                   which, thrown from inside a dialog, leaves the body scroll lock
+                   applied and the whole page unclickable. -->
+              {#each segments as segment, i (i)}
                 <TimeField.Segment part={segment.part} class={segmentClass}>
                   {segment.value}
                 </TimeField.Segment>


### PR DESCRIPTION
Clicking **Schedule…** did nothing and left the entire site unclickable until a
reload. Scheduling from the composer was unusable. Regression from #58.

## Root cause

The time field's segments were keyed by `segment.part`:

```svelte
{#each segments as segment (segment.part)}
```

A 24-hour time field emits four segments, two of them `literal` — the separator
either side of the colon. The key is not unique, so Svelte throws while
rendering the dialog's contents:

```
each_key_duplicate: Keyed each block has duplicate key `literal` at indexes 1 and 3
  in time-field-input.svelte
  in ScheduleDialog.svelte
```

## Why one dialog took the whole page down

The body scroll lock. Bits UI applies `overflow: hidden` and, after a tick,
`pointer-events: none` to `<body>` when a modal opens, and removes them when the
last lock is destroyed (`internal/body-scroll-lock.svelte.js`).

The lock was applied, the content then failed to render, and nothing was ever
mounted that could release it. Every click on the page was swallowed, with no
dialog on screen to explain why — exactly the reported symptom.

## The fix

Key by index. Applied to the calendar's weekday, week and day loops too: those
are snapshot arrays rebuilt wholesale on each render, and a narrow weekday
format repeats letters (T/T, S/S) — the identical collision waiting to happen.

## How this got through

It typechecks and builds cleanly either way, so nothing short of running the
page would have caught it. #58 was verified through the API, the server-rendered
HTML and the database, but the dialog was never opened in a browser — and I said
so in that PR. This is the bug that was sitting in the gap.

Fixed by driving Chromium, which is now how this component gets checked.

## Verified

In Chromium, both entry points:

| | |
| --- | --- |
| Composer → **Schedule…** | dialog opens, no errors |
| Manage → **Reschedule** | dialog opens seeded with the stored time |
| Presets | "Tomorrow, 09:00" updates the confirmation line to `Friday, August 21, 2026 at 09:00 · GMT+4 · in 1 day` |
| Calendar | 42 day cells, past dates disabled |
| Time field | 4 segments (the two literals that caused this) |
| Submitting | lands on `/posts/manage?tab=scheduled` |
| **Timezone** | 09:00 GMT+4 stored as `2026-08-21T05:00:00.000Z` — the conversion the dialog exists to get right |
| After closing | `document.body.style.pointerEvents` back to `""`, page interactive |

Zero console or page errors in either flow.

## Not addressed

The failure mode is worse than the bug: any render error inside a modal bricks
the page, because the scroll lock outlives the content that would release it. A
`<svelte:boundary>` around the dialog content would contain that — the dialog
would render a fallback and stay dismissible, so the lock gets released. I have
not added it here, because it changes what happens on *future* errors (degrading
quietly instead of failing loudly) and that is a call worth making deliberately
rather than folding into a bug fix. Happy to do it as a follow-up.