### PR TITLE
fix(anubis): answer a challenge with 503, not 200

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -77,11 +77,37 @@
 	}
 	handle {
 		# App (SvelteKit) branch. When the admin enables AI-scraper protection,
-		# the backend reloads this config with this one line changed to
-		# `reverse_proxy anubis:8080` (the Anubis sidecar, which forwards back to
-		# frontend:3000). The exact string is matched in anubisProtection.ts —
-		# keep it on its own line.
-		reverse_proxy frontend:3000
+		# the backend swaps the upstream below for the Anubis sidecar (which
+		# forwards back to this same app) and reloads the config.
+		#
+		# That swap is a literal substring replacement of the directive line, so
+		# the line must appear exactly once in this file — a second occurrence,
+		# in a comment above all, would be rewritten instead and the toggle would
+		# silently do nothing. anubisProtection.ts refuses to apply rather than
+		# guess if it ever finds more than one.
+		reverse_proxy frontend:3000 {
+			# Anubis announces a challenge with 503 (see status_codes in
+			# botPolicy.yaml). A 503 is supposed to say *when* to come back, and
+			# nothing else in the stack can say it: Anubis has no way to set a
+			# response header, so the one client-facing half of that answer is
+			# added here.
+			#
+			# An hour: long enough that a search crawler or an uptime monitor
+			# backs off properly rather than retrying into the same wall, short
+			# enough that a URL is re-checked the same day the operator turns
+			# protection off. Browsers ignore it entirely — they are busy solving
+			# the challenge.
+			#
+			# Attached to the branch rather than to the Anubis upstream, so the
+			# toggle stays a one-line substring swap. With protection off this is
+			# inert: SvelteKit does not answer 503, and if it ever did under load,
+			# a Retry-After would be the right thing to send anyway.
+			@challenge status 503
+			handle_response @challenge {
+				header Retry-After 3600
+				copy_response
+			}
+		}
 	}
 }
 

--- a/apps/backend/src/lib/caddyfile.ts
+++ b/apps/backend/src/lib/caddyfile.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// The one edit the AI-scraper-shield toggle makes to the operator's Caddyfile.
+//
+// Kept here, free of config and database imports, so it can be tested on its
+// own — the wiring that reads the file and pushes it to Caddy's admin API is in
+// services/anubisProtection.ts. Same split as lib/shareImage.ts.
+
+// By default the app branch proxies the app directly; enabling protection
+// re-points it at the Anubis sidecar, which forwards to the same app. Keep both
+// strings in step with the Caddyfile.
+export const DIRECT_UPSTREAM = "reverse_proxy frontend:3000";
+export const ANUBIS_UPSTREAM = "reverse_proxy anubis:8080";
+
+/**
+ * The Caddyfile with the app upstream re-pointed at the Anubis sidecar.
+ *
+ * Exactly one occurrence, not at least one. `String.replace` with a string
+ * pattern rewrites the *first* one, so a second — a mention in a comment above
+ * the directive, say — would be rewritten in its place and the real upstream
+ * left pointing at the app. Caddy would accept that config, the admin page would
+ * report success, and the shield would simply not be in the request path.
+ * Refuse rather than guess.
+ */
+export function routeThroughAnubis(caddyfile: string): string {
+  const found = caddyfile.split(DIRECT_UPSTREAM).length - 1;
+  if (found !== 1) {
+    throw new Error(
+      `Caddyfile must contain "${DIRECT_UPSTREAM}" exactly once to route through ` +
+        `Anubis; found ${found}.`,
+    );
+  }
+  return caddyfile.replace(DIRECT_UPSTREAM, ANUBIS_UPSTREAM);
+}

--- a/apps/backend/src/lib/caddyfile_test.ts
+++ b/apps/backend/src/lib/caddyfile_test.ts
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { assert, assertStringIncludes, assertThrows } from "@std/assert";
+import { routeThroughAnubis } from "@/lib/caddyfile.ts";
+
+// The toggle is one substring replacement in the operator's own Caddyfile, and
+// every way it can go wrong is silent: Caddy accepts the result either way, the
+// admin page reports success either way, and the only difference is whether the
+// shield is actually in the request path. So the shipped Caddyfile is checked
+// here, as a file, rather than the logic being checked against a fixture that
+// cannot drift with it.
+
+const CADDYFILE = await Deno.readTextFile(new URL("../../../../Caddyfile", import.meta.url));
+
+Deno.test("the shipped Caddyfile is routed through Anubis, upstream and nothing else", () => {
+  const routed = routeThroughAnubis(CADDYFILE);
+  assertStringIncludes(routed, "reverse_proxy anubis:8080");
+  assert(
+    !routed.includes("reverse_proxy frontend:3000"),
+    "the app upstream survived the swap — the shield would not be in the path",
+  );
+});
+
+Deno.test("an ambiguous Caddyfile is refused, not guessed at", async (t) => {
+  await t.step("a second mention, as in a comment above the directive", () => {
+    // This is the trap: `String.replace` would rewrite the comment and leave the
+    // directive alone, and nothing downstream could tell.
+    assertThrows(() =>
+      routeThroughAnubis("# see reverse_proxy frontend:3000\n\treverse_proxy frontend:3000\n")
+    );
+  });
+
+  await t.step("no upstream to swap at all", () => {
+    assertThrows(() => routeThroughAnubis("handle {\n\trespond 200\n}\n"));
+  });
+});

