### PR TITLE
fix(anubis): brand the challenge screen, and say which text is English

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -71,6 +71,33 @@
 	@anubis_boot path /.within.website/x/cmd/anubis/static/js/main.mjs /.within.website/x/cmd/anubis/static/locales/*
 	header @anubis_boot >Cache-Control "no-cache"
 
+	# Anubis's stylesheet, answered with Omicron's own — see anubis-theme.css for
+	# what it changes, what it deliberately leaves alone, and why this is the only
+	# seam available. Anubis renders the challenge screen itself and never forwards
+	# those requests, so the app cannot style that page; Caddy sits in front of
+	# Anubis, so answering the stylesheet's path here wins and the pinned upstream
+	# image stays untouched.
+	#
+	# Both of Anubis's stylesheet URLs are matched: the templates link the minified
+	# one, and the unminified path exists too.
+	#
+	# Not conditional on the shield being on. With it off nothing ever requests
+	# this path, and a route that has to know about the toggle is a route the
+	# toggle can break.
+	#
+	# `no-cache` rather than a long max-age: the file is bind-mounted, so an
+	# upgrade or an operator's edit must not be shadowed by a week-old copy. It
+	# costs one 304 on a few KB — against the ~190 KB of embedded fonts it replaces
+	# — and it keeps a round trip in front of the challenge script, which is what
+	# the @anubis_boot block above exists to guarantee.
+	@anubis_theme path /.within.website/x/xess/xess.min.css /.within.website/x/xess/xess.css
+	handle @anubis_theme {
+		root * /srv
+		rewrite * /anubis-theme.css
+		header Cache-Control "no-cache"
+		file_server
+	}
+
 	@federation path /.well-known/* /users/* /inbox /nodeinfo /nodeinfo/*
 	handle @federation {
 		reverse_proxy backend:8000

--- a/anubis-theme.css
+++ b/anubis-theme.css
@@ -1,0 +1,249 @@
+/* Omicron's skin for the Anubis interstitial.
+ *
+ * Anubis renders the "Making sure you're not a bot!" screen itself — it answers
+ * before the request ever reaches this app — so the first page a visitor sees on
+ * a protected route is not ours to write. Out of the box it arrives in Anubis's
+ * own colours: a gruvbox dark background, a serif display face for the heading
+ * and a magenta progress bar, none of which appear anywhere else on this site.
+ * The visitor's honest reading of that is "I have landed on the wrong site".
+ *
+ * The one seam we have is the stylesheet. Anubis links exactly one, at a fixed
+ * path, and Caddy sits in front of Anubis — so Caddy answers that path with this
+ * file instead (see the `@anubis_theme` handler in the Caddyfile). Nothing is
+ * patched, forked or rebuilt; the pinned upstream image is untouched.
+ *
+ * What this deliberately does NOT do: the mascot, the "Protected by Anubis"
+ * footer and the page's wording all stay exactly as upstream ships them. Anubis
+ * is MIT and its authors sell custom images, custom titles and "Anubis" removal
+ * as BotStopper — restyling the frame while leaving their attribution and their
+ * jackal in place is the line this file stays on. An operator who wants the rest
+ * should buy BotStopper: https://anubis.techaro.lol/docs/admin/botstopper
+ *
+ * The text is already localized, and better than this app is: Anubis renders it
+ * server-side in whichever of its ~25 languages best matches the visitor's
+ * Accept-Language header (Polish, Italian, Turkish, Ukrainian, Chinese …), and
+ * falls back to English otherwise. Nothing here should hard-code any string —
+ * every rule below styles what is there rather than replacing it.
+ *
+ * Colours are the app's own tokens, copied from `apps/frontend/src/app.css` and
+ * resolved to plain hsl() because Tailwind never runs on this file. Keep them in
+ * step by hand if the theme moves.
+ *
+ * Light/dark follows the OS, which is what the app does too until the reader
+ * picks otherwise. That choice lives in localStorage, which a stylesheet cannot
+ * read, so a reader who forced dark on a light machine gets a light challenge
+ * screen. Unfixable from here, and mild.
+ *
+ * Upgrade note (written against Anubis v1.26.2): if a later Anubis moves its
+ * stylesheet URL the Caddy handler stops matching, Anubis serves its own CSS
+ * again and the screen goes back to looking upstream — visibly plain, never
+ * broken. If it keeps the URL but renames elements, the generic element rules
+ * below still carry the page. Re-check this file when bumping the image tag.
+ */
+
+:root {
+  --om-background: hsl(0 0% 100%);
+  --om-foreground: hsl(0 0% 9%);
+  --om-muted: hsl(240 5% 96%);
+  --om-muted-foreground: hsl(0 0% 9% / 0.65);
+  --om-border: hsl(240 6% 10% / 0.1);
+  --om-destructive: hsl(347 77% 50%);
+
+  /* Same stack as the app's `--font-sans`. Inter itself is bundled by Vite under
+     a content-hashed URL that nothing outside a build can link to, so this page
+     uses it only when the reader happens to have it installed and lands on
+     system-ui otherwise — close enough that the two screens read as one site. */
+  --om-font:
+    "Inter Variable", Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
+    "Helvetica Neue", Arial, sans-serif;
+  --om-font-mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+
+  color-scheme: light dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --om-background: hsl(0 0% 5%);
+    --om-foreground: hsl(0 0% 95%);
+    --om-muted: hsl(240 4% 16%);
+    --om-muted-foreground: hsl(0 0% 100% / 0.55);
+    --om-border: hsl(0 0% 96% / 0.1);
+    --om-destructive: hsl(350 89% 60%);
+  }
+}
+
+/* Anubis inlines `html, body { height: 100%; display: flex; … }` in a <style>
+   block that comes *after* this file, so plain type selectors lose the cascade
+   to it no matter what they say. `:root` outranks `html` on specificity and
+   wins from anywhere, which is why these two rules are written the long way.
+   Both elements need saying: the rule names `html` as well as `body`, so
+   leaving `html` a flex container centres the whole body box inside the
+   viewport however the body itself is laid out.
+   The flex centering they replace is also a trap: content taller than the
+   viewport (the "Why am I seeing this?" section, expanded) overflows above the
+   top edge with no way to scroll to it. */
+:root,
+:root body {
+  display: block;
+  height: auto;
+  min-height: 100%;
+}
+
+:root body {
+  margin: 0;
+  padding: clamp(2rem, 10vh, 6rem) 1.25rem 3rem;
+  background-color: var(--om-background);
+  color: var(--om-foreground);
+  font-family: var(--om-font);
+  font-size: 16px;
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+main {
+  box-sizing: border-box;
+  width: 100%;
+  max-width: 34rem;
+  margin: 0 auto;
+}
+
+/* Matches the app's auth screens: `text-2xl font-bold tracking-tight`. */
+h1,
+#title {
+  margin: 0 0 0.5rem;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.25;
+  letter-spacing: -0.025em;
+}
+
+p {
+  margin: 0 0 0.75rem;
+}
+
+a {
+  color: inherit;
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  text-decoration-thickness: 1px;
+}
+
+a:hover {
+  text-decoration-thickness: 2px;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+strong {
+  font-weight: 600;
+}
+
+ul {
+  margin: 0 0 0.75rem;
+  padding-left: 1.25rem;
+}
+
+li {
+  margin-bottom: 0.35rem;
+}
+
+code,
+pre {
+  font-family: var(--om-font-mono);
+  font-size: 0.8125rem;
+}
+
+pre {
+  overflow-x: auto;
+  margin: 0;
+  padding: 0.75rem 0.875rem;
+  border-radius: 10px;
+  background-color: var(--om-muted);
+  text-align: left;
+}
+
+/* The status line under the mascot ("Loading…", "Calculating…"), and the error
+   the page unhides when its own script never arrives. */
+body #status {
+  margin: 1rem 0 0;
+  color: var(--om-muted-foreground);
+  font-size: 0.875rem;
+}
+
+body #anubis-script-error {
+  margin: 0.75rem 0 0;
+  color: var(--om-destructive);
+  font-size: 0.875rem;
+}
+
+/* Progress bar. Anubis's inline block gives it a 4px magenta outline and a 2rem
+   height; the app's own progress bars are a thin neutral track with a solid
+   foreground fill, so this is the one element worth actively undoing. `body …`
+   only exists to outrank that later inline block. */
+body #progress {
+  box-sizing: border-box;
+  width: min(20rem, 90%);
+  height: 0.5rem;
+  margin: 1.25rem auto 0.5rem;
+  border-radius: 9999px;
+  outline: none;
+  background-color: var(--om-muted);
+}
+
+body .bar-inner {
+  background-color: var(--om-foreground);
+}
+
+/* "Why am I seeing this?" — collapsed by default, and long. */
+details {
+  margin: 1.5rem 0 0;
+  padding: 1rem 1.125rem;
+  border: 1px solid var(--om-border);
+  border-radius: 16px;
+  background-color: var(--om-background);
+  color: var(--om-muted-foreground);
+  font-size: 0.875rem;
+  text-align: left;
+}
+
+details > summary {
+  cursor: pointer;
+  color: var(--om-foreground);
+  font-weight: 500;
+}
+
+details[open] > summary {
+  margin-bottom: 0.75rem;
+}
+
+details p:last-child {
+  margin-bottom: 0;
+}
+
+/* The no-JavaScript notice, and the way out this instance adds to it — see the
+   `impressum` block in botPolicy.yaml. */
+noscript {
+  display: block;
+  margin-top: 1.5rem;
+  font-size: 0.875rem;
+}
+
+footer {
+  margin-top: 2.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid var(--om-border);
+  color: var(--om-muted-foreground);
+  font-size: 0.8125rem;
+  line-height: 1.55;
+}
+
+footer p {
+  margin: 0 0 0.5rem;
+}
+
+footer p:last-child {
+  margin-bottom: 0;
+}

