### PR TITLE
fix(frontend): clip an excerpt at a word boundary

### DIFF
--- a/apps/backend/src/lib/webhook.ts
+++ b/apps/backend/src/lib/webhook.ts
@@ -175,6 +175,10 @@ export function requireCreateFields(payload: ContentPayload): void {
  * stripping Markdown by hand means every syntax markdown-it understands is
  * handled, including what a regex would miss (reference links, HTML blocks,
  * tables). Truncation lands on a word boundary when one is close enough.
+ *
+ * The frontend's `excerpt` (lib/format.ts) is the same rule, for posts written
+ * in the editor rather than ingested. The two appear side by side in one feed,
+ * so change them together.
  */
 export function summarize(contentHtml: string, limit = SUMMARY_LENGTH): string {
   const text = htmlToText(contentHtml).replace(/\s+/g, " ").trim();

--- a/apps/frontend/src/lib/format.ts
+++ b/apps/frontend/src/lib/format.ts
@@ -33,9 +33,25 @@ export function stripHtml(html: string): string {
     .trim();
 }
 
+// Clipped at a word boundary, not at the character the limit happens to land
+// on: a slice mid-word ("the functions open, read, wri…") reads as damage
+// rather than as an abbreviation, and this text is the card excerpt, the
+// og:description on every share and the RSS item description.
+//
+// The rule is the backend's `summarize` (lib/webhook.ts), deliberately: an
+// ingested post carries a summary derived there and an editor-written one is
+// summarized here, and the two sit side by side in the same feed. Keep them
+// the same shape. A short last word is dropped; a boundary that would throw
+// away more than 40% of the allowance is ignored and the hard cut kept, so a
+// single very long token can't collapse the excerpt to nothing. Trailing
+// punctuation goes before the ellipsis so it doesn't read as ",…".
 export function excerpt(html: string, len = 180): string {
   const text = stripHtml(html);
-  return text.length > len ? `${text.slice(0, len).trimEnd()}…` : text;
+  if (text.length <= len) return text;
+  const clipped = text.slice(0, len);
+  const lastSpace = clipped.lastIndexOf(" ");
+  const head = lastSpace > len * 0.6 ? clipped.slice(0, lastSpace) : clipped;
+  return `${head.replace(/[\s.,;:!?-]+$/, "")}…`;
 }
 
 // Rough Medium-style read time (~200 words/min, floored at 1).


### PR DESCRIPTION
Two claims in the report; one is a real bug, the other isn't ours.

## The word boundary — fixed

`excerpt` in `lib/format.ts` sliced at whatever character the limit landed on:

```ts
return text.length > len ? `${text.slice(0, len).trimEnd()}…` : text;
```

Before and after, on a body that clips inside a word:

```
before: "…goes through one of them: the functions open, read, write, lseek and clos…"
after : "…goes through one of them: the functions open, read, write, lseek and…"
```

The backend already did this properly. `summarize` in `apps/backend/src/lib/webhook.ts` backs off to the last space, keeps the hard cut when a boundary would throw away more than 40% of the allowance (so one unbroken 400-character token can't collapse the excerpt to nothing), and strips trailing punctuation so it doesn't read as `",…"`.

So the same feed showed two behaviours depending on where a post came from — an ingested post carries a summary derived by the backend, an editor-written one is summarized in the browser. `excerpt` now uses the backend's rule, and each function's comment names the other so they don't drift apart again.

This text is also the `og:description` on every share (`+layout.svelte`) and the fallback `<description>` on every RSS item (`lib/rss.ts`), both of which were being cut the same way.

## The `#` — not an excerpt bug

The excerpt is showing exactly what the article shows. `#UserID` is in the post body as literal text, because CommonMark requires a space after the hash for an ATX heading. Rendering the three cases through the real pipeline:

```
SRC : "#UserID"
HTML: <p>#UserID<br /> The user ID from our entry in the password file…</p>
SUM : "#UserID The user ID from our entry in the password file…"

SRC : "# User ID"
HTML: <h1>User ID</h1> <p>The user ID from our entry in the password file…</p>
SUM : "User ID The user ID from our entry in the password file…"
```

Nothing is leaking through the summarizer — `summarize` flattens the *rendered* HTML, so there is no Markdown left in it by then. The hash is a paragraph character in the stored body, and a reader opening the article sees `#UserID` there too.

The source needs a space after the hash. Making markdown-it accept `#Heading` is a dialect change I'd argue against on this project specifically: on a fediverse platform a line beginning `#introductions` is a hashtag, and it would silently become an `<h1>`.

## Verified

- Exercised the new `excerpt` against: a mid-word clip, a clip landing on a space, text shorter than the limit, a 400-character single token (hard cut kept, output 181 chars), a clip landing on a comma (stripped), and the `#UserID` body above.
- Rendered `#UserID` / `# User ID` / `#Proc and proc ID` through the real `renderMarkdown` + `summarize` to establish where the hash comes from.
- `pnpm svelte-check` — 5209 files, 0 errors, 0 warnings. `pnpm fmt` applied.
- `deno test src/lib/webhook_test.ts` — 24 passed (the backend's word-boundary rule is already covered there, including the unbroken-run case).

**Not verified by a test:** the frontend has no test runner, so the new `excerpt` behaviour is checked by the manual cases above rather than by anything that will catch a regression. If it's worth wiring vitest into `apps/frontend` for `format.ts` and friends, say so and I'll do it separately.

**Left alone:** the two limits still differ — 150 characters for a backend-derived summary, 180 for a frontend one — so an ingested post's excerpt is a little shorter than a neighbouring editor-written one. That's a design call rather than a defect, and `line-clamp-3` hides it in the card. Happy to unify if you want them identical.

## Deploy notes

Both apps rebuild. Existing ingested posts keep the summary already stored — the backend rule didn't change, so nothing needs re-deriving.