### PR TITLE
fix: responses before read-next, and three related posts

### DIFF
--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -339,7 +339,7 @@ export function listSitemapEntries(page = 1) {
 // explainable to the author who chose those tags, and it degrades to "recent
 // posts by anyone" rather than to nothing when a post shares no tags — an empty
 // section would leave the dead end exactly as it was.
-export function listRelated(postId: string, limit = 4) {
+export function listRelated(postId: string, limit = 3) {
   const shared = db
     .select({
       id: posts.id,

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -304,7 +304,7 @@ async function assertVisible(row: postsRepo.PostWithAuthor, viewerId: string | n
 // shares tags with nothing (or carries none), the newest posts stand in, so the
 // reader is never left at a dead end. Deduplicated by id because the fallback
 // is only topped up when the related set comes back short.
-export async function relatedPosts(postId: string, limit = 4) {
+export async function relatedPosts(postId: string, limit = 3) {
   const related = await postsRepo.listRelated(postId, limit);
   if (related.length >= limit) return related;
 

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -421,20 +421,9 @@
   </div>
 </article>
 
-{#if data.related?.length}
-  <!-- Where to go next. A post page linked onward to nothing but its author,
-       which left readers with only the back button and left crawlers unable to
-       reach the rest of the archive from an article. Real <a> links, rendered
-       server-side, so both audiences follow the same ones. -->
-  <section aria-labelledby="read-next" class="mt-12 border-t border-border pt-8">
-    <h2 id="read-next" class="mb-4 text-lg font-bold tracking-tight text-foreground">Read next</h2>
-    {#each data.related as related (related.id)}
-      <PostCard post={related} />
-    {/each}
-  </section>
-{/if}
-
-<div id="responses" class="mt-12">
+<!-- scroll-mt clears the 64px sticky header, so the comment-count button
+     above lands on the "Responses" heading rather than under the nav. -->
+<div id="responses" class="mt-12 scroll-mt-20 border-t border-border pt-8">
   <Comments
     postId={post.id}
     initial={data.comments}
@@ -442,6 +431,24 @@
     onCountChange={(delta) => (commentCount += delta)}
   />
 </div>
+
+{#if data.related?.length}
+  <!-- Where to go next. A post page linked onward to nothing but its author,
+       which left readers with only the back button and left crawlers unable to
+       reach the rest of the archive from an article. Real <a> links, rendered
+       server-side, so both audiences follow the same ones.
+
+       Last on the page, below the responses: a reader who reaches the end of an
+       article is either replying to it or leaving, and an exit ramp placed
+       above the reply box pushes that box off screen at the moment it is
+       wanted. The thread paginates, so the bottom stays reachable. -->
+  <section aria-labelledby="read-next" class="mt-12 border-t border-border pt-8">
+    <h2 id="read-next" class="mb-4 text-lg font-bold tracking-tight text-foreground">Read next</h2>
+    {#each data.related as related (related.id)}
+      <PostCard post={related} />
+    {/each}
+  </section>
+{/if}
 
 <Dialog.Root bind:open={reportOpen} onOpenChange={onReportOpenChange}>
   <Dialog.Portal>


### PR DESCRIPTION
## Symptom

At the end of an article the reader gets, in this order: the article, then
**Read next** with four related posts, then **Responses**. The response box —
the thing someone who just finished reading is most likely to want — starts
around 700px below the article on a 900px viewport, well below the fold. Four
full-width cards is taller than the screen on its own, so the rail reads as a
second feed grafted onto the post rather than as a suggestion.

## Root cause

Not a decision. `62cd53a` added the rail directly after `</article>`, which is
where the article ends; the responses block was already further down the file
and simply got pushed. That commit's message argues for the rail existing at
all — crawl depth, link equity, readers hitting a dead end — and says nothing
about it outranking the conversation. The limit of 4 came from the same commit
with no stated reason.

## The fix

Two separable commits:

1. **Order.** `article → Responses → Read next`. A reader at the last
   paragraph is either replying or leaving; serving the exit ramp first trades
   a session for a bounce. The divider moves with the sections so each band
   stays delimited, and `#responses` gains `scroll-mt-20` — the comment-count
   button in the engagement bar already links there, and without a
   scroll-margin the heading lands under the 64px sticky header.
2. **Count.** `relatedPosts` and `listRelated` default to 3. Enough to make the
   archive reachable, which is the point of the rail, without the wall.

### Why not the alternatives

- *A long thread will bury the rail.* It won't: the thread paginates behind a
  "load more" (`Comments.svelte:29` carries the cursor), so the page bottom
  stays reachable.
- *Links lower in the DOM rank worse.* They are the same server-rendered `<a>`
  elements in the same document. Position in the DOM is not what decides
  whether a crawler follows them.

## What was verified

Against a local stack (podman Postgres, backend on :8099, `vite dev` on :5200)
with six tag-sharing posts and a comment on the one under test:

- Rendered in Chromium, signed out and signed in. DOM order measured, not eyeballed:
  `article@96 → responses@586 → read-next@890`.
- `GET /posts/:id/related` returns exactly 3 with six candidates available;
  the rendered rail contains 3 cards.
- Clicked the comment-count button — `#responses` now lands on the "Responses"
  heading instead of under the nav.
- No page errors or console errors in either state.
- `deno check`, `deno lint`, `deno fmt --check`; `pnpm lint`, `pnpm fmt:check`,
  `pnpm svelte-check` (0 errors). Integration suite: 12 passed, 36 steps.

Not verified: narrow-viewport layout was not measured, only the desktop
breakpoint. Nothing in the change is width-dependent — it moves two blocks and
changes a default — but I did not photograph it on mobile.

## Deploy notes

None. Plain `docker compose up -d --build`; no migration, no config.