--- a/apps/backend/src/lib/caddyfile_test.ts
+++ b/apps/backend/src/lib/caddyfile_test.ts
@@ -33,3 +33,24 @@ Deno.test("an ambiguous Caddyfile is refused, not guessed at", async (t) => {
     assertThrows(() => routeThroughAnubis("handle {\n\trespond 200\n}\n"));
   });
 });
+
+// The challenge screen's stylesheet is three files agreeing with each other:
+// the Caddyfile answers Anubis's own stylesheet URL out of /srv, the compose
+// file mounts anubis-theme.css there, and the file exists to be served. Break
+// any one of those links — a rename, a moved mount — and nothing errors: Caddy
+// 404s the path, Anubis serves its own CSS, and the first page a visitor sees
+// quietly goes back to looking like someone else's site. Nobody would notice
+// until they looked.
+Deno.test("the challenge screen's stylesheet is wired end to end", async () => {
+  assertStringIncludes(CADDYFILE, "@anubis_theme path /.within.website/x/xess/xess.min.css");
+  assertStringIncludes(CADDYFILE, "root * /srv");
+  assertStringIncludes(CADDYFILE, "rewrite * /anubis-theme.css");
+
+  const compose = await Deno.readTextFile(
+    new URL("../../../../docker-compose.yml", import.meta.url),
+  );
+  assertStringIncludes(compose, "./anubis-theme.css:/srv/anubis-theme.css:ro");
+
+  const css = await Deno.readTextFile(new URL("../../../../anubis-theme.css", import.meta.url));
+  assert(css.length > 0, "anubis-theme.css is shipped but empty");
+});

