### PR TITLE
fix(auth): stop the sign-up page promising the admin account

### DIFF
--- a/apps/frontend/src/routes/login/+page.svelte
+++ b/apps/frontend/src/routes/login/+page.svelte
@@ -1,11 +1,18 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
   import { goto, invalidateAll } from "$app/navigation";
+  import { page } from "$app/state";
+  import { env } from "$env/dynamic/public";
   import { endpoints, ApiError } from "$lib/api";
   import logo from "$lib/assets/omicron.svg";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import Button from "$lib/components/ui/Button.svelte";
+  import type { InstanceInfo } from "$lib/types";
   import { Label } from "bits-ui";
+
+  // "Omicron" is the software's name; the site has the operator's. Same
+  // resolution order as the nav and PageTitle.
+  const appName = $derived((page.data.instance as InstanceInfo | null)?.name || env.PUBLIC_APP_NAME || "Omicron");
 
   let identifier = $state("");
   let password = $state("");
@@ -37,7 +44,7 @@
 <div class="mb-8 text-center">
   <div class="mb-4 flex justify-center"><img src={logo} alt="" class="h-12 w-auto" /></div>
   <h1 class="text-2xl font-bold tracking-tight text-foreground">Welcome back</h1>
-  <p class="mt-1.5 text-sm text-muted-foreground">Sign in to continue to Omicron.</p>
+  <p class="mt-1.5 text-sm text-muted-foreground">Sign in to continue to {appName}.</p>
 </div>
 
 <form onsubmit={submit} class="flex flex-col gap-4">

--- a/apps/frontend/src/routes/register/+page.svelte
+++ b/apps/frontend/src/routes/register/+page.svelte
@@ -1,11 +1,29 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
   import { goto, invalidateAll } from "$app/navigation";
+  import { page } from "$app/state";
+  import { env } from "$env/dynamic/public";
   import { endpoints, ApiError } from "$lib/api";
   import logo from "$lib/assets/omicron.svg";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import Button from "$lib/components/ui/Button.svelte";
+  import type { InstanceInfo } from "$lib/types";
   import { Label } from "bits-ui";
+
+  // Whose site this is. The line under the heading used to say that the first
+  // account on a fresh instance becomes the admin — which no visitor of this
+  // page can ever act on: the layout gate redirects every route to /setup until
+  // setup is complete, and setup is complete as soon as a single account exists
+  // (isSetupComplete in instanceSetup.ts). By the time /register renders, the
+  // admin exists. So it promised a role the reader can't have and volunteered
+  // the instance's setup state to a stranger.
+  //
+  // What a sign-up form on a federated network actually owes the reader is the
+  // name of the instance they're joining, which is the operator's, not the
+  // project's. Resolution order matches the nav and PageTitle: admin-configured
+  // name, then the build-time env, then the project name as a last resort.
+  const instance = $derived(page.data.instance as InstanceInfo | null);
+  const appName = $derived(instance?.name || env.PUBLIC_APP_NAME || "Omicron");
 
   let username = $state("");
   let email = $state("");
@@ -39,7 +57,16 @@
 <div class="mb-8 text-center">
   <div class="mb-4 flex justify-center"><img src={logo} alt="" class="h-12 w-auto" /></div>
   <h1 class="text-2xl font-bold tracking-tight text-foreground">Create your account</h1>
-  <p class="mt-1.5 text-sm text-muted-foreground">The first account on a fresh instance becomes the admin.</p>
+  <!-- Federation is an operator's switch: an instance can be run as a standalone
+       blog, and this flag is the state the backend is actually running with, not
+       a pending toggle. Don't promise the fediverse to someone who won't get it. -->
+  <p class="mt-1.5 text-sm text-muted-foreground">
+    {#if instance?.federationEnabled}
+      Join {appName} and follow writers across the fediverse.
+    {:else}
+      Join {appName} and start writing.
+    {/if}
+  </p>
 </div>
 
 <form onsubmit={submit} class="flex flex-col gap-4">


### PR DESCRIPTION
## The symptom

`/register` says, under the heading:

> The first account on a fresh instance becomes the admin.

On a public instance that already has an admin — which is every instance that can display this page — a visitor reads that as an offer. It also tells a stranger something about the instance's setup state that is none of their business.

## The root cause

The sentence is not merely stale on public instances; it can never be true where it is shown.

- `apps/frontend/src/routes/+layout.server.ts` redirects **every** route to `/setup` while `instance.setupComplete` is false.
- `isSetupComplete()` in `apps/backend/src/services/instanceSetup.ts` returns true when the wizard finished **or** `countUsers() > 0`.

So an instance with zero accounts never renders `/register` — it renders the wizard — and by the time `/register` is reachable the admin account exists. The only place the claim holds is the setup wizard itself, which already makes it: "This first account is the instance admin." (`routes/setup/+page.svelte:207`).

## The fix

Replace it with the thing a sign-up form on a federated network actually owes the reader — whose site they are joining:

> Join **&lt;instance name&gt;** and follow writers across the fediverse.

Name resolution is the one the nav and `PageTitle` already use: admin-configured name → `PUBLIC_APP_NAME` → `Omicron`.

The fediverse clause is conditional on `instance.federationEnabled`, falling back to "Join &lt;name&gt; and start writing." Federation is an operator's switch and an instance can be run as a standalone blog; replacing one untrue sentence with another would be a poor trade. The flag read here is `federationRunning()` — what the backend is actually serving with, not a toggle awaiting a restart.

A second commit does the same for `/login`, which greeted visitors with "Sign in to continue to **Omicron**" — the software's name where the site's belongs. It was the last auth page still hardcoding it.

The alternative — keeping the line and gating it on a user count — was not worth it: it needs a new public "how many accounts exist" signal to render a sentence that, by the redirect above, would never render.

## What was verified

- `pnpm check` (oxfmt, svelte-check, oxlint) clean; `pnpm build` clean.
- Rendered `/register` and `/login` against a dev server in all three states, by temporarily stubbing the layout's instance load:
  - no backend reachable (`instance` null) → "Join Omicron and start writing.", no crash;
  - named instance, federation on → "Join Bakı Bloq and follow writers across the fediverse.";
  - named instance, federation off → "Join Bakı Bloq and start writing.";
  - `/login` → "Sign in to continue to Bakı Bloq."; the stub was reverted afterwards.
- Not verified: a real end-to-end run against a live backend with a renamed instance — the layout stub exercised the same code path the backend feeds.

## Deploy notes

None beyond a normal `docker compose up -d --build`. Frontend-only, no env or config change.