### PR TITLE
fix(federation): NodeInfo, host-meta, and an actor URL a person can open

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -57,6 +57,25 @@ function withPublicScheme(req: Request): Request {
   return fixed === req.url ? req : new Request(fixed, req);
 }
 
+// Every federation route but WebFinger and NodeInfo is JSON-LD only: ask for
+// HTML and Fedify answers 406. That is right for a collection nobody browses,
+// and wrong for an actor — /users/<name> is the identity another instance
+// republishes, so it gets opened in browsers, from a WebFinger client, from a
+// link someone pasted. Send those to the profile page instead, which is what the
+// actor's own `url` now advertises (see federation/actor.ts).
+//
+// Only the bare actor document. A 406 on /users/<name>/outbox is a correct
+// answer to a request that has no HTML equivalent to be redirected to.
+function onNotAcceptable(request: Request): Response {
+  const path = new URL(request.url).pathname;
+  const actor = /^\/users\/([^/]+)$/.exec(path);
+  if (!actor) return new Response("Not Acceptable", { status: 406 });
+  // 302, not 308: the actor document is still what lives at this URL, and a
+  // client that later asks for JSON-LD must come back here rather than replay a
+  // cached permanent redirect to a page of HTML.
+  return new Response(null, { status: 302, headers: { location: `/@${actor[1]}` } });
+}
+
 // Builds the fully-composed Hono app. Federation is mounted only when enabled,
 // keeping the standalone blog free of any ActivityPub code paths.
 export async function buildApp() {
@@ -119,7 +138,10 @@ export async function buildApp() {
           });
           return await fed.fetch(buffered, { contextData: undefined });
         }
-        const res = await fed.fetch(withPublicScheme(c.req.raw), { contextData: undefined });
+        const res = await fed.fetch(withPublicScheme(c.req.raw), {
+          contextData: undefined,
+          onNotAcceptable,
+        });
         return isActorDoc(c.req.method, path)
           ? await withAttributionDomains(res, config.APP_DOMAIN)
           : res;

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -6,6 +6,7 @@ import { federationRunning } from "@/services/federationState.ts";
 import { handleError } from "@/lib/http.ts";
 import { sessionMiddleware } from "@/routes/middleware.ts";
 import { healthRoutes } from "@/routes/health.ts";
+import { wellKnownRoutes } from "@/routes/wellKnown.ts";
 import { apiRoutes } from "@/routes/index.ts";
 import { registerJobHandlers } from "@/queue/handlers.ts";
 import { checkRateLimit, clientIp, rateLimit } from "@/lib/rateLimit.ts";
