### PR TITLE
fix(frontend): unify reaction counters via ReactionCount component

### DIFF
--- a/apps/frontend/src/lib/components/Discover.svelte
+++ b/apps/frontend/src/lib/components/Discover.svelte
@@ -4,9 +4,9 @@
   import { env } from "$env/dynamic/public";
   import FollowButton from "$lib/components/FollowButton.svelte";
   import Icon from "$lib/components/Icon.svelte";
+  import ReactionCount from "$lib/components/ReactionCount.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
-  import { countLabel } from "$lib/format";
   import { postPath } from "$lib/links";
   import type { Post, SuggestedUser, TagWithCount } from "$lib/types";
 
@@ -57,20 +57,9 @@
                 {post.title ?? "Untitled"}
               </a>
               <div class="mt-1 flex items-center gap-3 text-xs text-muted-foreground">
-                <span class="flex items-center gap-1" title={countLabel(post.likeCount, "like")}>
-                  <span aria-hidden="true" class="flex items-center gap-1">
-                    <Icon name="heart" size={12} />
-                    {post.likeCount}
-                  </span>
-                  <span class="sr-only">{countLabel(post.likeCount, "like")}</span>
-                </span>
-                <span class="flex items-center gap-1" title={countLabel(post.commentCount, "response")}>
-                  <span aria-hidden="true" class="flex items-center gap-1">
-                    <Icon name="comment" size={12} />
-                    {post.commentCount}
-                  </span>
-                  <span class="sr-only">{countLabel(post.commentCount, "response")}</span>
-                </span>
+                <ReactionCount icon="heart" count={post.likeCount} singular="like" size={12} />
+                <ReactionCount icon="comment" count={post.commentCount} singular="response" size={12} />
+                <ReactionCount icon="recommend" count={post.recommendCount} singular="recommendation" size={12} />
               </div>
             </div>
           </li>

