### PR TITLE
fix(a11y): name card links from their title, not their whole contents

### DIFF
--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -14,6 +14,19 @@
 
   let { post }: { post: Post } = $props();
 
+  // The card's body is one big link over the title, the summary and the
+  // thumbnail, so its accessible name was everything inside it concatenated:
+  // "UNIX-programming-timev Historically, UNIX systems have maintained two
+  // different time values for a file." Anyone pulling up a list of links, or
+  // tabbing through a feed, heard the whole excerpt on every card before they
+  // could tell one post from the next. Naming the link from the heading alone
+  // fixes that and leaves the hit area, the markup and the styling untouched.
+  //
+  // Only when there is a title: an untitled post (a remote note, mostly) has no
+  // heading to point at, and its summary is then the only thing that can name
+  // the link — which is what happens without the attribute.
+  const titleId = $props.id();
+
   const signedIn = $derived(!!page.data.user);
   // An ingested post carries its own preview (the CMS's `description`); anything
   // written in the editor has none, so fall back to clipping the body.
@@ -60,11 +73,19 @@
     {/if}
   </div>
 
-  <Button href={postPath(post)} variant="plain" class="group block w-full text-left">
+  <Button
+    href={postPath(post)}
+    variant="plain"
+    aria-labelledby={post.title ? titleId : undefined}
+    class="group block w-full text-left"
+  >
     <div class="flex items-start gap-4">
       <div class="min-w-0 flex-1">
         {#if post.title}
-          <h2 class="text-xl leading-snug font-bold text-foreground group-hover:text-foreground-alt sm:text-2xl">
+          <h2
+            id={titleId}
+            class="text-xl leading-snug font-bold text-foreground group-hover:text-foreground-alt sm:text-2xl"
+          >
             {post.title}
           </h2>
         {/if}

--- a/apps/frontend/src/lib/components/ReadingListCard.svelte
+++ b/apps/frontend/src/lib/components/ReadingListCard.svelte
@@ -8,10 +8,17 @@
   let { list }: { list: ReadingList } = $props();
 
   const count = $derived(list.itemCount === 1 ? "1 post" : `${list.itemCount} posts`);
+
+  // As on a post card: the whole card is one link, so without this its
+  // accessible name is every scrap of text in it — "Private <title>
+  // <description> 3 posts". The title is what distinguishes one card from
+  // another; the rest is visible beside it either way.
+  const titleId = $props.id();
 </script>
 
 <a
   href={listPath(list)}
+  aria-labelledby={titleId}
   class="group flex flex-col gap-2 rounded-card border border-border bg-background-alt p-4 transition-colors hover:bg-muted focus-visible:outline-hidden"
 >
   <div class="flex items-start justify-between gap-2">
@@ -27,7 +34,7 @@
       </span>
     {/if}
   </div>
-  <h3 class="truncate font-semibold text-foreground group-hover:text-foreground-alt">
+  <h3 id={titleId} class="truncate font-semibold text-foreground group-hover:text-foreground-alt">
     {list.title}
   </h3>
   {#if list.description}


### PR DESCRIPTION
## Symptom

Reported as the post title and the excerpt being fused into one string with no boundary between them:

> `## UNIX-programming-timev Historically, UNIX systems have maintained two different time values…`

## Root cause — not the heading

The heading structure is already what you'd want. `PostCard.svelte` renders the title in its own `<h2>` and the summary in a sibling `<p>`, and the SSR output confirms it:

```html
<a href="/@voctl/unix-programming-timev" class="group block w-full text-left">
  <div class="flex items-start gap-4">
    <div class="min-w-0 flex-1">
      <h2 class="text-xl leading-snug font-bold …">UNIX-programming-timev</h2>
      <p class="mt-1.5 line-clamp-3 text-muted-foreground">Historically, UNIX systems have maintained two different time values for a file.</p>
    </div>
  </div>
</a>
```

So heading navigation lands on the title alone, and a crawler reads an `<h2>` containing only the title. Those two parts of the report don't hold.

What does fuse is the **link's accessible name**. The card body is one `<a>` wrapping the title, the summary and the thumbnail, so the name is computed from the entire subtree. Extracted from that same rendered output:

```
accessible name of the card link =
'UNIX-programming-timev Historically, UNIX systems have maintained two different time values for a file.'
```

Character for character the reported string, missing boundary included. Anyone tabbing through a feed, or opening a list-of-links (NVDA's elements list, VoiceOver's rotor), hears the full excerpt on every card before they can tell one post from the next.

## The fix

`aria-labelledby` on the card link, pointing at the heading, so the name comes from the title alone. The id comes from `$props.id()`, which is unique per component instance and stable across hydration.

Markup, hit area and styling are all untouched. The obvious alternative — shrink the link down to the title text and stretch a `::after` over the card to keep it clickable — changes the layout and kills text selection over the summary, which is a lot of blast radius for an accessible-name problem.

The attribute is only set when there **is** a title. An untitled post — a remote note, mostly — has no heading to point at, and its summary is then the only thing that can name the link, which is exactly what happens with the attribute absent.

Second commit applies the identical fix to `ReadingListCard`, which has the same shape: its name was `"Private Systems reading Papers and posts about kernels, filesystems and time. 3 posts"`. Not in the original report, but the same defect in the same idiom — flagging it here rather than leaving a known instance behind.

## Verified

- Rendered both components through `vite dev` with a mock payload and extracted the accessible name before and after. Before: title + excerpt. After: `aria-labelledby="s1"` → `<h2 id="s1">`, title only.
- Two cards on one page get distinct ids (`s1`, `s4`), each paired with its own heading.
- An untitled card renders with no `aria-labelledby` and falls back to its summary, as intended.
- Checked Svelte's `props_id` in both runtimes: SSR emits `s*` and hydration reuses it from the `<!--$s1-->` marker; client-created instances take `c*` from a `window.__svelte` counter. So cards appended by "Load more" can't collide with server-rendered ones.
- `pnpm svelte-check` — 5209 files, 0 errors, 0 warnings. `pnpm lint` clean apart from two pre-existing warnings in unrelated files. `pnpm fmt` applied.

**Not verified:** no screen reader was actually run. The claims above are from the computed accessible name in the rendered HTML, which is what AT reads, but that's a step short of hearing it.

## Deploy notes

None — frontend only.