--- a/botPolicy.yaml
+++ b/botPolicy.yaml
@@ -89,14 +89,26 @@ status_codes:
 # version of the same explanation. An operator who wants a support address or a
 # legal notice on their instance's challenge screen should add it to the body
 # here; nothing else in this file needs to change.
+#
+# `lang="en"`, because everything around it may not be. Anubis picks the page's
+# language from the visitor's Accept-Language header and renders its own text in
+# whichever of its ~25 translations fits, stamping `<html lang="pl">` (or `it`,
+# `uk`, `zh-CN`, …) to match. These two blocks are the instance's own words and
+# stay English whatever it picks, so they are labelled as English: it is what
+# lets a browser's "translate this page" offer handle them, and what stops a
+# screen reader from voicing English prose with Polish phonemes. An operator who
+# translates this text should change the tag with it.
 impressum:
   footer: >-
-    Stuck on this screen? Getting past it needs JavaScript, and it only guards
-    this site's sign-in, account and writing pages. Everything there is to read
-    works without it — <a href="/">go to the home page</a>.<br>
+    <span lang="en">Stuck on this screen? Getting past it needs JavaScript, and
+    it only guards this site's sign-in, account and writing pages. Everything
+    there is to read works without it —
+    <a href="/">go to the home page</a>.</span><br>
   page:
     title: Why am I seeing that screen?
     body: >-
+      <div lang="en">
+
       <p>You came here from a screen that says "Making sure you're not a bot!".
       It is a proof-of-work check that this site puts in front of its sign-in,
       account and writing pages, so that automated scrapers cannot hammer the
@@ -118,6 +130,8 @@ impressum:
       reading lists and feeds are all served straight from the site, with no
       challenge and no JavaScript required.
       <a href="/">Go to the home page</a> to carry on reading.</p>
+
+      </div>
 
 bots:
   # Legitimate search-engine crawlers, so the shield never delists this instance

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -241,6 +241,10 @@ services:
       - "${HTTPS_PORT:-443}:443"
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      # Omicron's skin for the Anubis challenge screen, served by Caddy at the
+      # path Anubis links its own stylesheet from. See anubis-theme.css and the
+      # @anubis_theme handler in the Caddyfile.
+      - ./anubis-theme.css:/srv/anubis-theme.css:ro
       - caddy_data:/data
       - caddy_config:/config
 


### PR DESCRIPTION
## The symptom

