### PR TITLE
test(frontend): add regression tests for reaction counters

### DIFF
--- a/apps/frontend/src/lib/components/PostCard.test.ts
+++ b/apps/frontend/src/lib/components/PostCard.test.ts
@@ -1,12 +1,15 @@
 import type { Post } from "$lib/types";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
-// Regression tests for the title and excerpt sharing one heading (the bug
-// reported as "## UNIX-programming-timev Historically, UNIX systems have
-// maintained two different time values…"). The card must expose the title as a
-// heading and the excerpt as a separate paragraph, so a screen reader's
-// heading list names the post and SEO reads a clean heading signal. If the
-// excerpt ever ends up inside the `<h2>`, these tests fail.
+// Regression tests for the card layout. The first pair guards the title and
+// excerpt sharing one heading (the bug reported as "## UNIX-programming-timev
+// Historically, UNIX systems have maintained two different time values…") —
+// the card must expose the title as a heading and the excerpt as a separate
+// paragraph. The second pair guards the reaction counters rendering as bare
+// numbers ("2 0 0" on cards, "5 0 0" on the post page): each has to carry its
+// meaning for hover and for assistive tech, or a sighted reader cannot tell a
+// like from a response from a recommendation and a screen reader hears only
+// digits. If any label or tooltip regresses, these tests fail.
 import { render, screen } from "@testing-library/svelte";
 import { describe, expect, it } from "vitest";
 import PostCard from "./PostCard.svelte";
