### PR TITLE
fix(feeds): make an author's feed findable

### DIFF
--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -72,11 +72,14 @@
   // og:image.
   const shareImage = $derived(absoluteBanner(post?.bannerUrl, origin) ?? ogImage);
 
-  // RSS auto-discovery: a reader pointed at a profile or reading-list page finds
-  // the feed from this tag alone. Local profiles only (a remote actor's posts are
-  // syndicated by their own instance) and public lists only (a private list's
-  // feed 404s for the anonymous reader that would fetch it). Skipped when the
-  // admin has indexing off, since the feed serves nothing then.
+  // RSS auto-discovery: a reader pointed at a profile, an article or a
+  // reading-list page finds the feed from this tag alone — which is how Feedly,
+  // Inoreader, Miniflux and NetNewsWire subscribe, none of them running the
+  // JavaScript that would reveal the link any other way. Local authors only (a
+  // remote actor's posts are syndicated by their own instance) and public lists
+  // only (a private list's feed 404s for the anonymous reader that would fetch
+  // it). Skipped when the admin has indexing off, since the feed serves nothing
+  // then.
   const feedLink = $derived.by(() => {
     if (data.seo?.indexingEnabled === false) return null;
     const pageData = $page.data as { remote?: boolean; profile?: Profile; list?: ReadingList };
@@ -86,6 +89,16 @@
     }
     if ($page.route.id === "/lists/[id]" && pageData.list?.visibility === "public") {
       return { href, title: `${pageData.list.title} · ${appName}` };
+    }
+    // An article advertises its author's feed, not a feed of its own: paste the
+    // URL you are reading into a feed reader and you subscribe to the writer,
+    // which is the only feed that exists. Not `href` above — that would append
+    // /feed.xml to the article's own path.
+    if (post && !post.remote) {
+      return {
+        href: `/@${post.author.username}/feed.xml`,
+        title: `${post.author.displayName} · ${appName}`,
+      };
     }
     return null;
   });

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.server.ts
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.server.ts
@@ -6,6 +6,26 @@ import { postPath } from "$lib/links";
 import { error, redirect } from "@sveltejs/kit";
 import type { PageServerLoad } from "./$types";
 
+// Addresses a reader guesses for an author's feed when all they have is the
+// author's URL. The one real feed is /@username/feed.xml — its own route, which
+// wins over this one — and every other spelling landed here as a post slug and
+// 404ed, so a subscription typed by hand silently never arrived.
+//
+// Redirected rather than served, so the feed keeps a single URL: one address for
+// a reader's client to poll and revalidate, and one for a search engine to see.
+const FEED_ALIASES = new Set([
+  "rss",
+  "atom",
+  "feed",
+  "rss.xml",
+  "atom.xml",
+  "feed.rss",
+  "feed.atom",
+  // WordPress and Hugo defaults, which are what a reader who has used either
+  // will try first.
+  "index.xml",
+]);
+
 // Blog post at /@username/<slug>. The slug is the address: the backend resolves
 // it against the author's live slug, then against slugs the post has been moved
 // off (a retitle), then against a trailing short id — which is what permalinks
@@ -39,7 +59,16 @@ export const load: PageServerLoad = async ({ fetch, locals, params, url }) => {
     post.contentHtml = deferBodyImages(highlightCodeBlocks(post.contentHtml));
     data = { post, comments, related };
   } catch (err) {
-    if (err instanceof ApiError && err.status === 404) error(404, "Post not found");
+    if (err instanceof ApiError && err.status === 404) {
+      // Checked only once the slug has failed to resolve, so an author who
+      // titles a post "RSS" keeps /@them/rss. And local authors only: a remote
+      // actor's posts are syndicated by their own instance, and this instance's
+      // feed route 404s for them, so a redirect would only move the 404.
+      if (!handle.includes("@") && FEED_ALIASES.has(params.slug.toLowerCase())) {
+        redirect(308, `/@${handle}/feed.xml`);
+      }
+      error(404, "Post not found");
+    }
     throw err;
   }
 


### PR DESCRIPTION
## Symptom

Reported as *"the RSS feed is unreachable for bots — `/@omicronhq/rss` returns a challenge, so a subscription never updates."*

Two of the three parts of that were already true before this branch, and it is worth being precise about which:

- **Content-Type was already correct.** `lib/rss.ts:160` serves `application/rss+xml; charset=utf-8`.
- **Feed URLs are no longer challenged.** [#62](https://github.com/the-jk-labs/omicron/pull/62) inverted the bot policy; `.xml`, `/rss`, `/atom` and `/feed` all reach the app now. Re-verified below against the pinned Anubis image with real feed-reader User-Agents.
- **`/@user/rss` genuinely did not work** — but because it is not a route, not because of the shield. It 404ed then and would 404 now.

Also, the profile's RSS control copies `/@user/feed.xml`, which is right; it is not a link to `/rss`.

So what is actually broken is discovery, in two places.

## The fix

**1. The addresses readers guess now resolve.** `/rss`, `/atom`, `/feed`, `/rss.xml`, `/atom.xml`, `/feed.rss`, `/feed.atom` and `/index.xml` under a local author 308 to `/@user/feed.xml`. Redirected, not duplicated, so the feed keeps one URL for a client to poll and one for a search engine to see.

The alias is checked **only after the slug fails to resolve**, so an author who titles a post "RSS" keeps `/@them/rss` — verified below. Local authors only: a remote actor's feed is their own instance's to serve, and `feed.xml` 404s for them, so redirecting would just move the 404.

**2. An article page now advertises its author's feed.** Auto-discovery was emitted on profile and reading-list pages only. The article URL is the one a reader actually has — the one that gets shared — and pasting it into Feedly, Inoreader, Miniflux or NetNewsWire found nothing. None of them runs JavaScript, so the RSS button in the profile header is no help; the `<link rel="alternate">` tag is the entire mechanism. Built from the author's handle rather than the page path, which would produce `/@user/<slug>/feed.xml`.

## Verified

Ran the production build (`node server.js`) against a stub backend, and put the pinned Anubis image in front of it.

**Feed addresses**

| Request | Result |
| --- | --- |
| `/@omicronhq/feed.xml` | `200`, `application/rss+xml; charset=utf-8`, valid RSS 2.0 body |
| `/@omicronhq/rss`, `/atom`, `/feed`, `/index.xml`, `/RSS` | `308` → `/@omicronhq/feed.xml` |
| following `/rss` with a Feedly UA | lands on the feed, correct Content-Type, `<channel>` renders |
| `/@omicronhq/nope` | `404`, unchanged |
| `/@omicronhq/rss` **when a real post has slug `rss`** | `200`, serves the post — the alias does not shadow it |

**Auto-discovery** — article page now emits:

```html
<link rel="alternate" type="application/rss+xml" title="Omicron HQ · Stub" href="/@omicronhq/feed.xml"/>
```

**Through the shield** — every feed address passes for `Feedly`, `Inoreader`, `Miniflux`, `NetNewsWire` and a plain browser UA; none is challenged.

`svelte-check` clean (5208 files, 0 errors), `oxlint` and `oxfmt --check` clean.

**Not verified:** no real backend or database — the stub returns fixed JSON, so this exercises routing, redirects, headers and head tags, not feed content against real posts. The profile page did not render in the harness (the stub's profile payload is too thin), so the profile branch of the auto-discovery block was not re-exercised; it is untouched by this diff, and the article branch that was added runs through the same `$derived`.

## Deploy notes

None — plain `docker compose up -d --build`. No new environment variables and no change to the existing feed URL.