### PR TITLE
fix(frontend): label reaction counters for screen readers and hover

### DIFF
--- a/apps/frontend/src/lib/components/CommentNode.svelte
+++ b/apps/frontend/src/lib/components/CommentNode.svelte
@@ -14,7 +14,7 @@
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { insertEmojiIntoField, emojiOverlayBtn } from "$lib/emoji";
-  import { formatDateTime } from "$lib/format";
+  import { countLabel, formatDateTime } from "$lib/format";
   import { timeZone } from "$lib/timezone";
   import type { Comment, User } from "$lib/types";
 
@@ -35,6 +35,9 @@
   } = $props();
 
   const isReply = $derived(comment.id !== thread.id);
+  // `aria-label` replaces the button's content as its accessible name, so the
+  // like count has to be spoken in the label itself.
+  const likeLabel = $derived(`${comment.liked ? "Unlike" : "Like"} (${countLabel(comment.likeCount, "like")})`);
 
   // Local refs for caret-aware emoji insertion into the edit/reply boxes. Only
   // one of each is ever open at a time (state lives in the shared `ui`).
@@ -90,7 +93,8 @@
           size="xs"
           class={comment.liked ? "text-foreground" : "text-muted-foreground"}
           aria-pressed={comment.liked}
-          aria-label={comment.liked ? "Unlike" : "Like"}
+          aria-label={likeLabel}
+          title={likeLabel}
         >
           <Icon name="heart" size={15} class={comment.liked ? "fill-current" : ""} />
           {#if comment.likeCount > 0}<span class="tabular-nums">{comment.likeCount}</span>{/if}

--- a/apps/frontend/src/lib/components/Discover.svelte
+++ b/apps/frontend/src/lib/components/Discover.svelte
@@ -6,6 +6,7 @@
   import Icon from "$lib/components/Icon.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
+  import { countLabel } from "$lib/format";
   import { postPath } from "$lib/links";
   import type { Post, SuggestedUser, TagWithCount } from "$lib/types";
 
@@ -56,8 +57,20 @@
                 {post.title ?? "Untitled"}
               </a>
               <div class="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
-                <span class="flex items-center gap-1"><Icon name="heart" size={12} /> {post.likeCount}</span>
-                <span class="flex items-center gap-1"><Icon name="comment" size={12} /> {post.commentCount}</span>
+                <span class="flex items-center gap-1" title={countLabel(post.likeCount, "like")}>
+                  <span aria-hidden="true" class="flex items-center gap-1">
+                    <Icon name="heart" size={12} />
+                    {post.likeCount}
+                  </span>
+                  <span class="sr-only">{countLabel(post.likeCount, "like")}</span>
+                </span>
+                <span class="flex items-center gap-1" title={countLabel(post.commentCount, "response")}>
+                  <span aria-hidden="true" class="flex items-center gap-1">
+                    <Icon name="comment" size={12} />
+                    {post.commentCount}
+                  </span>
+                  <span class="sr-only">{countLabel(post.commentCount, "response")}</span>
+                </span>
               </div>
             </div>
           </li>

--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -7,7 +7,7 @@
   import TagList from "$lib/components/TagList.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
-  import { excerpt, formatDate, formatTime, readTime } from "$lib/format";
+  import { countLabel, excerpt, formatDate, formatTime, readTime } from "$lib/format";
   import { postPath } from "$lib/links";
   import { timeZone } from "$lib/timezone";
   import type { Post } from "$lib/types";
@@ -132,8 +132,20 @@
       ></span
     >
     <span class="flex items-center gap-1"><Icon name="clock" size={13} /> {minutes} min read</span>
-    <span class="flex items-center gap-1"><Icon name="heart" size={13} /> {post.likeCount}</span>
-    <span class="flex items-center gap-1"><Icon name="comment" size={13} /> {post.commentCount}</span>
+    <span class="flex items-center gap-1" title={countLabel(post.likeCount, "like")}>
+      <span aria-hidden="true" class="flex items-center gap-1">
+        <Icon name="heart" size={13} />
+        {post.likeCount}
+      </span>
+      <span class="sr-only">{countLabel(post.likeCount, "like")}</span>
+    </span>
+    <span class="flex items-center gap-1" title={countLabel(post.commentCount, "response")}>
+      <span aria-hidden="true" class="flex items-center gap-1">
+        <Icon name="comment" size={13} />
+        {post.commentCount}
+      </span>
+      <span class="sr-only">{countLabel(post.commentCount, "response")}</span>
+    </span>
     <span class="ml-auto flex shrink-0 items-center gap-1">
       <RecommendButton postId={post.id} recommended={post.recommended} recommendCount={post.recommendCount} size="xs" />
       <SaveToListButton postId={post.id} {signedIn} />

--- a/apps/frontend/src/lib/components/RecommendButton.svelte
+++ b/apps/frontend/src/lib/components/RecommendButton.svelte
@@ -5,6 +5,7 @@
   import { endpoints } from "$lib/api";
   import Icon from "$lib/components/Icon.svelte";
   import Button from "$lib/components/ui/Button.svelte";
+  import { countLabel } from "$lib/format";
   import { untrack } from "svelte";
 
   // Recommend ("repost") toggle — federates as an ActivityPub
@@ -37,6 +38,13 @@
     count = recommendCountProp;
   });
 
