### PR TITLE
fix: stop promising an email the instance cannot send

### DIFF
--- a/apps/backend/src/services/emailSettings.ts
+++ b/apps/backend/src/services/emailSettings.ts
@@ -89,6 +89,20 @@ async function defaultFrom(): Promise<string> {
 
 // The effective, ready-to-send configuration. Every field falls back through
 // env then a built-in default, so this is always fully populated.
+/**
+ * The effective transport mode on its own, resolved by the same DB → env →
+ * default rule as the full config.
+ *
+ * Separate from `getEmailConfig` because the only public caller — the instance
+ * info a signed-out visitor reads, to know whether a reset link can actually be
+ * delivered — has no business loading the SMTP password and the DKIM private
+ * key to answer one question.
+ */
+export async function getEmailMode(): Promise<EmailMode> {
+  const mode = await settingsRepo.get<string>(EMAIL_KEYS.mode);
+  return isMode(mode) ? mode : (config.EMAIL_TRANSPORT as EmailMode);
+}
+
 export async function getEmailConfig(): Promise<EmailConfig> {
   const g = settingsRepo.get;
   const [

--- a/apps/backend/src/services/emailSettings.ts
+++ b/apps/backend/src/services/emailSettings.ts
@@ -87,8 +87,6 @@ async function defaultFrom(): Promise<string> {
   return `${name} <noreply@${domain}>`;
 }
 
-// The effective, ready-to-send configuration. Every field falls back through
-// env then a built-in default, so this is always fully populated.
 /**
  * The effective transport mode on its own, resolved by the same DB → env →
  * default rule as the full config.
@@ -103,6 +101,8 @@ export async function getEmailMode(): Promise<EmailMode> {
   return isMode(mode) ? mode : (config.EMAIL_TRANSPORT as EmailMode);
 }
 
+// The effective, ready-to-send configuration. Every field falls back through
+// env then a built-in default, so this is always fully populated.
 export async function getEmailConfig(): Promise<EmailConfig> {
   const g = settingsRepo.get;
   const [

--- a/apps/backend/src/services/instanceSetup.ts
+++ b/apps/backend/src/services/instanceSetup.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import * as settingsRepo from "@/db/repositories/instanceSettings.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
-import { type EmailInput, setEmailConfig } from "@/services/emailSettings.ts";
+import { type EmailInput, getEmailMode, setEmailConfig } from "@/services/emailSettings.ts";
 import { federationRunning } from "@/services/federationState.ts";
 import { config } from "@/config.ts";
 
@@ -16,7 +16,6 @@ export const SETUP_KEYS = {
   appName: "instance.appName",
   appDomain: "instance.appDomain",
   federationEnabled: "instance.federationEnabled",
-  emailMode: "email.mode",
   bannerText: "instance.bannerText",
   bannerImageUrl: "instance.bannerImageUrl",
 } as const;
@@ -57,14 +56,6 @@ export async function getFederationEnabled(): Promise<boolean> {
 // Persist the desired federation state from the admin page. Restart-applied.
 export async function setFederationEnabled(value: boolean): Promise<void> {
   await settingsRepo.set(SETUP_KEYS.federationEnabled, value);
-}
-
-// Effective email transport mode: wizard → EMAIL_TRANSPORT env/default.
-// The wizard stores the operator's choice here; the concrete transport wiring
-// (SMTP creds / relay) is configured in a later step of the wizard.
-export async function getEmailMode(): Promise<string> {
-  const fromDb = await settingsRepo.get<string>(SETUP_KEYS.emailMode);
-  return fromDb?.trim() || config.EMAIL_TRANSPORT;
 }
 
 // The effective instance origin (scheme + domain), honouring a wizard-set
@@ -155,18 +146,28 @@ export async function setBannerImageUrl(url: string | null): Promise<void> {
 }
 
 // A public snapshot of the instance's identity, safe to expose unauthenticated.
+//
+// `emailEnabled` is here rather than behind the admin API because the pages
+// that need it are the ones nobody is signed in on: password reset and email
+// verification both end at "check your inbox", and on an instance still using
+// the default `console` transport there is no inbox to check — the link only
+// ever reaches the operator's backend log. A visitor who is locked out has to
+// be told that, and it gives away nothing: it is a property of the instance,
+// not of any account, and it names no host, credential or key.
 export async function publicInfo(): Promise<{
   name: string;
   domain: string;
   federationEnabled: boolean;
   setupComplete: boolean;
+  emailEnabled: boolean;
   bannerText: string | null;
   bannerImageUrl: string | null;
 }> {
-  const [name, domain, setupComplete, bannerText, bannerImageUrl] = await Promise.all([
+  const [name, domain, setupComplete, emailMode, bannerText, bannerImageUrl] = await Promise.all([
     getAppName(),
     getAppDomain(),
     isSetupComplete(),
+    getEmailMode(),
     getBannerText(),
     getBannerImageUrl(),
   ]);
@@ -175,6 +176,7 @@ export async function publicInfo(): Promise<{
     domain,
     federationEnabled: federationRunning(),
     setupComplete,
+    emailEnabled: emailMode !== "console",
     bannerText,
     bannerImageUrl,
   };

--- a/apps/frontend/src/lib/components/AdminEmail.svelte
+++ b/apps/frontend/src/lib/components/AdminEmail.svelte
@@ -265,6 +265,18 @@
     </RadioGroup.Item>
   </RadioGroup.Root>
 
+  {#if mode === "console"}
+    <!-- "Zero config" is only half the story, and the missing half costs an
+         operator their users' accounts: with nothing configured, a reader who
+         forgets their password has no way back in and no way to find that out
+         except by asking. Say it here, where the choice is being made. -->
+    <p class="rounded-card border border-border bg-background-alt px-4 py-3 text-sm text-muted-foreground">
+      Nothing is delivered in this mode — reset and confirmation links are written to the backend log. Password reset
+      and email verification tell visitors so instead of offering a form. Fine for local development; pick another mode
+      before anyone else signs up.
+    </p>
+  {/if}
+
   {#if mode !== "console"}
     <div class="flex flex-col gap-1.5">
       <Label.Root for="email-from" class={labelClass}>From address</Label.Root>

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -394,6 +394,11 @@ export type InstanceInfo = {
   domain: string;
   federationEnabled: boolean;
   setupComplete: boolean;
+  // False while the instance is still on the default `console` transport, which
+  // writes mail to the backend log instead of sending it. The pages that end at
+  // "check your inbox" — password reset, email verification — have to say so
+  // rather than promising a message that will never arrive.
+  emailEnabled: boolean;
   // Admin-customizable signed-out visitor card; null means "use the built-in
   // default" (a generated sentence / the bundled artwork).
   bannerText: string | null;

--- a/apps/frontend/src/routes/forgot-password/+page.svelte
+++ b/apps/frontend/src/routes/forgot-password/+page.svelte
@@ -1,11 +1,21 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
+  import { page } from "$app/state";
   import { endpoints, ApiError } from "$lib/api";
   import logo from "$lib/assets/omicron.svg";
   import Icon from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import Button from "$lib/components/ui/Button.svelte";
+  import type { InstanceInfo } from "$lib/types";
   import { Label } from "bits-ui";
+
+  // An instance still on the default `console` transport writes the reset link
+  // to the backend log instead of sending it. Offering the form anyway ends the
+  // only account-recovery path there is on a screen that says a message is on
+  // its way, and nothing ever arrives — so say what is actually true and point
+  // at the one person who can help.
+  const instance = $derived(page.data.instance as InstanceInfo | null);
+  const canSendEmail = $derived(instance?.emailEnabled !== false);
 
   let identifier = $state("");
   let error = $state("");
@@ -33,7 +43,20 @@
 
 <PageTitle text="Reset password" />
 
-{#if sent}
+{#if !canSendEmail}
+  <div class="flex flex-col items-center text-center">
+    <div class="mb-5 flex size-14 items-center justify-center rounded-full bg-muted text-muted-foreground">
+      <Icon name="mail" size={26} />
+    </div>
+    <h1 class="text-2xl font-bold tracking-tight text-foreground">This instance can't send email</h1>
+    <p class="mt-2 max-w-xs text-sm leading-relaxed text-muted-foreground">
+      Password reset needs outbound email, and it hasn't been set up here yet. Ask the administrator of
+      <span class="font-medium text-foreground">{instance?.domain ?? "this instance"}</span> to reset your password or to
+      configure email.
+    </p>
+    <Button href="/login" variant="outline" class="mt-6 h-11 w-full">Back to sign in</Button>
+  </div>
+{:else if sent}
   <div class="flex flex-col items-center text-center">
     <div class="mb-5 flex size-14 items-center justify-center rounded-full bg-muted text-foreground">
       <Icon name="mail" size={26} />

--- a/apps/frontend/src/routes/verify-email/+page.svelte
+++ b/apps/frontend/src/routes/verify-email/+page.svelte
@@ -6,6 +6,7 @@
   import Icon from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import Button from "$lib/components/ui/Button.svelte";
+  import type { InstanceInfo } from "$lib/types";
   import { Label } from "bits-ui";
   import { onMount } from "svelte";
 
@@ -14,6 +15,11 @@
   type State = "verifying" | "success" | "error" | "resend" | "resent";
 
   const token = $page.url.searchParams.get("token") ?? "";
+  // Only the resend form depends on outbound email. A token already in hand
+  // verifies fine either way — it reached the reader somehow — so the check
+  // gates the form, not the whole page.
+  const instance = $derived($page.data.instance as InstanceInfo | null);
+  const canSendEmail = $derived(instance?.emailEnabled !== false);
   let view = $state<State>(token ? "verifying" : "resend");
   let errorMsg = $state("");
 
@@ -90,6 +96,18 @@
     <p class="mt-2 max-w-xs text-sm leading-relaxed text-muted-foreground">
       If <span class="font-medium text-foreground">{email}</span> needs verifying, a fresh link is on its way. It expires
       in 24 hours.
+    </p>
+    <Button href="/login" variant="outline" class="mt-6 h-11 w-full">Back to sign in</Button>
+  </div>
+{:else if !canSendEmail}
+  <div class="flex flex-col items-center text-center">
+    <div class="mb-5 flex size-14 items-center justify-center rounded-full bg-muted text-muted-foreground">
+      <Icon name="mail" size={26} />
+    </div>
+    <h1 class="text-2xl font-bold tracking-tight text-foreground">This instance can't send email</h1>
+    <p class="mt-2 max-w-xs text-sm leading-relaxed text-muted-foreground">
+      Confirmation links need outbound email, and it hasn't been set up here yet. Ask the administrator of
+      <span class="font-medium text-foreground">{instance?.domain ?? "this instance"}</span> to configure it.
     </p>
     <Button href="/login" variant="outline" class="mt-6 h-11 w-full">Back to sign in</Button>
   </div>


### PR DESCRIPTION
## Symptom

On an instance still using the default `console` email transport, "Forgot your password?" accepts the form and answers:

> **Check your inbox** — If an account matches …, we've sent a link to reset your password. It expires in one hour.

Nothing was sent. The reset link went to the backend's stdout and nowhere else. Password reset is the only account-recovery path there is, so a reader who forgets their password is locked out permanently, believing a message is on its way. The resend half of email verification dead-ends the same way.

## Root cause

`console` is the default transport (`services/email.ts`) and is genuinely useful — in dev, the link is printed to the log and the whole flow is exercisable with no SMTP server. The problem is only that nothing tells the *visitor*. An operator who never reaches the email step of the wizard ships a public instance where recovery silently does nothing, and the admin page describes the mode as "Log links to the server — zero config" without mentioning what it costs.

## The fix

`publicInfo` gains `emailEnabled` — false while the mode is `console`. It's in the unauthenticated snapshot because the pages that need it are the ones nobody is signed in on. It leaks nothing: it's a property of the instance rather than of any account, and it names no host, credential, or key.

Both pages that end at an inbox now tell the truth and point at the administrator:

> **This instance can't send email** — Password reset needs outbound email, and it hasn't been set up here yet. Ask the administrator of example.social to reset your password or to configure email.

Verifying a token already in hand still works either way — it reached the reader somehow — so the check gates the resend form, not the whole verify page.

The admin email page now says plainly what console mode means while it's selected, so the choice is informed at the point it's made.

### One thing cleaned up on the way

`instanceSetup.ts` had its own reader of the same `email.mode` key that didn't validate the stored value, while `getEmailConfig` did. A junk value would have been reported as a working transport while the sender fell back to console. The new `getEmailMode` in `emailSettings.ts` validates it the same way `getEmailConfig` does; the unvalidated copy had no caller outside its own file and is gone, along with the now-unused `SETUP_KEYS` entry.

## Verified

- Rendered both pages through `vite dev` against a load returning `emailEnabled: false` and then `true`. False: both show "This instance can't send email" with the instance domain. True: both show their original forms unchanged.
- Fallback when `instance` is null (backend unreachable) is to show the form — `emailEnabled !== false` — so a transport hiccup doesn't hide recovery.
- `deno check src/main.ts` clean; `deno test` — 178 unit tests pass.
- `pnpm svelte-check` — 5209 files, 0 errors, 0 warnings. `pnpm fmt` applied.

**Not verified:** the three `tests/integration/*` suites need a `DATABASE_URL` and weren't run — they fail at config load before any of this code, on this branch and on `main` alike. I also didn't exercise the flow end to end against a live instance with a real SMTP transport; the positive path is unchanged code, but that's an assertion about the diff, not an observation.

## Deploy notes

Both apps rebuild. `/api/instance` gains a field; nothing consumes it that isn't in this PR. No migration, no config change — an instance that already has SMTP, relay, or direct configured sees no difference.

**Docs:** this changes what an operator sees on the admin email page and what a visitor sees on password reset, so `omicron-docs` likely wants a line about it. Happy to open that separately — say the word.