--- a/apps/backend/src/services/anubisProtection.ts
+++ b/apps/backend/src/services/anubisProtection.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import * as settingsRepo from "@/db/repositories/instanceSettings.ts";
+import { routeThroughAnubis } from "@/lib/caddyfile.ts";
 
 // AI-scraper shield (Anubis) — an opt-in, admin-toggled proof-of-work wall in
 // front of browser page loads. Off by default (see setup-must-be-toy-easy: a
@@ -28,12 +29,6 @@ const CADDY_ADMIN_URL = Deno.env.get("CADDY_ADMIN_URL")?.trim();
 // so we transform the operator's real config rather than a drifting duplicate.
 const CADDYFILE_PATH = Deno.env.get("CADDYFILE_PATH")?.trim() || "/etc/caddy/Caddyfile";
 
-// The single line the toggle rewrites. By default the fallback proxies the app
-// directly; enabling protection re-points it at the Anubis sidecar, which then
-// forwards to the same app. Keep these two strings in sync with the Caddyfile.
-const DIRECT_UPSTREAM = "reverse_proxy frontend:3000";
-const ANUBIS_UPSTREAM = "reverse_proxy anubis:8080";
-
 // Whether the live toggle can work in this deployment (Caddy admin reachable).
 export function anubisManaged(): boolean {
   return CADDY_ADMIN_URL !== undefined && CADDY_ADMIN_URL !== "";
@@ -47,13 +42,7 @@ export async function anubisProtectionEnabled(): Promise<boolean> {
 // the Anubis sidecar when enabling.
 async function renderCaddyfile(enabled: boolean): Promise<string> {
   const base = await Deno.readTextFile(CADDYFILE_PATH);
-  if (!enabled) return base;
-  if (!base.includes(DIRECT_UPSTREAM)) {
-    throw new Error(
-      `Caddyfile at ${CADDYFILE_PATH} has no "${DIRECT_UPSTREAM}" line to route through Anubis.`,
-    );
-  }
-  return base.replace(DIRECT_UPSTREAM, ANUBIS_UPSTREAM);
+  return enabled ? routeThroughAnubis(base) : base;
 }
 
 // Push a Caddyfile to Caddy's admin API, which adapts and applies it atomically

--- a/botPolicy.yaml
+++ b/botPolicy.yaml
@@ -36,6 +36,31 @@
 # New routes therefore default to ALLOW. A new *public* page needs nothing; a
 # new admin or compose-like page must be added to the app-challenge rule at the
 # bottom or it ships unshielded.
+
+# What HTTP status a refusal is announced with.
+#
+# Anubis answers both a challenge and a denial with 200 by default, which is a
+# lie in the one direction that costs something: the body is an interstitial, not
+# the page that was asked for, and every automated client is told the request
+# succeeded. A search engine reads a 200 whose body is not the article as a soft
+# 404 — and, since every challenged URL returns the same interstitial, as a pile
+# of duplicates of each other. An uptime monitor reads it as healthy. A link
+# checker reads it as a working link.
+#
+# 503 says what is true: this is temporary, the URL is fine, come back. It is
+# also the code Google documents for "do not drop this URL", and the one the
+# Caddyfile attaches a Retry-After to. 403 for a denial says the opposite and
+# equally true thing: this client is not getting served, and no amount of
+# retrying will change that.
+#
+# The challenge page has always carried `<meta name="robots" content="noindex,
+# nofollow">`; the status code was the half that was missing. Neither affects a
+# browser, which renders and runs an error page exactly as it does a 200 —
+# verified against this pinned image with a real browser solving the challenge.
+status_codes:
+  CHALLENGE: 503
+  DENY: 403
+
 bots:
   # Legitimate search-engine crawlers, so the shield never delists this instance
   # from search. Anubis's bundled list matches each crawler's User-Agent AND


### PR DESCRIPTION
Answers bug report #5. One half of it was already true; the other half was real, and Anubis has a native setting for it.

## What was wrong

Anubis v1.26.2 announces **both** a challenge and a denial with **200**. Verified against the pinned image with the shipped policy:

```
CHALLENGE  → 200   (body: "Making sure you're not a bot!")
DENY       → 200   (body: the refusal page)
```

The body is an interstitial, not the page that was asked for, so every automated client is told the request succeeded when it did not:

- A **search engine** reads a 200 whose body is not the article as a soft 404 — and, because every challenged URL returns the same interstitial, as a pile of duplicates of one another. That is exactly what the report describes.
- An **uptime monitor** reads it as healthy.
- A **link checker** reads it as a working link.

The report also asks for `<meta name="robots" content="noindex">`. That has been on the challenge page all along — Anubis emits `content="noindex,nofollow"`. The status code was the half that was missing.

**One correction to the report's premise.** The duplicate-content scenario is much smaller than it sounds today, and has been since #62 inverted the bot policy. Only `/compose`, `/search`, `/dashboard`, `/settings`, `/admin`, `/notifications`, the auth pages and post management are challenged — every one of them already `Disallow`ed in `robots.txt` and `noindex` in the app's own layout, so Googlebot does not fetch them at all. What this fixes is the correctness of the answer for everything else that can meet a challenge: monitors, link checkers, archives, a crawler that ignores robots.txt, and any instance whose operator widens the challenge list.

## The fix

**`botPolicy.yaml`** — three lines, a native Anubis feature:

```yaml
status_codes:
  CHALLENGE: 503
  DENY: 403
```

503 says what is true: this is temporary, the URL is fine, come back. It is also the code Google documents for "do not drop this URL". 403 says the opposite and equally true thing about a denial.

No rule in the shipped policy issues DENY today, so `DENY: 403` is set for the same reason the machine-endpoint ALLOWs above it are — so that adding one later cannot announce a refusal as success.

**`Caddyfile`** — the `Retry-After` a 503 is supposed to carry, since Anubis has no way to set a response header itself (a `headers:` block in the policy is silently ignored — tested). Attached to the app branch with a `handle_response` matcher on 503, so the toggle stays a one-line substring swap and the header appears on nothing else. An hour: long enough that a crawler or monitor backs off properly, short enough that a URL is re-checked the same day protection is turned off.

## The bug this nearly shipped with

Adding a block under `reverse_proxy frontend:3000` meant writing a comment above it, and the first draft of that comment quoted the directive verbatim. The toggle swaps the upstream with `String.replace(DIRECT_UPSTREAM, ANUBIS_UPSTREAM)` — **first occurrence only** — so it would have rewritten *the comment* and left the real upstream pointing at the app. Caddy accepts that config, the admin page reports success, and the shield is simply not in the request path. The existing guard was `includes`, which passes in exactly that case.

So the first commit fixes that independently: the check now counts and refuses anything but exactly one, and the substitution moves to `lib/caddyfile.ts` so it can be tested without a database. Its test reads **the shipped Caddyfile**, not a fixture — the coupling under test is between that code and that file, and a fixture would drift away from it silently, which is the whole failure mode.

## What was verified

Against the pinned `ghcr.io/techarohq/anubis:v1.26.2`, the shipped `botPolicy.yaml`, and a Caddy running the real `Caddyfile` put through `routeThroughAnubis()` — i.e. the exact config the admin toggle produces.

| Request | Result |
| --- | --- |
| `/compose`, `/search`, `/admin`, `/login`, `/settings`, `/dashboard`, `/posts/manage`, `/notifications` (browser UA) | `503` · `Retry-After: 3600` · `noindex,nofollow` |
| `/`, `/index.html` (browser UA) | `200`, no `Retry-After`, real page |
| a genuine upstream `404` | stays `404` — not turned into a 503 |
| `/compose` (curl UA) | passes through to the app |
| `/` (Twitterbot) | passes through to the app |
| spoofed `Googlebot` on `/admin` | `503` — reverse DNS fails, falls to the challenge |

**A real browser still gets through.** Headless Chrome driven over CDP, fresh profile, against the config above: navigated to `/compose`, solved the proof of work, and landed on the app in about a second — with the challenge served as 503. An error status changes nothing about how a page renders or its scripts run, and this is what Anubis's own `status_codes` option exists for.

`caddy validate` passes on the Caddyfile in **both** toggle states (protection off, and after the swap). Plus `deno check`, `deno lint`, `deno fmt --check`, and 177 unit tests (2 new, covering the swap).

**Not verified:** no search console has seen a 503 from this instance, so the SEO benefit is inference from Google's documented handling of 503 rather than something observed. And `Retry-After` is a hint — Google says it *may* honour it.

## Deploy notes

`botPolicy.yaml` is bind-mounted and read once at startup: `docker compose restart anubis` after pulling, or the status codes stay 200.

The `Caddyfile` change needs Caddy to reload it — `docker compose up -d --force-recreate caddy`, or simply toggling the shield off and on in **Admin → Security**, which pushes the on-disk file through Caddy's admin API.

If the shield is off, nothing changes: the added block is inert, since SvelteKit does not answer 503.