--- a/apps/frontend/src/lib/components/Discover.test.ts
+++ b/apps/frontend/src/lib/components/Discover.test.ts
@@ -1,0 +1,62 @@
+import type { Post } from "$lib/types";
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import Discover from "./Discover.svelte";
+
+const post: Post = {
+  id: "11111111-2222-3333-4444-555555555555",
+  title: "Hello world",
+  slug: "hello-world",
+  contentHtml: "<p>Body</p>",
+  remote: false,
+  summary: null,
+  bannerUrl: null,
+  createdAt: "2026-08-20T12:00:00.000Z",
+  author: { id: "author-1", username: "alice", displayName: "Alice", avatarUrl: null },
+  tags: [],
+  likeCount: 1,
+  liked: false,
+  commentCount: 2,
+  recommendCount: 3,
+  recommended: false,
+  recommendedBy: null,
+};
+
+describe("Discover trending counters", () => {
+  it("shows like, comment and recommend with the same labelled format as cards", () => {
+    render(Discover, { props: { data: { posts: [post], people: [], tags: [] } } });
+
+    // All three counters must be present, each with title + sr-only + aria-hidden,
+    // the exact same pattern PostCard uses via ReactionCount. Two counters ("1 2")
+    // was the bug — trending must show three ("1 2 3") via the single component.
+    const likeSr = screen.getByText("1 like");
+    expect(likeSr).toHaveClass("sr-only");
+    expect(likeSr.closest('[title="1 like"]')).not.toBeNull();
+    expect(likeSr.closest('[title="1 like"]')!.querySelector('[aria-hidden="true"]')).toHaveTextContent("1");
+
+    const commentSr = screen.getByText("2 responses");
+    expect(commentSr).toHaveClass("sr-only");
+    expect(commentSr.closest('[title="2 responses"]')).not.toBeNull();
+
+    const recSr = screen.getByText("3 recommendations");
+    expect(recSr).toHaveClass("sr-only");
+    expect(recSr.closest('[title="3 recommendations"]')).not.toBeNull();
+    expect(recSr.closest('[title="3 recommendations"]')!.querySelector('[aria-hidden="true"]')).toHaveTextContent("3");
+  });
+
+  it("handles singular/plural the same way cards do", () => {
+    const solo: Post = { ...post, likeCount: 1, commentCount: 1, recommendCount: 1 };
+    const { unmount } = render(Discover, { props: { data: { posts: [solo], people: [], tags: [] } } });
+    expect(screen.getByText("1 like")).toBeInTheDocument();
+    expect(screen.getByText("1 response")).toBeInTheDocument();
+    expect(screen.getByText("1 recommendation")).toBeInTheDocument();
+    unmount();
+
+    const zero: Post = { ...post, likeCount: 0, commentCount: 0, recommendCount: 0 };
+    render(Discover, { props: { data: { posts: [zero], people: [], tags: [] } } });
+    expect(screen.getByText("0 likes")).toBeInTheDocument();
+    expect(screen.getByText("0 responses")).toBeInTheDocument();
+    expect(screen.getByText("0 recommendations")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -2,12 +2,13 @@
 <script lang="ts">
   import { page } from "$app/state";
   import Icon from "$lib/components/Icon.svelte";
+  import ReactionCount from "$lib/components/ReactionCount.svelte";
   import RecommendButton from "$lib/components/RecommendButton.svelte";
   import SaveToListButton from "$lib/components/SaveToListButton.svelte";
   import TagList from "$lib/components/TagList.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
-  import { countLabel, excerpt, formatDate, formatTime, readTime } from "$lib/format";
+  import { excerpt, formatDate, formatTime, readTime } from "$lib/format";
   import { postPath } from "$lib/links";
   import { timeZone } from "$lib/timezone";
   import type { Post } from "$lib/types";
@@ -132,20 +133,8 @@
       ></span
     >
     <span class="flex items-center gap-1"><Icon name="clock" size={13} /> {minutes} min read</span>
-    <span class="flex items-center gap-1" title={countLabel(post.likeCount, "like")}>
-      <span aria-hidden="true" class="flex items-center gap-1">
-        <Icon name="heart" size={13} />
-        {post.likeCount}
-      </span>
-      <span class="sr-only">{countLabel(post.likeCount, "like")}</span>
-    </span>
-    <span class="flex items-center gap-1" title={countLabel(post.commentCount, "response")}>
-      <span aria-hidden="true" class="flex items-center gap-1">
-        <Icon name="comment" size={13} />
-        {post.commentCount}
-      </span>
-      <span class="sr-only">{countLabel(post.commentCount, "response")}</span>
-    </span>
+    <ReactionCount icon="heart" count={post.likeCount} singular="like" size={13} />
+    <ReactionCount icon="comment" count={post.commentCount} singular="response" size={13} />
     <span class="ml-auto flex shrink-0 items-center gap-1">
       <RecommendButton postId={post.id} recommended={post.recommended} recommendCount={post.recommendCount} size="xs" />
       <SaveToListButton postId={post.id} {signedIn} />

--- a/apps/frontend/src/lib/components/ReactionCount.svelte
+++ b/apps/frontend/src/lib/components/ReactionCount.svelte
@@ -1,0 +1,28 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import Icon from "$lib/components/Icon.svelte";
+  import type { IconName } from "$lib/components/Icon.svelte";
+  import { countLabel } from "$lib/format";
+
+  let {
+    icon,
+    count,
+    singular,
+    plural,
+    size = 13,
+  }: {
+    icon: IconName;
+    count: number;
+    singular: string;
+    plural?: string;
+    size?: number;
+  } = $props();
+</script>
+
+<span class="flex items-center gap-1" title={countLabel(count, singular, plural)}>
+  <span aria-hidden="true" class="flex items-center gap-1">
+    <Icon name={icon} {size} />
+    {count}
+  </span>
+  <span class="sr-only">{countLabel(count, singular, plural)}</span>
+</span>

--- a/apps/frontend/src/lib/components/ReactionCount.test.ts
+++ b/apps/frontend/src/lib/components/ReactionCount.test.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import ReactionCount from "./ReactionCount.svelte";
+
+describe("ReactionCount", () => {
+  it("renders the count with title, sr-only and aria-hidden", () => {
+    render(ReactionCount, { props: { icon: "heart", count: 2, singular: "like", size: 13 } });
+
+    const sr = screen.getByText("2 likes");
+    expect(sr).toHaveClass("sr-only");
+    const wrap = sr.closest('[title="2 likes"]');
+    expect(wrap).not.toBeNull();
+    expect(wrap!.querySelector('[aria-hidden="true"]')).toHaveTextContent("2");
+  });
+
+  it("uses singular for count 1 and plural for 0 and many", () => {
+    const { unmount } = render(ReactionCount, {
+      props: { icon: "comment", count: 1, singular: "response", size: 12 },
+    });
+    expect(screen.getByText("1 response")).toBeInTheDocument();
+    expect(screen.getByTitle("1 response")).toBeInTheDocument();
+    unmount();
+
+    render(ReactionCount, { props: { icon: "comment", count: 0, singular: "response", size: 12 } });
+    expect(screen.getByText("0 responses")).toBeInTheDocument();
+  });
+
+  it("supports custom plural for recommendation", () => {
+    render(ReactionCount, {
+      props: { icon: "recommend", count: 3, singular: "recommendation", size: 12 },
+    });
+    expect(screen.getByText("3 recommendations")).toBeInTheDocument();
+    expect(screen.getByTitle("3 recommendations")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/test/mocks/$env/dynamic/public.ts
+++ b/apps/frontend/src/test/mocks/$env/dynamic/public.ts
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+export const env = { PUBLIC_APP_NAME: "Omicron" };

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
       "$app/navigation": fileURLToPath(new URL("./src/test/mocks/$app/navigation.ts", import.meta.url)),
       "$app/stores": fileURLToPath(new URL("./src/test/mocks/$app/stores.ts", import.meta.url)),
       "$app/environment": fileURLToPath(new URL("./src/test/mocks/$app/environment.ts", import.meta.url)),
+      "$env/dynamic/public": fileURLToPath(new URL("./src/test/mocks/$env/dynamic/public.ts", import.meta.url)),
     },
   },
 });


### PR DESCRIPTION
## Symptom

Trending showed "1 2" (like + comment) while feed cards showed "2 0 0" (like + comment + recommend). Same engagement data, two formats — the rail missed the recommend count and any label/tooltip change in one surface left the other stale.

## Root cause

Duplicated markup in `PostCard.svelte:135-148` and `Discover.svelte:59-73`: each rendered its own `<span title={countLabel(...)}><span aria-hidden>…</span><span sr-only>…</span></span>`. Fixing the a11y labels in #75 patched both copies, but nothing prevented them drifting again, and Discover never rendered `recommendCount`.

## Fix

Extract the pattern into one component `ReactionCount.svelte` (icon + count + `countLabel` title + `aria-hidden` visual + `sr-only` phrase) and use it in both places:

- `PostCard.svelte` — two `ReactionCount` (like/response, size 13) + existing `RecommendButton` (size xs) = 3 numbers.
- `Discover.svelte` — three `ReactionCount` (like/response/recommendation, size 12) = 3 numbers, same labels/tooltips as cards.

Any future tweak to counter styling, tooltip, or pluralization happens once. Added `vitest` alias for `$env/dynamic/public` so `Discover` can be rendered in jsdom.

## Verified

- Mutating `Discover.svelte` to drop the third `ReactionCount` or changing `PostCard` count fails `Discover.test.ts` / `ReactionCount.test.ts`.
- `pnpm check` passes: Oxfmt, Svelte Check (0 errors), Oxlint clean, Vitest 24 passed (6 files: Avatar 4 + PostCard 5 + RecommendButton 3 + format 7 + ReactionCount 3 + Discover 2).

## Deploy notes

Frontend only. Plain `docker compose up -d` is enough.