@@ -69,6 +70,12 @@ export async function buildApp() {
   // Federation paths are delegated to Fedify's fetch handler; everything else
   // falls through to the app's own routes.
   if (federationRunning()) {
+    // Discovery documents Fedify does not register — the NodeInfo entry point
+    // and host-meta. Mounted *before* the Fedify handler below, which is what
+    // lets the NodeInfo JRD here take the path back from Fedify's own
+    // single-version one. See routes/wellKnown.ts.
+    app.route("/", wellKnownRoutes);
+
     const { getFederation } = await import("@/federation/mod.ts");
     const { withAttributionDomains } = await import("@/federation/attribution.ts");
     const fed = getFederation();

--- a/apps/backend/src/db/repositories/comments.ts
+++ b/apps/backend/src/db/repositories/comments.ts
@@ -96,6 +96,14 @@ export function listReplies(parentIds: string[], viewerId: string | null) {
     .orderBy(asc(comments.createdAt), asc(comments.id));
 }
 
+// Every response on the instance, for NodeInfo's usage figures. Comments are
+// always local — the column is a FK to `users`, so a remote reply is never one
+// of these — which is why there is nothing to filter here.
+export async function countAll(): Promise<number> {
+  const [row] = await db.select({ n: sql<number>`count(*)::int` }).from(comments);
+  return row?.n ?? 0;
+}
+
 // Comment count for many posts in one query.
 export async function countsFor(postIds: string[]): Promise<Map<string, number>> {
   const map = new Map<string, number>();

--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -400,6 +400,23 @@ export function listRecentExcluding(postId: string, limit = 4) {
     .limit(limit);
 }
 
+// Everything this instance has itself published, for NodeInfo's usage figures.
+//
+// Deliberately wider than `publishedLocally()` above, which is the *sitemap's*
+// question ("what should a crawler index?") and so drops private authors. This
+// one asks what the node holds, and a private author's article is as much this
+// node's output as anyone's — only the count leaves, never a title or a body.
+// Drafts and scheduled posts are not published and never counted; a suspended
+// author's work is withdrawn, so it is not counted either.
+export async function countLocalPublished(): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(posts)
+    .innerJoin(users, eq(posts.authorId, users.id))
+    .where(and(eq(posts.remote, false), isPublished, isNull(users.suspendedAt)));
+  return row?.n ?? 0;
+}
+
 export async function countSitemapEntries(): Promise<number> {
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })

--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { and, desc, eq, ilike, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, ilike, ne, or, sql } from "drizzle-orm";
 import { db } from "@/db/client.ts";
-import { type ActorKeyPair, follows, type NewUser, users } from "@/db/schema.ts";
+import { type ActorKeyPair, follows, type NewUser, sessions, users } from "@/db/schema.ts";
 
 // All user DB access lives here. Services/routes never touch `db` directly.
 
@@ -88,6 +88,22 @@ export function firstUser() {
 
 export async function countUsers(): Promise<number> {
   const [row] = await db.select({ n: sql<number>`count(*)::int` }).from(users);
+  return row?.n ?? 0;
+}
+
+// Accounts that signed in at least once since `since` — NodeInfo's definition of
+// an active user, which is a sign-in and not a post.
+//
+// Counted from sessions, one row per sign-in, so an account that signed in twice
+// counts once. It errs low and never high: signing out deletes the row, so a
+// visit that ended in a deliberate logout is not remembered. That is the right
+// direction for a number published to fediverse directories — an undercount
+// misrepresents nothing, and there is no other record of a sign-in to consult.
+export async function countActiveSince(since: Date): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(distinct ${sessions.userId})::int` })
+    .from(sessions)
+    .where(gte(sessions.createdAt, since));
   return row?.n ?? 0;
 }
 

--- a/apps/backend/src/federation/actor.ts
+++ b/apps/backend/src/federation/actor.ts
@@ -64,7 +64,18 @@ export async function buildPerson(
     // approval flow. Public accounts advertise instant follows (false).
     manuallyApprovesFollowers: user.isPrivate,
     endpoints: new Endpoints({ sharedInbox: ctx.getInboxUri() }),
-    url: ctx.getActorUri(identifier),
+    // Where a *person* goes, which is not where the actor document lives.
+    //
+    // `id` above is the ActivityPub identity (/users/<name>) and is served as
+    // JSON-LD only — Fedify answers a browser's Accept header there with 406.
+    // This field is the one Mastodon renders as the profile link and the one
+    // WebFinger republishes as `rel="profile-page"`, so pointing it at the actor
+    // document meant every route a human could take from another instance to
+    // this author's profile ended at "Not Acceptable". The reading page is the
+    // answer, and it negotiates back to this actor for anything that asks for
+    // JSON-LD (see the frontend's hooks.server.ts). Same split Mastodon draws
+    // between /users/<name> and /@<name>.
+    url: new URL(`/@${identifier}`, origin),
     icon: user.avatarUrl ? new Image({ url: new URL(user.avatarUrl, origin) }) : undefined,
     publicKey: keys[0]?.cryptographicKey,
     assertionMethods: keys.map((k) => k.multikey),

--- a/apps/backend/src/federation/mod.ts
+++ b/apps/backend/src/federation/mod.ts
@@ -41,6 +41,7 @@ import * as notifications from "@/services/notifications.ts";
 import { articleLanguage, buildArticle } from "@/federation/article.ts";
 import { buildPerson } from "@/federation/actor.ts";
 import { cacheActor } from "@/federation/remote.ts";
+import { setupNodeInfo } from "@/federation/nodeinfo.ts";
 import { origin } from "@/config.ts";
 import { normalizeTags } from "@/lib/tags.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
@@ -61,6 +62,7 @@ export function getFederation(): Federation<ContextData> {
   if (federation) return federation;
 
   const f = createFederationInstance();
+  setupNodeInfo(f);
   setupActor(f);
   setupFollowers(f);
   setupLists(f);

--- a/apps/backend/src/federation/nodeinfo.ts
+++ b/apps/backend/src/federation/nodeinfo.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { Federation } from "@fedify/fedify";
+import { nodeInfo } from "@/services/nodeInfo.ts";
+
+// Serves the instance's NodeInfo document at /nodeinfo/2.1.
+//
+// Registering the dispatcher is also what makes /.well-known/nodeinfo useful:
+// Fedify answers that path unconditionally, but with an empty `links` array
+// until there is a document to point at — a 200 that tells a directory nothing,
+// which is exactly how an instance ends up federating correctly and still
+// appearing in no listing anywhere.
+//
+// The document itself (what we claim, and why each field says what it says) is
+// services/nodeInfo.ts; this file is only the ActivityPub-side wiring.
+export function setupNodeInfo<T>(f: Federation<T>) {
+  f.setNodeInfoDispatcher("/nodeinfo/2.1", () => nodeInfo());
+}

--- a/apps/backend/src/routes/wellKnown.ts
+++ b/apps/backend/src/routes/wellKnown.ts
@@ -1,0 +1,91 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { Hono } from "hono";
+import { escapeHtml } from "@/lib/html.ts";
+import { nodeInfo20 } from "@/services/nodeInfo.ts";
+import { getOrigin } from "@/services/instanceSetup.ts";
+
+// Discovery documents an instance is expected to answer on, beyond what Fedify
+// registers for us. Mounted only when federation is running (see app.ts): each
+// one describes a fediverse node, and answering as one while federation is off
+// would be a claim about this instance that isn't true.
+//
+// These are the addresses a directory or a remote server hits *before* it knows
+// anything about us, so each must answer 200 with the right Content-Type on a
+// plain unauthenticated GET. Anything else and the instance is simply not there
+// as far as the fediverse is concerned.
+export const wellKnownRoutes = new Hono();
+
+// NodeInfo's entry point: a JRD listing where the real documents live.
+//
+// This shadows Fedify's own handler for the path, deliberately, and is why it is
+// mounted ahead of the federation middleware. Fedify emits a link for 2.1 alone
+// — it has room for exactly the one dispatcher — and this instance publishes 2.0
+// as well (see services/nodeInfo.ts for why), so the entry point has to list
+// both or the second document is unreachable by the crawlers that need it.
+const NODEINFO_TYPE = (version: string) =>
+  `application/json; profile="http://nodeinfo.diaspora.software/ns/schema/${version}#"`;
+
+wellKnownRoutes.get("/.well-known/nodeinfo", async (c) => {
+  const origin = await getOrigin();
+  return c.json(
+    {
+      links: ["2.0", "2.1"].map((version) => ({
+        rel: `http://nodeinfo.diaspora.software/ns/schema/${version}`,
+        href: `${origin}/nodeinfo/${version}`,
+        type: NODEINFO_TYPE(version),
+      })),
+    },
+    200,
+    { "content-type": "application/jrd+json" },
+  );
+});
+
+// The 2.0 document. Its 2.1 twin is Fedify's, from the dispatcher in
+// federation/nodeinfo.ts, and both render the same numbers from the same query.
+wellKnownRoutes.get(
+  "/nodeinfo/2.0",
+  async (c) => c.json(await nodeInfo20(), 200, { "content-type": NODEINFO_TYPE("2.0") }),
+);
+
+// host-meta: the pre-WebFinger discovery step from RFC 6415, which hands a
+// client the WebFinger URL template rather than making it assume the well-known
+// path. Most modern software goes straight to /.well-known/webfinger, but the
+// older and more conservative half of the network — and several instance
+// directories — still ask for this first and give up when it 404s.
+//
+// The template is built on the instance's canonical origin rather than the host
+// this request arrived on, so an alias hostname (`www.`) hands out the one
+// address the instance actually federates under.
+function webFingerTemplate(origin: string): string {
+  return `${origin}/.well-known/webfinger?resource={uri}`;
+}
+
+wellKnownRoutes.get("/.well-known/host-meta", async (c) => {
+  // The domain is operator-set (the wizard), so it is escaped before going
+  // into an XML attribute. `{uri}` survives untouched — escapeHtml leaves
+  // braces alone — which it must, being the spec's own placeholder.
+  const template = escapeHtml(webFingerTemplate(await getOrigin()));
+  // XRD, the XML form, is what the spec defines and what every client that
+  // bothers with host-meta at all requests. `{uri}` is the spec's own
+  // placeholder and must survive unescaped.
+  const xrd = `<?xml version="1.0" encoding="UTF-8"?>
+<XRD xmlns="http://docs.oasis-open.org/ns/xri/xrd-1.0">
+  <Link rel="lrdd" type="application/jrd+json" template="${template}"/>
+</XRD>
+`;
+  return c.body(xrd, 200, { "content-type": "application/xrd+xml; charset=utf-8" });
+});
+
+// The JSON spelling of the same document, for clients that ask for it by name.
+wellKnownRoutes.get("/.well-known/host-meta.json", async (c) =>
+  c.json(
+    {
+      links: [{
+        rel: "lrdd",
+        type: "application/jrd+json",
+        template: webFingerTemplate(await getOrigin()),
+      }],
+    },
+    200,
+    { "content-type": "application/jrd+json" },
+  ));

