### PR TITLE
fix(a11y): stop reading every author's name twice

### DIFF
--- a/apps/frontend/src/lib/components/ui/Avatar.svelte
+++ b/apps/frontend/src/lib/components/ui/Avatar.svelte
@@ -4,6 +4,20 @@
 
   // Styled with the Bits UI docs' Avatar classes verbatim (bg-muted fallback with
   // initials). Falls back to initials when `src` is absent or the image fails to load.
+  //
+  // The avatar is decorative, and deliberately so: `name` feeds the initials and
+  // nothing else. Every place this renders, the person is already named — as
+  // adjacent text on a card, comment, or profile header, or by an `aria-label` on
+  // the control wrapping it (the account menu, the change-photo button). Giving
+  // the image `alt={name}` made a screen reader read that name twice, and the
+  // initials made it three times when the image hadn't loaded: "Omicron Blog OB
+  // Omicron Blog". So the picture and the initials are both hidden from assistive
+  // tech; they are a second rendering of the neighbouring text, not new
+  // information.
+  //
+  // The consequence for callers: an avatar can no longer be the only content of a
+  // link or button. Put the name next to it inside the same control, or label the
+  // control.
   let {
     name,
     src = undefined,
@@ -30,7 +44,7 @@
     {#if src}
       <Avatar.Image
         {src}
-        alt={name}
+        alt=""
         width={size}
         height={size}
         loading="lazy"
@@ -38,7 +52,10 @@
         class="aspect-square h-full w-full object-cover"
       />
     {/if}
-    <Avatar.Fallback class="flex h-full w-full items-center justify-center rounded-full border border-muted">
+    <Avatar.Fallback
+      aria-hidden="true"
+      class="flex h-full w-full items-center justify-center rounded-full border border-muted"
+    >
       {initials}
     </Avatar.Fallback>
   </div>

--- a/apps/frontend/src/routes/follow-requests/+page.svelte
+++ b/apps/frontend/src/routes/follow-requests/+page.svelte
@@ -51,20 +51,22 @@
   <ul class="space-y-1">
     {#each items as req (req.requestId)}
       <li class="flex items-center gap-3 rounded-card px-4 py-3 transition-colors hover:bg-muted">
-        <a href={`/@${req.actor.username}`} class="shrink-0">
+        <!-- Avatar and name in one link, as in every other people list (search,
+             connections, the follower dialog). They were two separate links to
+             the same profile: now that the avatar is decorative the first would
+             have had no accessible name at all, and before that it was a second
+             identical stop for anyone tabbing or listening through the row. -->
+        <a href={`/@${req.actor.username}`} class="group flex min-w-0 flex-1 items-center gap-3">
           <Avatar name={req.actor.displayName} src={req.actor.avatarUrl ?? undefined} size={40} />
+          <span class="min-w-0">
+            <span class="block truncate text-sm font-semibold text-foreground group-hover:underline">
+              {req.actor.displayName}
+            </span>
+            <span class="block truncate text-xs text-muted-foreground">
+              @{req.actor.username} · {timeAgo(req.createdAt, $timeZone)}
+            </span>
+          </span>
         </a>
-        <div class="min-w-0 flex-1">
-          <a
-            href={`/@${req.actor.username}`}
-            class="block truncate text-sm font-semibold text-foreground hover:underline"
-          >
-            {req.actor.displayName}
-          </a>
-          <p class="truncate text-xs text-muted-foreground">
-            @{req.actor.username} · {timeAgo(req.createdAt, $timeZone)}
-          </p>
-        </div>
         <div class="flex shrink-0 items-center gap-2">
           <Button size="sm" variant="solid" disabled={busy[req.requestId]} onclick={() => act(req, true)}>
             <Icon name="check" size={15} /> Approve


### PR DESCRIPTION
## Symptom

Anyone using a screen reader hears the author's name twice on every card, comment, notification row and profile header:

> Voctl Voctl · arifastark arifastark · Yusif Aliyev Yusif Aliyev

and three times when the avatar image hasn't loaded, because the initials are read too:

> Omicron Blog OB Omicron Blog

## Root cause

`ui/Avatar.svelte` set `alt={name}` on the image, and every caller renders the same name as visible text right next to it. Confirmed in real SSR output rather than by reading the source — `PostCard`-style markup renders as:

```html
<a href="/@ob" class="flex items-center gap-2">
  <img alt="Omicron Blog" ... data-avatar-image="" src="...">
  <span data-avatar-fallback="">OB</span>
  <span class="truncate font-medium">Omicron Blog</span>
</a>
```

The `<span data-avatar-fallback>` is Bits UI's initials fallback. It's in the DOM while the image is loading and stays there permanently if the image fails or there is no `src`, so its text is in the accessibility tree as well.

## The fix

The avatar is a second rendering of text that's already on the page, so it's decorative: `alt=""` on the image and `aria-hidden="true"` on the fallback. `name` is still the prop — it feeds the initials, nothing else.

I checked all eighteen call sites before deciding that. Every one either shows the name adjacent (post cards, comments, notifications, search, admin users, the profile header, the follower/connections lists) or labels the wrapping control itself, which already overrides the subtree:

- `Nav.svelte` — `aria-label="Account menu"` on the dropdown trigger
- `settings/+page.svelte` — `aria-label="Change profile picture"` on the button

Two more are the signed-in user's own avatar beside a comment box (`Comments.svelte`, `CommentNode.svelte`), where the name was never information the reader needed.

`aria-hidden` rather than dropping the fallback text: the initials are a real visual affordance for sighted readers when there's no photo, they're just not new information for anyone listening.

**Why not `role="img"` with a label instead** — that would keep the double announcement, which is the bug.

### The one call site that had to change with it

A decorative avatar can't be the only content of a link. `follow-requests/+page.svelte` linked the avatar and the name to the same profile as two separate anchors, so `alt=""` would have left the first one with no accessible name (WCAG 2.4.4). Merged into one link, which is what `search`, `ConnectionsManager` and `FollowListDialog` already do — and which also removes a duplicate tab stop that existed before this change.

The component comment now states the constraint so the next caller doesn't reintroduce it.

## Verified

- Reproduced the exact reported string from live SSR output (`vite dev`), then re-fetched after the fix and confirmed `alt=""` and `aria-hidden="true"` on the rendered elements.
- `pnpm svelte-check` — 5209 files, 0 errors, 0 warnings.
- `pnpm lint` — clean; the two warnings it prints are pre-existing and in unrelated files.
- `pnpm fmt` applied.

**Not verified:** the follow-requests row was not looked at in a browser — that needs a private account with a pending request. The markup is a direct copy of the `ConnectionsManager` row, which sits in the same `flex items-center gap-3` list item, so I expect it to be pixel-identical apart from the hover underline now being driven by `group-hover` on the shared link. Worth a glance from anyone who has that state handy.

## Deploy notes

None — frontend only, takes effect on a normal rebuild.