A reader browsing an instance whose posts are in Azerbaijani, Polish or Italian
clicks through to sign in and lands on a page that looks like it belongs to a
different website: cream-and-magenta gruvbox, a serif display face, a jackal
mascot, and an English technical explanation about proof-of-work. Nothing on it
resembles the site they were just reading. The reasonable conclusion is that the
link went somewhere else.

## The root cause

Two separate things, and only one of them was actually broken.

**The look.** Anubis renders the interstitial itself and answers before the
request ever reaches the frontend, so that page is not ours to write — it has
always arrived in Anubis's own theme. The app cannot style what it never serves.

**The language.** Not broken. Anubis has server-side i18n: it reads
`Accept-Language`, renders in whichever of its ~25 translations matches, and
stamps `<html lang="…">`. Verified through this repo's real Caddyfile against
the pinned `v1.26.2` image:

| `Accept-Language` | `<title>` |
| --- | --- |
| `pl` | Sprawdzamy, czy nie jesteś botem! |
| `it` | Controllo se sei un robot… |
| `tr` | Ah hayır! (error page) |
| `az` | Making sure you're not a bot! |

Azerbaijani is the gap: `static/locales/manifest.json` in the image lists 25
languages and `az` is not one, so an Azerbaijani reader falls back to English.
That is upstream's translation catalogue, not something this repo can fix —
adding it means contributing `az.json` to TecharoHQ/anubis. Turkish is there
today, which is the nearest thing on offer.

## The fix

Anubis links exactly one stylesheet, at a fixed path, and Caddy sits in front of
Anubis — so Caddy answers that path with `anubis-theme.css` and Anubis's own CSS
never reaches the browser. Nothing is patched, forked or rebuilt; the pinned
image is untouched.

The new stylesheet carries the app's tokens (`background`, `foreground`,
`muted`, `border`, `destructive`, the `--font-sans` stack), resolved to plain
`hsl()` because Tailwind never runs on that file, with a `prefers-color-scheme`
dark set. It also undoes two things worth undoing:

- the flex centering on `html`/`body`, which puts the expanded "why am I seeing
  this?" text above the top of the viewport on a short window with no way to
  scroll to it;
- the 4px magenta outline on the progress bar, replaced by the thin neutral
  track the app uses.

Being 7 KB against the 194 KB of embedded fonts it replaces is a side effect,
not the point.

**Why not something else.** There is no supported knob: `--help` on v1.26.2 has
no custom-CSS, template or static-directory flag, and the policy file has no
branding key. Custom CSS, custom images and custom titles are what upstream
sells as BotStopper. So the mascot, the "Protected by Anubis" footer and every
word on the page are left exactly as shipped — this restyles the frame and
nothing else. An instance that wants the rest should buy BotStopper.

The second commit is the small honest half of "localize it": the footer sentence
and imprint page **this instance** adds are English inside a document that may be
`<html lang="pl">`, and now say so with `lang="en"` — enough for a browser's
translate offer to handle them and for a screen reader not to voice English with
Polish phonemes.

## What was verified

Against `ghcr.io/techarohq/anubis:v1.26.2` and `caddy:2-alpine` under podman,
with this repo's real `Caddyfile` (put through the shield toggle's own substring
swap) and real `botPolicy.yaml`:

- Challenge page 503, the theme served at Anubis's stylesheet URL (`no-cache`,
  ETag, 304 on revalidation), the mascot and script still served by Anubis.
- Rendered in headless Firefox and looked at — with JavaScript **off** (the
  no-JS dead-end case from #67), with it **on** at difficulty 25 to catch the
  progress bar mid-solve, in **dark** mode, plus the imprint page and the
  `Oh noes!` error page, which share the stylesheet. Compared side by side with
  an unmodified Anubis for the before shot.
- `caddy fmt --diff` clean, `caddy validate` "Valid configuration".
- Backend `check` / `lint` / `fmt --check` / 178 tests green, including the new
  wiring test and the existing one that swaps the shipped Caddyfile.
- Localization table above, fetched through the full Caddy → Anubis path.

**Not verified:** no real browser other than Firefox, and no touch device. The
"Details" disclosure on the challenge page has no `<summary>` and shows the
browser's default label — that is upstream's markup and is identical before and
after this change.

## Deploy notes

`docker compose up -d --build` is enough this time. The `caddy` service
definition itself changed (it gains the `anubis-theme.css` mount), so compose
recreates that container and picks up both the new Caddyfile and the new file —
no `--force-recreate` needed. The `anubis` container is untouched by the first
commit; the second changes `botPolicy.yaml`, which Anubis reads only at startup,
so that one does need `--force-recreate` (or `docker compose restart anubis`) to
take effect.