--- a/apps/backend/src/services/nodeInfo.ts
+++ b/apps/backend/src/services/nodeInfo.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { NodeInfo } from "@fedify/fedify";
+import * as commentsRepo from "@/db/repositories/comments.ts";
+import * as postsRepo from "@/db/repositories/posts.ts";
+import * as usersRepo from "@/db/repositories/users.ts";
+import { getAppName } from "@/services/instanceSetup.ts";
+import { APP_VERSION } from "@/version.ts";
+
+// What this instance tells the fediverse about itself.
+//
+// NodeInfo is the protocol every directory reads — FediDB, fedidb.org,
+// instances.social — and the one a peer reads to learn what software it is
+// talking to. Without it the instance is invisible to all of them: it federates
+// fine, but it appears in no listing and no statistic, which is most of how a
+// small instance is found at all. Served at /nodeinfo/2.1 and pointed to from
+// /.well-known/nodeinfo; both are wired up in federation/nodeinfo.ts.
+//
+// Everything here is an aggregate. No title, no handle, no address ever leaves
+// through this document — only counts, the software name, and the instance's own
+// display name, which is on every page already.
+
+// NodeInfo's two activity windows, defined by the spec as the users who signed
+// in within the last 30 and 180 days.
+const MONTH_MS = 30 * 24 * 60 * 60 * 1000;
+const HALFYEAR_MS = 180 * 24 * 60 * 60 * 1000;
+
+export async function nodeInfo(): Promise<NodeInfo> {
+  const now = Date.now();
+  const [name, total, activeMonth, activeHalfyear, localPosts, localComments] = await Promise.all([
+    getAppName(),
+    usersRepo.countUsers(),
+    usersRepo.countActiveSince(new Date(now - MONTH_MS)),
+    usersRepo.countActiveSince(new Date(now - HALFYEAR_MS)),
+    postsRepo.countLocalPublished(),
+    commentsRepo.countAll(),
+  ]);
+
+  return {
+    software: {
+      // Lowercase and hyphen-only: NodeInfo requires it, and Fedify rejects the
+      // document outright otherwise. This is the key directories group instances
+      // by, so it must stay "omicron" across every release and every fork that
+      // has not renamed itself.
+      name: "omicron",
+      version: APP_VERSION,
+      repository: new URL("https://github.com/the-jk-labs/omicron"),
+    },
+    protocols: ["activitypub"],
+    services: {
+      // Nothing is ingested from another network; every profile and reading list
+      // publishes an RSS feed (see the frontend's feed.xml routes).
+      inbound: [],
+      outbound: ["rss2.0"],
+    },
+    // Registration is open on every Omicron instance: /api/auth/register takes
+    // anyone, rate-limited but ungated. Revisit this the day an invite or
+    // approval mode lands, or the document will be advertising a door that is
+    // no longer open.
+    openRegistrations: true,
+    usage: {
+      users: { total, activeMonth, activeHalfyear },
+      localPosts,
+      localComments,
+    },
+    // `nodeName` is what a directory prints as the instance's title. Not part of
+    // the 2.1 schema proper, but the field Mastodon publishes and every
+    // directory reads, so an instance that omits it is listed by bare hostname.
+    metadata: { nodeName: name },
+  };
+}
+
+// The same document in the 2.0 schema.
+//
+// Both versions are published because the fediverse reads both: 2.1 is what
+// Fedify serves and what this instance prefers, but Mastodon — and so a good
+// share of the crawlers written against it — only ever exposed 2.0, and a
+// directory that hardcodes that rel would otherwise see nothing here. Every
+// large implementation (Lemmy, Misskey, GoToSocial) answers on both for the same
+// reason.
+//
+// 2.0 has no `repository`/`homepage` on `software` and no `$schema` key, so this
+// is 2.1 minus what 2.0 has no field for — never a separate set of facts.
+export async function nodeInfo20(): Promise<Record<string, unknown>> {
+  const info = await nodeInfo();
+  return {
+    version: "2.0",
+    software: { name: info.software.name, version: info.software.version },
+    protocols: [...info.protocols],
+    services: {
+      inbound: [...(info.services?.inbound ?? [])],
+      outbound: [...(info.services?.outbound ?? [])],
+    },
+    openRegistrations: info.openRegistrations ?? false,
+    usage: info.usage,
+    metadata: info.metadata ?? {},
+  };
+}