+  // The visible count is inside the button, but `aria-label` replaces the
+  // content as the accessible name — so the count has to be in the label
+  // itself, or a screen reader hears "Recommend" and never the number.
+  const label = $derived(
+    `${recommended ? "Remove recommendation" : "Recommend"} (${countLabel(count, "recommendation")})`,
+  );
+
   async function toggle() {
     if (!page.data.user) {
       goto("/login");
@@ -68,8 +76,8 @@
   {size}
   class={recommended ? "text-foreground" : "text-muted-foreground"}
   aria-pressed={recommended}
-  aria-label={recommended ? "Remove recommendation" : "Recommend"}
-  title={recommended ? "Remove recommendation" : "Recommend"}
+  aria-label={label}
+  title={label}
 >
   <Icon name="recommend" size={iconSize} />
   <span class="tabular-nums">{count}</span>

--- a/apps/frontend/src/lib/format.ts
+++ b/apps/frontend/src/lib/format.ts
@@ -54,6 +54,13 @@ export function excerpt(html: string, len = 180): string {
   return `${head.replace(/[\s.,;:!?-]+$/, "")}…`;
 }
 
+// A counter as a phrase — "2 likes", "1 response" — for tooltips and
+// screen-reader labels, where the bare number the counter shows ("2") names
+// nothing on its own.
+export function countLabel(n: number, one: string, many = `${one}s`): string {
+  return `${n} ${n === 1 ? one : many}`;
+}
+
 // Rough Medium-style read time (~200 words/min, floored at 1).
 export function readTime(html: string): number {
   return readTimeFromWords(countWords(stripHtml(html)));

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -12,7 +12,7 @@
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import { formatDateTime, readTime } from "$lib/format";
+  import { countLabel, formatDateTime, readTime } from "$lib/format";
   import { languageLabel } from "$lib/languages";
   import { timeZone } from "$lib/timezone";
   import { Dialog, DropdownMenu, Label, Separator } from "bits-ui";
@@ -49,6 +49,11 @@
     likeCount = data.post.likeCount;
     commentCount = data.post.commentCount;
   });
+  // The counts sit inside the buttons visually, but an `aria-label` replaces
+  // the content as the accessible name — so the labels carry the counts
+  // themselves, or a screen reader hears "Like" and never the number.
+  const likeLabel = $derived(`${liked ? "Unlike" : "Like"} (${countLabel(likeCount, "like")})`);
+  const commentLabel = $derived(countLabel(commentCount, "response"));
   // Enhance server-rendered code blocks with a copy-to-clipboard button. The
   // content is injected via {@html}, so we reach into the DOM after each render.
   let contentEl = $state<HTMLElement>();
@@ -402,13 +407,16 @@
       variant="ghost"
       class={liked ? "text-foreground" : "text-muted-foreground"}
       aria-pressed={liked}
-      aria-label={liked ? "Unlike" : "Like"}
+      aria-label={likeLabel}
+      title={likeLabel}
     >
       <Icon name="heart" size={18} class={liked ? "fill-current" : ""} />
       <span class="tabular-nums">{likeCount}</span>
     </Button>
     <a
       href="#responses"
+      aria-label={commentLabel}
+      title={commentLabel}
       class="inline-flex h-10 items-center gap-1.5 rounded-input px-4 text-sm font-medium text-muted-foreground hover:bg-muted"
     >
       <Icon name="comment" size={18} />


### PR DESCRIPTION
## Symptom

Reaction counters render as bare numbers beside icons — "2 0 0" on feed cards, "5 0 0" on the post page. A sighted reader hovering gets no hint of what each number counts (likes? responses? saves?). Screen-reader users fare worse: the static card counters announce as unexplained digits, and the buttons announce no count at all — an `aria-label` replaces a button's content as its accessible name, so "Like" swallows the number rendered inside it. The comment-count link on the post page had no label at all, so its accessible name was literally "5".

## Root cause

Every reaction counter was icon + bare number, with no label, tooltip, or screen-reader text — in all five places they appear: `PostCard`, the `Discover` rail, the post page's engagement bar (like button + comment link), `RecommendButton`, and comment like buttons in `CommentNode`.

## Fix

- New `countLabel()` helper in `$lib/format.ts` — "2 likes", "1 response".
- Static counters (`PostCard`, `Discover`): the visual digit + icon are wrapped in `aria-hidden`, the full phrase is spoken via `sr-only` text, and the wrapper gets a `title` tooltip.
- Buttons (post Like, Recommend, comment Like): the count is folded into the `aria-label` itself ("Like (5 likes)"), with a matching `title`.
- The post page's comment-count anchor gets `aria-label` + `title` ("5 responses" — matching the existing "Responses" heading).

Tooltips use the native `title` attribute, the pattern the codebase already uses (`RecommendButton`, `SaveToListButton`).

## Verified

- `svelte-check`: 0 errors, 0 warnings
- `oxfmt --check`: clean
- `oxlint`: only 2 pre-existing warnings in an unrelated file
- Not verified with an actual screen reader; the pattern (sr-only phrase for static text, count inside `aria-label` for buttons) is the standard approach.