@@ -56,5 +59,55 @@ describe("PostCard", () => {
     const heading = container.querySelector("h2");
     expect(heading).not.toBeNull();
     expect(heading!.contains(excerpt)).toBe(false);
+  });
+});
+
+describe("PostCard reaction counters", () => {
+  it("labels the like and comment counters for screen readers and hover", () => {
+    const counted: Post = { ...post, likeCount: 2, commentCount: 5, recommendCount: 3 };
+    const { container } = render(PostCard, { props: { post: counted } });
+
+    // Static counters: visual number is hidden from assistive tech, sr-only
+    // text carries the phrase, and the wrapper exposes the same phrase as a
+    // hover tooltip. Without any of the three, the card would read as "2 5 3".
+    const likeSr = screen.getByText("2 likes");
+    expect(likeSr).toHaveClass("sr-only");
+    const likeWrap = likeSr.closest('[title="2 likes"]');
+    expect(likeWrap).not.toBeNull();
+    expect(likeWrap!.querySelector('[aria-hidden="true"]')).toHaveTextContent("2");
+
+    const commentSr = screen.getByText("5 responses");
+    expect(commentSr).toHaveClass("sr-only");
+    const commentWrap = commentSr.closest('[title="5 responses"]');
+    expect(commentWrap).not.toBeNull();
+    expect(commentWrap!.querySelector('[aria-hidden="true"]')).toHaveTextContent("5");
+
+    // Interactive counter: aria-label replaces the button's content as its
+    // accessible name, so the count has to be in the label itself.
+    const recBtn = screen.getByRole("button", { name: "Recommend (3 recommendations)" });
+    expect(recBtn).toHaveAttribute("title", "Recommend (3 recommendations)");
+    // The count is still visible, just not the accessible name.
+    expect(recBtn).toHaveTextContent("3");
+
+    // Ensure the static counters did not accidentally become buttons.
+    expect(container.querySelectorAll('[title="2 likes"]').length).toBe(1);
+  });
+
+  it("uses singular forms when the count is one", () => {
+    const counted: Post = { ...post, likeCount: 1, commentCount: 1, recommendCount: 1 };
+    render(PostCard, { props: { post: counted } });
+
+    expect(screen.getByText("1 like")).toBeInTheDocument();
+    expect(screen.getByText("1 response")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Recommend (1 recommendation)" })).toBeInTheDocument();
+  });
+
+  it("still labels a zero as a phrase, not a bare digit", () => {
+    render(PostCard, { props: { post } });
+
+    // `post` has 0 for every counter.
+    expect(screen.getByText("0 likes")).toBeInTheDocument();
+    expect(screen.getByText("0 responses")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Recommend (0 recommendations)" })).toBeInTheDocument();
   });
 });

--- a/apps/frontend/src/lib/components/RecommendButton.test.ts
+++ b/apps/frontend/src/lib/components/RecommendButton.test.ts
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Regression tests for the recommendation counter rendering as a bare number.
+// The visible digit inside the button is not its accessible name — `aria-label`
+// replaces the content — so the count has to be folded into the label itself,
+// or a screen reader hears "Recommend" and never the number. The same phrase
+// is mirrored in `title` for the hover tooltip. If either regresses, the card
+// and post page would again show "2 0 0" / "5 0 0" to sighted users and silence
+// to assistive tech.
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import RecommendButton from "./RecommendButton.svelte";
+
+describe("RecommendButton", () => {
+  it("includes the count in its accessible name and hover tooltip", () => {
+    render(RecommendButton, {
+      props: { postId: "11111111-2222-3333-4444-555555555555", recommended: false, recommendCount: 2 },
+    });
+
+    const btn = screen.getByRole("button", { name: "Recommend (2 recommendations)" });
+    expect(btn).toBeInTheDocument();
+    expect(btn).toHaveAttribute("title", "Recommend (2 recommendations)");
+    expect(btn).toHaveAttribute("aria-pressed", "false");
+    expect(btn).toHaveTextContent("2");
+  });
+
+  it("switches the verb when already recommended", () => {
+    render(RecommendButton, {
+      props: { postId: "11111111-2222-3333-4444-555555555555", recommended: true, recommendCount: 1 },
+    });
+
+    const btn = screen.getByRole("button", { name: "Remove recommendation (1 recommendation)" });
+    expect(btn).toHaveAttribute("title", "Remove recommendation (1 recommendation)");
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+    expect(btn).toHaveTextContent("1");
+  });
+
+  it("labels a zero with the plural phrase, not a bare digit", () => {
+    render(RecommendButton, {
+      props: { postId: "11111111-2222-3333-4444-555555555555", recommended: false, recommendCount: 0 },
+    });
+
+    expect(screen.getByRole("button", { name: "Recommend (0 recommendations)" })).toHaveAttribute(
+      "title",
+      "Recommend (0 recommendations)",
+    );
+  });
+});

--- a/apps/frontend/src/lib/format.test.ts
+++ b/apps/frontend/src/lib/format.test.ts
@@ -1,4 +1,4 @@
-import { excerpt } from "$lib/format";
+import { countLabel, excerpt } from "$lib/format";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //
 // Regression tests for Markdown syntax leaking into the excerpt (the bug
@@ -7,7 +7,10 @@ import { excerpt } from "$lib/format";
 // rendered HTML; a heading written without the space after `#` is not a
 // heading, so the `#` survives into the plain text. These tests pin that the
 // marker is dropped — on every section, not just the first — while a genuine
-// `#` in code or mid-prose is kept.
+// `#` in code or mid-prose is kept. The `countLabel` tests guard the reaction
+// counters ("2 0 0" on cards, "5 0 0" on the post page) that once rendered as
+// bare numbers: the phrase has to agree in number, or the tooltip and
+// screen-reader label would read as broken English.
 import { describe, expect, it } from "vitest";
 
 describe("excerpt", () => {
@@ -30,5 +33,27 @@ describe("excerpt", () => {
 
   it("keeps a hash mid-prose", () => {
     expect(excerpt("<p>Read about the #UserID field here</p>")).toContain("#UserID");
+  });
+});
+
+describe("countLabel", () => {
+  it("uses the singular form only for one", () => {
+    expect(countLabel(1, "like")).toBe("1 like");
+    expect(countLabel(1, "response")).toBe("1 response");
+    expect(countLabel(1, "recommendation")).toBe("1 recommendation");
+  });
+
+  it("uses the plural form for zero and for many", () => {
+    expect(countLabel(0, "like")).toBe("0 likes");
+    expect(countLabel(2, "like")).toBe("2 likes");
+    expect(countLabel(0, "response")).toBe("0 responses");
+    expect(countLabel(5, "response")).toBe("5 responses");
+    expect(countLabel(0, "recommendation")).toBe("0 recommendations");
+    expect(countLabel(3, "recommendation")).toBe("3 recommendations");
+  });
+
+  it("honours an explicit irregular plural", () => {
+    expect(countLabel(1, "ox", "oxen")).toBe("1 ox");
+    expect(countLabel(2, "ox", "oxen")).toBe("2 oxen");
   });
 });


### PR DESCRIPTION
## Symptom

Reaction counters rendered as bare numbers beside icons ("2 0 0" on cards, "5 0 0" on the post page). Hover gave no hint of what each counted, and screen-reader users heard only digits — or nothing at all for buttons, where `aria-label` replaces the content.

## Root cause

Static counters were plain `<span><Icon /> {count}</span>` with no `title` or screen-reader phrase; interactive counters (Recommend, Like) had `aria-label` without the count, so the number was invisible to assistive tech.

## Fix

Already in `main` (`fix(frontend): label reaction counters … (#75)`): static counters hide the visual digit (`aria-hidden`) and speak `countLabel` via `sr-only` plus `title` tooltip; interactive buttons fold the count into `aria-label`/`title` (`Like (2 likes)`, `Recommend (3 recommendations)`). This PR only adds the regression guard that was missing:

- `PostCard.test.ts`: pins like/comment `sr-only` + `title` + `aria-hidden`, and recommend button `aria-label`/`title`, covering singular/plural/zero.
- `RecommendButton.test.ts`: pins `aria-label`/`title` and the Recommend vs Remove recommendation verb.
- `format.test.ts`: pins `countLabel` agreement for the three counter vocabularies.

## Verified

- Mutated `PostCard.svelte` (`title` → `"broken"`) and `RecommendButton.svelte` (`aria-label` → `"broken"`) — both correctly fail the new tests.
- `pnpm check` passes: Oxfmt, Svelte Check, Oxlint clean; Vitest 19 passed (4 Avatar + 5 PostCard + 3 RecommendButton + 7 format).

## Deploy notes

No runtime change — test-only. Plain `docker compose up -d` is enough.