--- a/apps/backend/tests/integration/harness.ts
+++ b/apps/backend/tests/integration/harness.ts
@@ -12,12 +12,14 @@ import { sql } from "@/db/client.ts";
 import { db } from "@/db/client.ts";
 import { runMigrations } from "@/db/migrate.ts";
 import {
+  comments,
   follows,
   posts,
   postTags,
   readingListItems,
   readingLists,
   recommendations,
+  sessions,
   tagFollows,
   tags,
   users,
@@ -93,6 +95,22 @@ export async function mkPost(authorId: string, slug: string, opts: PostOpts = {}
     ...(opts.createdAt ? { createdAt: opts.createdAt, updatedAt: opts.createdAt } : {}),
   }).returning();
   return row;
+}
+
+export async function mkComment(postId: string, authorId: string, content = "hi") {
+  const [row] = await db.insert(comments).values({ postId, authorId, content }).returning();
+  return row;
+}
+
+// A sign-in. `createdAt` is the whole point — the activity windows NodeInfo
+// publishes are windows on this column — so it is required rather than defaulted.
+export async function mkSession(userId: string, createdAt: Date) {
+  await db.insert(sessions).values({
+    id: `session-${userId}-${createdAt.getTime()}`,
+    userId,
+    createdAt,
+    expiresAt: new Date(createdAt.getTime() + 30 * 24 * 3_600_000),
+  });
 }
 
 export async function mkTag(slug: string) {

--- a/apps/backend/tests/integration/nodeinfo_test.ts
+++ b/apps/backend/tests/integration/nodeinfo_test.ts
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// The numbers this instance publishes to the fediverse, against a real database.
+//
+// NodeInfo's usage block is the one place aggregate counts leave the instance,
+// and each one is a SQL predicate with a judgement call inside it: a draft is
+// not a post, another instance's article is not ours, a suspended author's work
+// is withdrawn, and a private author's is still this node's output. Nothing but
+// a database can tell whether those predicates say what the comments above them
+// claim, and getting one wrong is not visible from inside — it just publishes a
+// wrong number to every directory that asks.
+import { assertEquals } from "@std/assert";
+import * as commentsRepo from "@/db/repositories/comments.ts";
+import * as postsRepo from "@/db/repositories/posts.ts";
+import * as usersRepo from "@/db/repositories/users.ts";
+import { closeDb, mkComment, mkPost, mkSession, mkUser, resetDb } from "./harness.ts";
+
+const opts = { sanitizeResources: false, sanitizeOps: false };
+
+const DAY = 24 * 3_600_000;
+
+Deno.test("local post count is what this instance actually published", opts, async (t) => {
+  await resetDb();
+  const author = await mkUser("writer");
+
+  await mkPost(author.id, "published");
+  await mkPost(author.id, "draft", { status: "draft" });
+  await mkPost(author.id, "scheduled", { status: "scheduled" });
+
+  await t.step("counts published posts, never drafts or scheduled ones", async () => {
+    assertEquals(await postsRepo.countLocalPublished(), 1);
+  });
+
+  await t.step("a private author's posts are still this node's", async () => {
+    const hermit = await mkUser("hermit", { isPrivate: true });
+    await mkPost(hermit.id, "behind-a-lock");
+    assertEquals(await postsRepo.countLocalPublished(), 2);
+  });
+
+  await t.step("a post flagged as another instance's is not ours to count", async () => {
+    // A real federated row carries no local author at all, so the join alone
+    // would drop it. This asserts the `remote` predicate in its own right —
+    // the guard that still holds if a post is ever ingested against a local
+    // account (a CMS bridge, an import).
+    await mkPost(author.id, "someone-elses", { remote: true });
+    assertEquals(await postsRepo.countLocalPublished(), 2);
+  });
+
+  await t.step("a suspended author's work is withdrawn from the count", async () => {
+    const banned = await mkUser("banned", { suspended: true });
+    await mkPost(banned.id, "gone");
+    assertEquals(await postsRepo.countLocalPublished(), 2);
+  });
+});
+
+Deno.test("responses are counted, sign-ins are windowed", opts, async (t) => {
+  await resetDb();
+  const author = await mkUser("writer");
+  const reader = await mkUser("reader");
+  const post = await mkPost(author.id, "post");
+
+  await t.step("every response on the instance counts once", async () => {
+    await mkComment(post.id, reader.id);
+    await mkComment(post.id, author.id);
+    assertEquals(await commentsRepo.countAll(), 2);
+  });
+
+  await t.step("an account is active in a window it signed in during", async () => {
+    // Two sign-ins for one account, three months apart: inside the half-year
+    // window and outside the month one, and it must count once either way.
+    await mkSession(author.id, new Date(Date.now() - 90 * DAY));
+    await mkSession(author.id, new Date(Date.now() - 91 * DAY));
+    await mkSession(reader.id, new Date(Date.now() - 2 * DAY));
+
+    const month = new Date(Date.now() - 30 * DAY);
+    const halfYear = new Date(Date.now() - 180 * DAY);
+    assertEquals(await usersRepo.countActiveSince(month), 1);
+    assertEquals(await usersRepo.countActiveSince(halfYear), 2);
+  });
+
+  await t.step("an account that has never signed in is not active", async () => {
+    await mkUser("lurker");
+    assertEquals(await usersRepo.countUsers(), 3);
+    assertEquals(await usersRepo.countActiveSince(new Date(Date.now() - 180 * DAY)), 2);
+  });
+
+  await closeDb();
+});

--- a/apps/frontend/src/hooks.server.ts
+++ b/apps/frontend/src/hooks.server.ts
@@ -1,4 +1,5 @@
 import { canonicalOrigin, instanceDomain, isNonCanonicalHost } from "$lib/canonical";
+import { instanceSnapshot } from "$lib/instance";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Handle } from "@sveltejs/kit";
 
