### PR TITLE
fix(login): make the password-recovery link look like a link

### DIFF
--- a/apps/frontend/src/routes/login/+page.svelte
+++ b/apps/frontend/src/routes/login/+page.svelte
@@ -55,12 +55,19 @@
   <div class="flex flex-col gap-1.5">
     <div class="flex items-center justify-between">
       <Label.Root for="password" class={labelClass}>Password</Label.Root>
-      <a
-        href="/forgot-password"
-        class="text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-      >
-        Forgot password?
-      </a>
+      <!-- The one escape hatch for a locked-out reader, so it has to read as a
+           link before it is hovered. It used to be a bare <a> with
+           `underline-offset-4 hover:underline` — an offset for an underline it
+           never drew — in `text-xs text-muted-foreground`, which is this page's
+           colour for helper text that is *not* interactive (the subtitle above,
+           the prose below). It was the only anchor here without an underline,
+           and on a touch device the hover rule never fires, so it stayed
+           indistinguishable from a caption for good.
+           Button variant="link" is the idiom every other link on these screens
+           already uses ("Create one", "Sign in"): underlined, in the foreground
+           colour. Kept one step down at text-xs so it stays subordinate to the
+           label it sits beside. -->
+      <Button href="/forgot-password" variant="link" class="text-xs">Forgot password?</Button>
     </div>
     <input id="password" type="password" bind:value={password} autocomplete="current-password" class={field} />
   </div>


### PR DESCRIPTION
## Symptom

A user who forgets their password appears to have no way out of `/login`. Reported as "the Forgot password? link is missing" — the reporter inferred that recovery existed at all only because `/forgot-password` and `/reset-password` appear in `robots.txt`, not because they could find it on the page.

## Root cause

The link is not missing. It has been in `login/+page.svelte` since `921562d` (2026-07-02), it renders server-side, and `/forgot-password` answers 200. It just does not look like a link.

It was the one anchor on the page styled by hand instead of through `Button variant="link"`:

```
class="text-xs font-medium text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
```

Three things go wrong at once:

- **`underline-offset-4` with no `underline`** — an offset for an underline that is never drawn. This is the fingerprint: it was meant to be underlined and the class was simply never added.
- **`text-muted-foreground`** is this page's colour for *non-interactive* helper text. 14 elements on the rendered page use it, including the subtitle directly above the form and the "No account?" prose below it. The link is the same colour as the copy around it.
- **`hover:underline`** — so on any touch device the underline never appears. On mobile the only account-recovery entry point is permanently indistinguishable from a caption.

The four anchors in the rendered HTML, before the fix:

| Link | Underlined? |
|---|---|
| JS-off notice → `/` | yes |
| brand → `/` | n/a (logo) |
| **`/forgot-password`** | **no** |
| "Create one" → `/register` | yes |

## The fix

Use `Button variant="link"`, which is the idiom every other link on these auth screens already uses ("Create one", "Sign in", "Request a new link") — underlined, foreground colour, keyboard-focusable, and one shared definition instead of a hand-tuned class string. `CLAUDE.md` asks for the Bits UI component wherever one exists; `Button.svelte`'s own comment asks callers not to hand-tune these strings. Held at `text-xs` so it stays subordinate to the `Password` label it sits beside.

**Not** adding a second link below the password field, as the report suggested. Two entry points to the same page is worse than one that works, and the existing position — label row, above-right of the input — is the convention readers already scan for (GitHub, Google, Stripe all place it there). Colour and underline were what failed, not placement.

## What was verified

- Rendered `/login` through `vite dev` and diffed the anchors before/after. Confirmed the link now emits `underline underline-offset-4` in the foreground colour, matching the other two.
- `GET /forgot-password` → 200, form renders ("Forgot your password?", "Send reset link"), so the destination is live and this is genuinely the only thing that stood between a locked-out user and recovery.
- `pnpm svelte-check` — 0 errors, 0 warnings, 5209 files.
- `pnpm lint` — the two remaining warnings are pre-existing and in unrelated files (`AdminInstanceSettings.svelte`, `hooks.server.ts`).
- `pnpm fmt` touched no file but this one.

**Not verified:** whether the reset email actually arrives on this instance. That depends on the operator's configured transport — the default is `console`, which logs the link to the backend's stdout rather than delivering it. Out of scope here, but worth a separate look: on a `console`-transport instance the user still hits a dead end, just one page later.

## Deploy notes

Frontend-only. A plain `docker compose up -d --build` picks it up. No env, config, or `Caddyfile` change, no `--force-recreate`.