### PR TITLE
fix(webhook): strip Markdown heading markers from the excerpt

### DIFF
--- a/apps/backend/src/lib/webhook.ts
+++ b/apps/backend/src/lib/webhook.ts
@@ -181,13 +181,25 @@ export function requireCreateFields(payload: ContentPayload): void {
  * so change them together.
  */
 export function summarize(contentHtml: string, limit = SUMMARY_LENGTH): string {
-  const text = htmlToText(contentHtml).replace(/\s+/g, " ").trim();
+  const text = htmlToText(stripHeadingMarkers(contentHtml)).replace(/\s+/g, " ").trim();
   if (text.length <= limit) return text;
   const clipped = text.slice(0, limit);
   const lastSpace = clipped.lastIndexOf(" ");
   // Only honour the word boundary when it isn't throwing most of the text away.
   const head = lastSpace > limit * 0.6 ? clipped.slice(0, lastSpace) : clipped;
   return `${head.replace(/[\s.,;:!?-]+$/, "")}…`;
+}
+
+// A heading written `#UserID` — no space after the marker — is not an ATX
+// heading as far as markdown-it is concerned, so it renders as a literal `#` at
+// the start of a paragraph rather than an `<h1>`. That hash is Markdown syntax,
+// not prose: it heads every section of an ingested man page, and it showed up
+// in the summary as "#UserID The user ID …". Drop the marker so the summary
+// reads "UserID The user ID …". Anchoring the strip to a block-level opening
+// tag — never `<pre>`/`<code>` — leaves a genuine `#` untouched, whether that
+// is `#include` inside a code fence or a hashtag mid-prose.
+function stripHeadingMarkers(html: string): string {
+  return html.replace(/(<(?:p|li|blockquote|td|th)(?:\s[^>]*)?>)\s*#{1,6}(?=\S)/g, "$1");
 }
 
 /**

--- a/apps/backend/src/lib/webhook_test.ts
+++ b/apps/backend/src/lib/webhook_test.ts
@@ -205,6 +205,25 @@ Deno.test("summarize: clips a single unbroken run rather than emptying it", () =
   assertEquals(out, "x".repeat(20) + "…");
 });
 
+Deno.test("summarize: drops a heading marker markdown leaves literal", () => {
+  const out = summarize(renderMarkdown("#UserID The user ID from our entry in the password file"));
+  assertEquals(out, "UserID The user ID from our entry in the password file");
+});
+
+Deno.test("summarize: drops the marker on every section, not just the first", () => {
+  const out = summarize(
+    renderMarkdown("#UserID The user id\n\n#ProcandprocID An executing instance\n\nBody text."),
+  );
+  assert(!out.includes("#"), `still has a hash: ${out}`);
+  assertStringIncludes(out, "UserID The user id");
+  assertStringIncludes(out, "ProcandprocID An executing instance");
+});
+
+Deno.test("summarize: leaves a hash inside a code fence alone", () => {
+  const out = summarize(renderMarkdown("#NAME proc\n\n```c\n#include <sys/types.h>\n```\n"), 200);
+  assertStringIncludes(out, "#include <sys/types.h>");
+});
+
 Deno.test("externalKey: prefers the sender's slug over the title", () => {
   assertEquals(externalKey({ title: "Hello world", slug: "cms-doc-42" }), "cms-doc-42");
 });

--- a/apps/frontend/src/lib/format.test.ts
+++ b/apps/frontend/src/lib/format.test.ts
@@ -1,0 +1,34 @@
+import { excerpt } from "$lib/format";
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression tests for Markdown syntax leaking into the excerpt (the bug
+// reported as "#UserID The user ID from our entry in the password file" and
+// "#ProcandprocID An executing instance"). `excerpt` derives its text from
+// rendered HTML; a heading written without the space after `#` is not a
+// heading, so the `#` survives into the plain text. These tests pin that the
+// marker is dropped — on every section, not just the first — while a genuine
+// `#` in code or mid-prose is kept.
+import { describe, expect, it } from "vitest";
+
+describe("excerpt", () => {
+  it("drops a heading marker the renderer leaves literal", () => {
+    expect(excerpt("<p>#UserID The user ID from our entry in the password file</p>")).toBe(
+      "UserID The user ID from our entry in the password file",
+    );
+  });
+
+  it("drops the marker on every section, not just the first", () => {
+    const out = excerpt("<p>#UserID The user id</p><p>#ProcandprocID An executing instance</p>");
+    expect(out).toBe("UserID The user id ProcandprocID An executing instance");
+    expect(out).not.toContain("#");
+  });
+
+  it("keeps a hash inside a code fence", () => {
+    const out = excerpt('<p>#NAME proc</p><pre><code class="language-c">#include &lt;sys/types.h&gt;</code></pre>');
+    expect(out).toContain("#include <sys/types.h>");
+  });
+
+  it("keeps a hash mid-prose", () => {
+    expect(excerpt("<p>Read about the #UserID field here</p>")).toContain("#UserID");
+  });
+});

--- a/apps/frontend/src/lib/format.ts
+++ b/apps/frontend/src/lib/format.ts
@@ -33,6 +33,17 @@ export function stripHtml(html: string): string {
     .trim();
 }
 
+// A heading written `#UserID` — no space after the marker — is not an ATX
+// heading as far as the markdown renderer is concerned, so it renders as a
+// literal `#` at the start of a paragraph rather than a heading. That hash is
+// Markdown syntax, not prose, and it leaked into the excerpt ("#UserID The user
+// ID …"). Drop it here. Anchoring the strip to a block-level opening tag —
+// never `<pre>`/`<code>` — leaves a genuine `#` untouched, whether that is
+// `#include` inside a code fence or a hashtag mid-prose.
+function stripHeadingMarkers(html: string): string {
+  return html.replace(/(<(?:p|li|blockquote|td|th)(?:\s[^>]*)?>)\s*#{1,6}(?=\S)/g, "$1");
+}
+
 // Clipped at a word boundary, not at the character the limit happens to land
 // on: a slice mid-word ("the functions open, read, wri…") reads as damage
 // rather than as an abbreviation, and this text is the card excerpt, the
@@ -46,7 +57,7 @@ export function stripHtml(html: string): string {
 // single very long token can't collapse the excerpt to nothing. Trailing
 // punctuation goes before the ellipsis so it doesn't read as ",…".
 export function excerpt(html: string, len = 180): string {
-  const text = stripHtml(html);
+  const text = stripHtml(stripHeadingMarkers(html));
   if (text.length <= len) return text;
   const clipped = text.slice(0, len);
   const lastSpace = clipped.lastIndexOf(" ");


### PR DESCRIPTION
## Symptom

The auto-derived excerpt/summary of an ingested man page started with a stray hash: "#UserID The user ID from our entry in the password file", "#ProcandprocID An executing instance".

## Root cause

A heading written without the space after the marker — `#UserID` — is not an ATX heading as far as markdown-it is concerned (CommonMark requires the space), so it renders as a literal `#` at the start of a `<p>`, not an `<h1>`. `summarize` (backend) and `excerpt` (frontend) flatten that HTML to text and kept the `#`.

## Fix

Both `summarize` and `excerpt` now drop a `#{1,6}` marker sitting at the start of a block before flattening. The strip is anchored to a block-level opening tag (`p`, `li`, `blockquote`, `td`, `th`) rather than "any whitespace", so a genuine `#` is untouched:

- `#include` inside a fenced code block stays `#include`.
- a hashtag mid-prose stays `#tag`.

## Verified

- `deno test -A src/lib/webhook_test.ts` — 27 pass, including three new cases (literal marker, every section, code fence).
- `pnpm check` (frontend: Oxfmt, Svelte Check, Oxlint, Vitest) — all pass; `format.test.ts` adds four excerpt cases.
- `deno fmt --check`, `deno lint`, `deno check src/main.ts` — clean.

## Deploy notes

Existing posts still carry the old stored summary. Re-delivering the webhook payload (the ingestion path is idempotent) regenerates it; no migration is needed for a fresh render because the stored summary is served as-is.