@@ -24,6 +25,62 @@ async function canonicalRedirect(event: Parameters<Handle>[0]["event"]): Promise
   // 308 rather than 301: permanent (so engines transfer ranking to the canonical
   // URL) without the legacy licence to rewrite the method.
   return new Response(null, { status: 308, headers: { location: target } });
+}
+
+// ActivityPub content negotiation on a profile page.
+//
+// `/@alice` is where the fediverse now points at this instance's authors: the
+// actor advertises it as its `url` and WebFinger republishes it as the
+// profile-page link (see the backend's federation/actor.ts). A human asking for
+// that URL wants the page. A server asking for it — Mastodon resolving a handle
+// someone pasted into its search box, an instance following a link out of a post
+// — wants the actor document, and gets HTML it cannot parse unless this
+// redirects it to where the JSON lives.
+//
+// Local handles only. `/@user@host` is this instance's cached copy of somebody
+// else's actor; the original is theirs to serve, and /users/user@host is not a
+// route.
+const AP_HANDLE = /^\/@([^/@]+)$/;
+const AP_TYPES = new Set(["application/activity+json", "application/ld+json"]);
+
+// The client's most-preferred media type, or null when it expressed no
+// preference. Deliberately narrower than the backend's Fedify equivalent, which
+// also honours a bare `application/json`: this decides whether to redirect a
+// *page* away from a reader, so only an unambiguous request for ActivityPub
+// counts. A browser's `text/html,...,*/*;q=0.8` and a bare `*/*` both rank
+// something else first and are left alone.
+function topMediaType(accept: string | null): string | null {
+  if (!accept) return null;
+  const ranked = accept
+    .split(",")
+    .map((part, index) => {
+      const [type, ...params] = part
+        .trim()
+        .split(";")
+        .map((p) => p.trim());
+      const q = params.map((p) => /^q=([\d.]+)$/i.exec(p)).find((m) => m !== null);
+      return { type: type.toLowerCase(), q: q ? Number(q[1]) : 1, index };
+    })
+    .filter((entry) => entry.type && Number.isFinite(entry.q) && entry.q > 0)
+    // Equal weights keep the order the client wrote them in, which is the
+    // convention every ActivityPub implementation relies on.
+    .sort((a, b) => b.q - a.q || a.index - b.index);
+  return ranked[0]?.type ?? null;
+}
+
+async function activityPubRedirect(event: Parameters<Handle>[0]["event"]): Promise<Response | null> {
+  if (!CANONICAL_METHODS.has(event.request.method)) return null;
+  const handle = AP_HANDLE.exec(event.url.pathname);
+  if (!handle) return null;
+  if (!AP_TYPES.has(topMediaType(event.request.headers.get("accept")) ?? "")) return null;
+  // Only when the backend is actually federating. With federation off there is
+  // no actor to redirect to and /users/<name> is a 404, so the page — which at
+  // least says who the author is — is the better answer.
+  if (!(await instanceSnapshot(event.fetch)).federationEnabled) return null;
+
+  // 302: the page is what lives here, and this is a per-request answer to one
+  // client's Accept header, never a permanent move.
+  return new Response(null, { status: 302, headers: { location: `/users/${handle[1]}` } });
 }
 
 // `<html lang>` for this response. app.html carries a `%omicron.lang%`
