### PR TITLE
fix: stop stranding a visitor who cannot run JavaScript

### DIFF
--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -291,6 +291,25 @@
 </svelte:head>
 
 <div class="min-h-screen bg-background text-foreground">
+  <!-- The one thing a reader with JavaScript off can usefully be told. Every
+       form in this app posts through fetch (the `submit` handlers on the auth
+       pages, the search bar, the editor), so with scripting disabled those
+       pages render in full and then do nothing at all when the button is
+       pressed — no error, no hint that it never could have worked. The reading
+       half needs no JavaScript whatsoever, so say so and point at it.
+
+       On every page rather than only the interactive ones: a reader who lands
+       on an article has no way to find out that signing in is impossible until
+       they try, and one static line is cheaper to keep honest than another list
+       of routes. -->
+  <noscript>
+    <div class="border-b border-border bg-muted px-4 py-3 text-center text-sm text-foreground">
+      JavaScript is switched off, so anything here that needs a button — signing in, searching, publishing — does
+      nothing. Reading needs none of it:
+      <a href="/" class="font-medium underline underline-offset-4">go to the home page</a>.
+    </div>
+  </noscript>
+
   <Nav user={data.user} {appName} minimal={standalone} />
 
   {#if standalone}

--- a/botPolicy.yaml
+++ b/botPolicy.yaml
@@ -61,6 +61,64 @@ status_codes:
   CHALLENGE: 503
   DENY: 403
 
+# The way out for a visitor the challenge cannot let in.
+#
+# Anubis renders the interstitial itself — it never reaches this app — and that
+# page is a dead end for anyone who cannot solve it. It says "Making sure you're
+# not a bot!", shows a spinner, and stops there: no link back to the site, no
+# contact, and the only static sentence on it (an upstream <noscript>) says that
+# JavaScript is required and offers nothing to do about it. Two kinds of visitor
+# get stuck on it forever:
+#
+#   - someone browsing with JavaScript off, or blocked for this domain by an
+#     extension, for whom the check simply cannot complete;
+#   - someone whose browser *does* run JavaScript but failed to fetch the
+#     challenge script — that is the "Anubis could not load its JavaScript. The
+#     server may be overloaded." line, which the page keeps hidden (inline
+#     `display:none`) until its own watchdog gives up.
+#
+# `impressum.footer` is raw HTML that Anubis renders into the footer of every
+# page it serves — the challenge, the deny page and the imprint page below —
+# with no JavaScript involved, so it is the one place we can hand those visitors
+# an explanation and a link out. It points at `/`, which is never challenged
+# (see the rules below): the reading half of this instance works with JavaScript
+# off, and that is worth saying on the screen that has just refused to.
+#
+# `page` is not optional — Anubis refuses to start with a footer and no imprint
+# page ("impressum page title must be defined") — so it carries the longer
+# version of the same explanation. An operator who wants a support address or a
+# legal notice on their instance's challenge screen should add it to the body
+# here; nothing else in this file needs to change.
+impressum:
+  footer: >-
+    Stuck on this screen? Getting past it needs JavaScript, and it only guards
+    this site's sign-in, account and writing pages. Everything there is to read
+    works without it — <a href="/">go to the home page</a>.<br>
+  page:
+    title: Why am I seeing that screen?
+    body: >-
+      <p>You came here from a screen that says "Making sure you're not a bot!".
+      It is a proof-of-work check that this site puts in front of its sign-in,
+      account and writing pages, so that automated scrapers cannot hammer the
+      pages that cost real work to serve. It is not an error, and it is not
+      aimed at you personally.</p>
+
+      <p>Passing the check needs JavaScript. If the screen never finishes, it is
+      almost always one of two things:</p>
+
+      <ul>
+      <li><strong>JavaScript is switched off</strong> for this site, either in
+      your browser's settings or by an extension. Allow it here and reload the
+      page.</li>
+      <li><strong>The check's own script did not load.</strong> Reload the page;
+      it is fetched again from scratch.</li>
+      </ul>
+
+      <p>You do not have to pass the check to read. Articles, profiles, tags,
+      reading lists and feeds are all served straight from the site, with no
+      challenge and no JavaScript required.
+      <a href="/">Go to the home page</a> to carry on reading.</p>
+
 bots:
   # Legitimate search-engine crawlers, so the shield never delists this instance
   # from search. Anubis's bundled list matches each crawler's User-Agent AND


### PR DESCRIPTION
## The symptom

A visitor without working JavaScript hits a dead end with nothing on it.

Fetching a challenged URL returns a page whose only clue is the string
`Anubis could not load its JavaScript. The server may be overloaded.` — and on
screen not even that: the page shows "Making sure you're not a bot!", a
spinner, "Loading…", and stays there. No static content, no way to continue, no
link home, no contact.

## The root cause

Two separate dead ends that look like one.

**1. The challenge screen.** Anubis renders it itself — the request never
reaches this app, so nothing in this repo produced that text. Taking the pinned
`ghcr.io/techarohq/anubis:v1.26.2` image apart shows why the page reads the way
it does:

- the "could not load its JavaScript" line is
  `<p id="anubis-script-error" style="display:none;">`, unhidden only by the
  page's own watchdog after the script fails. It is therefore visible in a raw
  fetch of the HTML and *not* on screen, which is exactly the mismatch in the
  report;
- there is an upstream `<noscript>` ("Sadly, you must enable JavaScript to get
  past this challenge…"), but it offers nothing to do about it — no link, no
  contact;
- the only links on the page are Anubis's own footer credits.

**2. The app itself**, which is reached far more often, because the shield is
**off by default**. There is not one server-side form action in the codebase —
every form posts through `fetch` after `preventDefault()` (auth pages, search
bar, editor). With scripting off, `/login` renders in full, complete with a
working-looking submit button, and does nothing at all when it is pressed.

## The fix

**`botPolicy.yaml` — `impressum.footer` + `impressum.page`.** The footer is raw
HTML that Anubis renders into the footer of *every* page it serves, with no
JavaScript involved. It is the one place the challenge screen can be given an
explanation and a link out without forking the image or putting a
body-rewriting plugin into Caddy (standard Caddy has no way to modify a proxied
response body). It points at `/`, which no rule in this file challenges — the
reading half of an instance works with JavaScript off, and that is worth saying
on the screen that has just refused to serve something.

`page` is not optional: Anubis refuses to start with a footer and no imprint
page (`impressum page title must be defined`). It carries the longer version of
the same explanation, including which of the two failures a reload will fix,
and it is where an operator can add a support address if they want one on their
challenge screen.

**`+layout.svelte` — a `<noscript>` bar.** Says the two things a reader cannot
find out by trying: the button was never going to do anything, and reading is
unaffected. The link to `/` is there because the standalone auth and setup
screens strip the navigation to a logo, so on the pages where a reader is most
likely to be stuck it is the only way out that is not editing the URL. Shown on
every page rather than only the interactive ones — someone who lands on an
article cannot discover that signing in is impossible until they try, and one
static line is cheaper to keep honest than another list of routes to hold in
step.

### Why not `metarefresh`

Anubis ships a `metarefresh` challenge algorithm that a client without
JavaScript can pass, and it works — verified. It was rejected anyway: every
route this policy challenges (sign-in, registration, compose, settings, admin,
search) does nothing without JavaScript regardless, so letting a no-JS visitor
*through* the wall would move the dead end one page later while measurably
weakening the shield. Explaining the wall is the honest fix; removing it is not.

## What was verified

Against the pinned v1.26.2 image, running this exact `botPolicy.yaml`:

- the policy loads (an earlier draft was rejected outright for the missing
  imprint title, so this is a real check, not a formality);
- a challenged path answers `503` with the footer text and both links present
  in the body;
- the imprint page returns `200` with its own `<title>` and its home link;
- an unchallenged path still passes straight through, untouched;
- a challenge cookie carries the hash of the rule that issued it, so nothing
  here widens what an existing cookie satisfies.

Frontend: `svelte-check` 0 errors, `oxfmt --check` clean, production build
contains the bar in the server-rendered layout and Tailwind emits every class
it uses.

**Not verified:** the challenge screen has not been looked at in a real browser
with JavaScript disabled — the checks above are on the served HTML. And no
`DENY` rule exists in this policy today, so the footer's appearance on a deny
page is inferred from the shared template rather than observed.

## Deploy notes

Anubis reads the policy file once at startup and the compose service is
otherwise unchanged, so a plain `docker compose up -d` will **not** pick this
up:

```
docker compose restart anubis
```

The frontend change ships with a normal rebuild.
