### PR TITLE
test(frontend): add a PostCard heading regression test

### DIFF
--- a/apps/frontend/src/lib/components/PostCard.test.ts
+++ b/apps/frontend/src/lib/components/PostCard.test.ts
@@ -1,0 +1,60 @@
+import type { Post } from "$lib/types";
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression tests for the title and excerpt sharing one heading (the bug
+// reported as "## UNIX-programming-timev Historically, UNIX systems have
+// maintained two different time values…"). The card must expose the title as a
+// heading and the excerpt as a separate paragraph, so a screen reader's
+// heading list names the post and SEO reads a clean heading signal. If the
+// excerpt ever ends up inside the `<h2>`, these tests fail.
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import PostCard from "./PostCard.svelte";
+
+// `summary` is null on an editor-written post, so the card derives the excerpt
+// from the body — the exact path that produced "UNIX-programming-timev
+// Historically, UNIX systems have maintained two different time values…".
+const post: Post = {
+  id: "11111111-2222-3333-4444-555555555555",
+  title: "UNIX-programming-timev",
+  slug: "unix-programming-timev",
+  contentHtml: "<p>Historically, UNIX systems have maintained two different time values for a file.</p>",
+  remote: false,
+  summary: null,
+  bannerUrl: null,
+  createdAt: "2026-08-20T12:00:00.000Z",
+  author: { id: "author-1", username: "timev", displayName: "timev", avatarUrl: null },
+  tags: [],
+  likeCount: 0,
+  liked: false,
+  commentCount: 0,
+  recommendCount: 0,
+  recommended: false,
+  recommendedBy: null,
+};
+
+describe("PostCard", () => {
+  it("names the heading from the title alone", () => {
+    render(PostCard, { props: { post } });
+
+    // The heading's accessible name must be exactly the title. Had the excerpt
+    // leaked into the heading, the name would be "UNIX-programming-timev
+    // Historically, …" and this exact match would miss.
+    const heading = screen.getByRole("heading", { level: 2, name: "UNIX-programming-timev" });
+    expect(heading).toBeInTheDocument();
+    expect(heading).not.toHaveTextContent("Historically");
+  });
+
+  it("renders the excerpt in a paragraph outside the heading", () => {
+    const { container } = render(PostCard, { props: { post } });
+
+    const excerpt = screen.getByText(
+      "Historically, UNIX systems have maintained two different time values for a file.",
+    );
+    expect(excerpt.tagName).toBe("P");
+
+    const heading = container.querySelector("h2");
+    expect(heading).not.toBeNull();
+    expect(heading!.contains(excerpt)).toBe(false);
+  });
+});

--- a/apps/frontend/src/test/mocks/$app/environment.ts
+++ b/apps/frontend/src/test/mocks/$app/environment.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Vitest stand-in for SvelteKit's virtual `$app/environment` module. `browser`
+// is `false` (server-like) so anything gated on it — e.g. writing the timezone
+// cookie — stays inert during a render.
+export const browser = false;
+export const building = false;
+export const dev = true;
+export const version = "test";

--- a/apps/frontend/src/test/mocks/$app/navigation.ts
+++ b/apps/frontend/src/test/mocks/$app/navigation.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Vitest stand-in for SvelteKit's virtual `$app/navigation` module. Components
+// import `goto`/`invalidate` and call them from event handlers; tests only need
+// them to resolve, and to be spies when an interaction is being asserted.
+import { vi } from "vitest";
+
+export const goto = vi.fn();
+export const invalidate = vi.fn();
+export const invalidateAll = vi.fn();
+export const preloadData = vi.fn();
+export const preloadCode = vi.fn();
+export const pushState = vi.fn();
+export const replaceState = vi.fn();

--- a/apps/frontend/src/test/mocks/$app/state.ts
+++ b/apps/frontend/src/test/mocks/$app/state.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Vitest stand-in for SvelteKit's virtual `$app/state` module. Component tests
+// run outside a SvelteKit server, so the real module never exists; this keeps
+// `import { page } from "$app/state"` resolvable with a minimal, sensible shape.
+//
+// A plain object is enough for render-only assertions (components read
+// `page.data.*` once). Tests that need to flip state between renders should
+// reset `page.data` directly before rendering.
+export const page = {
+  data: { user: null },
+  url: new URL("http://localhost/"),
+  params: {},
+  route: { id: null },
+  status: 200,
+  error: null,
+};
+
+export const navigating = null;
+export const updated = { current: false };

--- a/apps/frontend/src/test/mocks/$app/stores.ts
+++ b/apps/frontend/src/test/mocks/$app/stores.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Vitest stand-in for SvelteKit's virtual `$app/stores` module. `$lib/timezone`
+// derives the render timezone from the `page` store, so it must be a real
+// `Readable`; `UTC` matches the server's first-render fallback.
+import { readable } from "svelte/store";
+
+export const page = readable({ data: { timeZone: "UTC" } });
+export const navigating = readable(null);
+export const updated = readable({ current: false });

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -32,6 +32,13 @@ export default defineConfig({
     conditions: ["browser"],
     alias: {
       $lib: fileURLToPath(new URL("./src/lib", import.meta.url)),
+      // SvelteKit's `$app/*` modules are virtual — there is no file to resolve
+      // outside a kit build. Point them at the jsdom test doubles so components
+      // that read `page`/`goto`/`browser` can be rendered directly.
+      "$app/state": fileURLToPath(new URL("./src/test/mocks/$app/state.ts", import.meta.url)),
+      "$app/navigation": fileURLToPath(new URL("./src/test/mocks/$app/navigation.ts", import.meta.url)),
+      "$app/stores": fileURLToPath(new URL("./src/test/mocks/$app/stores.ts", import.meta.url)),
+      "$app/environment": fileURLToPath(new URL("./src/test/mocks/$app/environment.ts", import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
## Context

Bug report: a post's title and excerpt are crammed into one heading — "## UNIX-programming-timev Historically, UNIX systems have maintained two different time values…" — so there is no structural boundary between the title and the summary, muddying the heading signal for SEO and heading navigation.

## Finding: no code fix needed

`PostCard.svelte` already renders the title in an `<h2>` and the excerpt in a separate `<p>`; `posts/manage/+page.svelte` does the same. The reported example is the accessible name the card's link used to have, fixed in #72 (`ac896a5`) via `aria-labelledby`, but the heading/excerpt split has always been separate.

## What this PR adds

Nothing guarded that split, so this PR adds a `PostCard` component test that fails if the excerpt ever lands inside the heading again:

- `PostCard.test.ts` — asserts the `<h2>`'s accessible name is exactly the title, and the derived excerpt renders in a `<p>` outside the heading (using the `summary: null` → body-derived path that produced the reported string).
- `$app/*` test doubles (`state`, `navigation`, `stores`, `environment`) aliased in `vitest.config.ts`, so SvelteKit components can render outside a kit build.

## Verified

- `pnpm test` — 6 tests pass (4 avatar + 2 PostCard) against current `main`.
- To prove the test guards the regression, I temporarily moved the excerpt inside the `<h2>` and both PostCard tests failed; restored.
- `pnpm check` (Oxfmt, Svelte Check, Oxlint, Vitest) all pass.

## Deploy notes

None — dev-only test files and config; no runtime or build behaviour changes.