@@ -58,7 +115,7 @@ function pageLang(locals: App.Locals): string {
 // svelte.config.js (`kit.csp`) so SvelteKit can nonce its own inline scripts;
 // the headers below are the ones it doesn't manage.
 export const handle: Handle = async ({ event, resolve }) => {
-  const redirectResponse = await canonicalRedirect(event);
+  const redirectResponse = (await canonicalRedirect(event)) ?? (await activityPubRedirect(event));
   const response =
     redirectResponse ??
     // Load runs inside resolve(), so `locals.lang` is already set by the time

--- a/apps/frontend/src/lib/canonical.ts
+++ b/apps/frontend/src/lib/canonical.ts
@@ -12,7 +12,7 @@
 // page's <head>, hooks.server.ts redirects page loads to it, and robots.txt +
 // sitemap.xml advertise it, so all four agree no matter which host was asked.
 
-import { endpoints } from "$lib/api";
+import { instanceSnapshot } from "$lib/instance";
 
 // Localhost has no certificate, so it is served over plain HTTP. Mirrors the
 // backend's own scheme rule in config.ts — keep the two in step.
@@ -51,20 +51,9 @@ export function isNonCanonicalHost(url: URL, domain: string | null | undefined):
   return url.host !== new URL(origin).host;
 }
 
-// The instance identity is a single row that changes only when an admin edits
-// it, but hooks.server.ts needs it on every page load — so hold it for a minute
-// rather than putting a backend round-trip in front of each request. A failed
-// lookup is cached as null for the same minute, which degrades to "no redirect".
-const TTL_MS = 60_000;
-let cached: { domain: string | null; at: number } | null = null;
-
+// Re-exported from $lib/instance, which owns the cached snapshot: the canonical
+// origin is one of several things a request needs the instance's own identity
+// for, and they should all read the same minute-old answer.
 export async function instanceDomain(fetchFn: typeof fetch): Promise<string | null> {
-  const now = Date.now();
-  if (cached && now - cached.at < TTL_MS) return cached.domain;
-
-  const info = await endpoints(fetchFn)
-    .instance()
-    .catch(() => null);
-  cached = { domain: info?.domain ?? null, at: now };
-  return cached.domain;
+  return (await instanceSnapshot(fetchFn)).domain;
 }

--- a/apps/frontend/src/lib/instance.ts
+++ b/apps/frontend/src/lib/instance.ts
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// The instance's own identity, cached for the server-side request path.
+//
+// A single row that changes only when an admin edits it, and something
+// hooks.server.ts needs on every page load — so it is held for a minute rather
+// than putting a backend round-trip in front of each request. A failed lookup is
+// cached as null/false for the same minute, so every reader degrades to "do
+// nothing" rather than to an error.
+
+import { endpoints } from "$lib/api";
+
+const TTL_MS = 60_000;
+
+export type InstanceSnapshot = {
+  domain: string | null;
+  // The federation state the backend is actually running with, not the admin's
+  // saved preference — the two differ until a restart. Anything routing a
+  // request to an ActivityPub URL has to know which one is true right now.
+  federationEnabled: boolean;
+};
+
+let cached: { value: InstanceSnapshot; at: number } | null = null;
+
+export async function instanceSnapshot(fetchFn: typeof fetch): Promise<InstanceSnapshot> {
+  const now = Date.now();
+  if (cached && now - cached.at < TTL_MS) return cached.value;
+
+  const info = await endpoints(fetchFn)
+    .instance()
+    .catch(() => null);
+  cached = {
+    value: {
+      domain: info?.domain ?? null,
+      federationEnabled: info?.federationEnabled ?? false,
+    },
+    at: now,
+  };
+  return cached.value;
+}

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -103,6 +103,22 @@
     return null;
   });
 
+  // ActivityPub autodiscovery on a profile page: the machine-readable twin of
+  // the RSS link above, and the other half of the negotiation in
+  // hooks.server.ts. A fediverse client that fetched this page as HTML — because
+  // it did not think to ask for JSON-LD, or followed a link that landed here —
+  // finds the actor from this tag rather than giving up on the handle.
+  //
+  // Local profiles only (a remote actor is served by its own instance, and this
+  // page is a cached copy), and only while the backend is federating, since
+  // /users/<name> is a 404 otherwise.
+  const actorLink = $derived.by(() => {
+    if (!data.instance?.federationEnabled) return null;
+    const pageData = $page.data as { remote?: boolean; profile?: Profile };
+    if ($page.route.id !== "/[handle]" || pageData.remote || !pageData.profile) return null;
+    return `${origin}/users/${pageData.profile.user.username}`;
+  });
+
   // The right discovery rail only belongs on the home feed and profile pages;
   // every other route (post, compose, settings, auth, …) hides it.
   const showDiscover = $derived($page.route.id === "/" || $page.route.id === "/[handle]");
@@ -253,6 +269,9 @@
   <meta property="og:image:alt" content={post?.title ?? appName} />
   {#if feedLink}
     <link rel="alternate" type="application/rss+xml" title={feedLink.title} href={feedLink.href} />
+  {/if}
+  {#if actorLink}
+    <link rel="alternate" type="application/activity+json" href={actorLink} />
   {/if}
   <!-- Search-engine site verification (admin-configured) -->
   {#each verificationTags as tag (tag.name)}

--- a/botPolicy.yaml
+++ b/botPolicy.yaml
@@ -109,6 +109,15 @@ bots:
     path_regex: ^/\.well-known/
     action: ALLOW
 
+  # NodeInfo. Caddy routes it to the backend without passing through Anubis; if
+  # that ever changes, this is what keeps the instance listed. A directory
+  # (FediDB, instances.social, fediverse.observer) crawls /.well-known/nodeinfo
+  # and /nodeinfo/2.x with no browser behind it, so a challenge here does not
+  # slow the crawl down — it removes the instance from the listing entirely.
+  - name: nodeinfo
+    path_regex: ^/nodeinfo(/|$)
+    action: ALLOW
+
   # Feeds and the sitemaps that share the .xml suffix: /@user/feed.xml,
   # /lists/<id>/feed.xml, /sitemap.xml, /sitemap/posts-<n>.xml. No feed reader
   # runs JavaScript.


### PR DESCRIPTION
## Symptom

The instance is invisible to fediverse directories. `/.well-known/nodeinfo` answers, but with nothing in it; `/nodeinfo/2.1` and `/.well-known/host-meta` 404. FediDB, instances.social and fediverse.observer all start at one of those three, so the instance is listed nowhere and counted in no statistic.

Separately, and found while checking the rest of the discovery chain: WebFinger works, but the profile link it hands out does not. `https://host/users/alice` in a browser is **406 Not Acceptable**.

## Root cause

**NodeInfo.** No dispatcher was ever registered. Fedify routes `/.well-known/nodeinfo` unconditionally and `handleNodeInfoJrd` builds its link list from `context.getNodeInfoUri()`, catching the `RouterError` when no dispatcher exists — so the path answered `200 {"links":[]}`. `/nodeinfo/2.1` was not a route at all. Verified against the pinned Fedify 2.3.4 with a real backend:

```
/.well-known/nodeinfo   200 application/jrd+json   {"links":[]}
/nodeinfo/2.1           404 text/plain
/.well-known/host-meta  404 text/plain
```

**host-meta.** Fedify registers exactly two well-known routes (`webfinger`, `nodeinfo`); host-meta is not one of them, and nothing else served it.

**The 406.** `buildPerson` set `url: ctx.getActorUri(identifier)` — the actor document. Everything but WebFinger and NodeInfo goes through Fedify's `acceptsJsonLd` gate, which answers `text/html` with 406. `url` is the field Mastodon renders as the profile link, and Fedify republishes it through WebFinger as `rel="profile-page"`, so every human route from another instance to a local author ended there:

```
$ curl -H 'Accept: text/html' https://host/users/alice
406 Not Acceptable
```

## The fix

Three parts, two commits.

**NodeInfo, 2.0 and 2.1.** Fedify has room for one dispatcher and it serves 2.1. Mastodon only ever exposed 2.0, and a crawler written against Mastodon hardcodes that rel — so the entry-point JRD has to list both, which is why `/.well-known/nodeinfo` is served from `routes/wellKnown.ts` (mounted ahead of the Fedify handler) rather than left to Fedify's single-version one. The 2.0 document is 2.1 minus the fields 2.0 has no room for, rendered from the same query, never a second set of facts. Lemmy, Misskey and GoToSocial all answer on both for the same reason.

**host-meta**, XRD and JSON, handing out the WebFinger template built on the canonical origin.

**The actor's `url` moves to `/@<name>`** — the same split Mastodon draws. The identity does not move: `id`, inbox, outbox and the WebFinger `self` link all still name `/users/<name>`. `/@<name>` then negotiates back, and `/users/<name>` redirects a browser to the page instead of 406ing.

Everything is mounted only while federation is actually running. Answering as a fediverse node with federation off would be a claim that isn't true.

### Two judgement calls worth reviewing

- **The negotiation is narrower than Fedify's.** `acceptsJsonLd` also accepts a bare `application/json`; this does not, and it ignores anything that ranks `text/html` first. Getting it wrong redirects a *reader* away from a page, so it only fires on an unambiguous request for ActivityPub.
- **`activeMonth`/`activeHalfyear` are counted from sessions**, which is NodeInfo's own definition (a sign-in, not a post). It errs low and never high: signing out deletes the row, so a visit that ended in a deliberate logout is not remembered. There is no other record of a sign-in to consult, and an undercount published to a directory misrepresents nothing.

## What was verified

Against a real backend (Deno + a throwaway Postgres) and a production frontend build, `Host`/`X-Forwarded-*` set as Caddy sets them.

Every endpoint in the report, before and after:

| | before | after |
|---|---|---|
| `/.well-known/nodeinfo` | 200, empty links | 200 `application/jrd+json`, 2.0 + 2.1 |
| `/nodeinfo/2.0` | 404 | 200 `application/json; profile=…2.0#` |
| `/nodeinfo/2.1` | 404 | 200 `application/json; profile=…2.1#` |
| `/.well-known/host-meta` | 404 | 200 `application/xrd+xml` |
| `/.well-known/host-meta.json` | 404 | 200 `application/jrd+json` |
| `/.well-known/webfinger?resource=acct:…` | 200 (already fine) | 200, profile-page now `/@alice` |
| `/users/alice` (AP) | 200 | 200 `application/activity+json` |
| `/users/alice` (browser) | **406** | 302 → `/@alice` |
| `/@alice` (browser) | 200 HTML | 200 HTML |
| `/@alice` (ActivityPub) | 200 HTML | 302 → `/users/alice` |

The negotiation matrix on `/@alice`: `application/activity+json`, the Mastodon-style `activity+json, ld+json; profile=…`, and bare `ld+json` all redirect; a browser's Accept, `*/*`, no Accept header at all, `text/html,application/activity+json`, and `activity+json;q=0.5,text/html;q=0.9` all serve the page. `/@user@host` and `/@alice/<slug>` are never redirected.

With `FEDERATION_ENABLED=false`: NodeInfo and host-meta 404, `/@alice` serves HTML to an ActivityPub Accept header, and the `rel="alternate"` actor link is absent.

Also: `deno check`, `deno lint`, `deno fmt --check`, 168 unit tests, 14 integration tests (7 new steps covering the counts), `svelte-check` 0 errors, `oxfmt` clean, frontend production build.

**Not verified:** no real directory has crawled this — the documents are checked against the schemas and the Fedify handler, not against FediDB's actual parser. And no live Mastodon has resolved a handle against it; the negotiation is verified by the redirects it emits, not end-to-end through another server.

## Deploy notes

Plain `docker compose up -d --build` picks all of it up. `botPolicy.yaml` gains a `nodeinfo` ALLOW — belt-and-braces, since Caddy routes `/nodeinfo` to the backend without passing through Anubis — and, as with any edit to that file, it is read once at Anubis startup, so `docker compose restart anubis` is what applies it.