### PR TITLE
fix(frontend): add legal footer with AGPL source and instance links

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -112,6 +112,17 @@
 # and is refused the redirect if it is missing here.
 #ANUBIS_REDIRECT_DOMAINS=example.com,www.example.com
 
+# ── Legal / footer (AGPL-3.0 §13 + EU public-service imprint) ──
+# Where the “Source” link in the footer points — your fork when you run a
+# modified build (AGPL-3.0 §13). Defaults to the upstream repository.
+#PUBLIC_SOURCE_URL=https://github.com/the-jk-labs/omicron
+# Optional external status page linked from the footer.
+#PUBLIC_STATUS_URL=https://status.example.com
+# Contact / abuse contact surfaced on /contact (imprint).
+#PUBLIC_CONTACT_URL=https://example.com/contact
+#PUBLIC_CONTACT_EMAIL=contact@example.com
+#PUBLIC_ABUSE_EMAIL=abuse@example.com
+
 # ── Networking / storage (usually leave as-is) ──
 #PORT=8000
 #INTERNAL_API_URL=http://backend:8000

--- a/apps/frontend/src/lib/components/Footer.svelte
+++ b/apps/frontend/src/lib/components/Footer.svelte
@@ -1,0 +1,93 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { env } from "$env/dynamic/public";
+  import type { InstanceInfo } from "$lib/types";
+
+  let {
+    appName = env.PUBLIC_APP_NAME || "Omicron",
+    instance = null,
+  }: {
+    appName?: string;
+    instance?: InstanceInfo | null;
+  } = $props();
+
+  const year = new Date().getFullYear();
+  const sourceUrl = $derived(
+    (env.PUBLIC_SOURCE_URL as string | undefined)?.trim() || "https://github.com/the-jk-labs/omicron",
+  );
+  const statusUrl = $derived((env.PUBLIC_STATUS_URL as string | undefined)?.trim() || "/status");
+  // Fediverse profile: the instance itself when federation is on. Falls back to
+  // a generic fediverse directory link when not federating — keeps the slot
+  // occupied rather than shifting layout between instances.
+  const fediverseUrl = $derived.by(() => {
+    if (instance?.federationEnabled && instance.domain) return `https://${instance.domain}`;
+    return "https://joinmastodon.org/servers";
+  });
+  const fediverseLabel = $derived(instance?.federationEnabled && instance.domain ? `@${instance.domain}` : "Fediverse");
+  const contactHref = $derived((env.PUBLIC_CONTACT_URL as string | undefined)?.trim() || "/contact");
+</script>
+
+<footer aria-label="Site footer" class="border-t border-border bg-background" data-testid="site-footer">
+  <div class="mx-auto max-w-6xl px-4 py-8">
+    <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+      <!-- Brand + legal notice -->
+      <div class="space-y-1">
+        <p class="text-sm font-semibold text-foreground">{appName}</p>
+        <p class="text-xs leading-relaxed text-muted-foreground">
+          © {year}
+          {appName} · Federated blogging ·
+          <span class="whitespace-nowrap"
+            >AGPL-3.0 · <a
+              href={sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              class="underline underline-offset-4 hover:text-foreground">Source</a
+            ></span
+          >
+        </p>
+        {#if instance?.domain}
+          <p class="text-xs text-muted-foreground">{instance.domain}</p>
+        {/if}
+      </div>
+
+      <!-- Footer navigation -->
+      <nav aria-label="Footer" class="flex flex-wrap gap-x-4 gap-y-2 text-sm">
+        <a href="/about" class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">About</a
+        >
+        <a href="/about#rules" class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >Instance rules</a
+        >
+        <a href="/privacy" class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >Privacy</a
+        >
+        <a href={contactHref} class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >Contact</a
+        >
+        <a
+          href={sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">Source</a
+        >
+        <a href={statusUrl} class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+          >Status</a
+        >
+        <a
+          href={fediverseUrl}
+          target={fediverseUrl.startsWith("http") ? "_blank" : undefined}
+          rel={fediverseUrl.startsWith("http") ? "me noopener noreferrer" : "me"}
+          class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">{fediverseLabel}</a
+        >
+      </nav>
+    </div>
+
+    <!-- Secondary row: imprint / abuse hint for EU public services -->
+    <p class="mt-6 border-t border-border pt-4 text-xs leading-relaxed text-muted-foreground">
+      Self-hostable · No vendor lock-in ·
+      <a href="/privacy" class="underline underline-offset-4 hover:text-foreground">Privacy policy</a>
+      ·
+      <a href="/contact" class="underline underline-offset-4 hover:text-foreground">Abuse / Contact</a>
+      . Source code offered per AGPL-3.0 §13 via the “Source” link above.
+    </p>
+  </div>
+</footer>

--- a/apps/frontend/src/lib/components/Footer.test.ts
+++ b/apps/frontend/src/lib/components/Footer.test.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { render, screen } from "@testing-library/svelte";
+import { describe, expect, it } from "vitest";
+import Footer from "./Footer.svelte";
+
+describe("Footer", () => {
+  it("renders legal and AGPL-required links", () => {
+    render(Footer, {
+      props: {
+        appName: "Omicron",
+        instance: {
+          name: "Omicron",
+          domain: "example.com",
+          federationEnabled: true,
+          setupComplete: true,
+          emailEnabled: false,
+          bannerText: null,
+          bannerImageUrl: null,
+        },
+      },
+    });
+
+    const footer = screen.getByTestId("site-footer");
+    expect(footer.tagName.toLowerCase()).toBe("footer");
+
+    // Required slots from the issue: About, Instance rules, Privacy, Contact, Source, Status, Fediverse
+    expect(screen.getByRole("link", { name: "About" })).toHaveAttribute("href", "/about");
+    expect(screen.getByRole("link", { name: "Instance rules" })).toHaveAttribute("href", "/about#rules");
+    expect(screen.getByRole("link", { name: "Privacy" })).toHaveAttribute("href", "/privacy");
+    expect(screen.getByRole("link", { name: "Contact" })).toBeInTheDocument();
+    // Source appears twice (brand line + nav) — at least one external source link
+    const sources = screen.getAllByRole("link", { name: "Source" });
+    expect(sources.length).toBeGreaterThanOrEqual(1);
+    expect(sources[0].getAttribute("href")).toMatch(/github\.com\/the-jk-labs\/omicron/);
+    expect(sources[0]).toHaveAttribute("target", "_blank");
+    expect(sources[0].getAttribute("rel")).toContain("noopener");
+
+    expect(screen.getByRole("link", { name: "Status" })).toBeInTheDocument();
+    // Fediverse profile link should be present
+    const fediCandidates = screen.getAllByText(/@example\.com|Fediverse/);
+    expect(fediCandidates.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("surfaces AGPL §13 notice", () => {
+    render(Footer, { props: { appName: "Omicron", instance: null } });
+    expect(screen.getByTestId("site-footer").textContent).toMatch(/AGPL-3\.0/);
+    expect(screen.getByTestId("site-footer").textContent).toMatch(/Source/);
+  });
+});

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -5,6 +5,7 @@
   import { env } from "$env/dynamic/public";
   import { canonicalOrigin } from "$lib/canonical";
   import Discover from "$lib/components/Discover.svelte";
+  import Footer from "$lib/components/Footer.svelte";
   import MobileNav from "$lib/components/MobileNav.svelte";
   import Nav from "$lib/components/Nav.svelte";
   import SideNav from "$lib/components/SideNav.svelte";
@@ -350,6 +351,10 @@
         </div>
       </div>
     </div>
+  {/if}
+
+  {#if !isSetup}
+    <Footer {appName} instance={data.instance} />
   {/if}
 </div>
 

--- a/apps/frontend/src/routes/about/+page.svelte
+++ b/apps/frontend/src/routes/about/+page.svelte
@@ -1,0 +1,61 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { page } from "$app/stores";
+  import { env } from "$env/dynamic/public";
+  import PageTitle from "$lib/components/PageTitle.svelte";
+  import type { InstanceInfo } from "$lib/types";
+
+  const instance = $derived(($page.data as { instance?: InstanceInfo | null }).instance ?? null);
+  const appName = $derived(instance?.name || env.PUBLIC_APP_NAME || "Omicron");
+  const domain = $derived(instance?.domain ?? "this instance");
+  const sourceUrl = env.PUBLIC_SOURCE_URL || "https://github.com/the-jk-labs/omicron";
+</script>
+
+<PageTitle text="About · {appName}" />
+
+<article class="mx-auto max-w-3xl">
+  <h1 class="text-3xl font-bold tracking-tight text-foreground">About {appName}</h1>
+  <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
+    {appName} is a federated blogging platform — a home for free expression on the fediverse. Every author is an ActivityPub
+    actor, posts federate, and you can self-host your own instance with no vendor lock-in.
+  </p>
+
+  <div class="prose-omicron mt-8">
+    <h2 id="instance">This instance</h2>
+    <p>
+      You are reading <strong>{domain}</strong> running <strong>{appName}</strong>. The operator configured this domain
+      and instance name via the setup wizard. When federation is enabled this instance participates in the fediverse.
+    </p>
+    {#if instance?.federationEnabled}
+      <p>This instance is federating — profiles and posts can be followed from any ActivityPub server.</p>
+    {:else}
+      <p>Federation is currently disabled on this instance.</p>
+    {/if}
+
+    <h2 id="rules">Instance rules</h2>
+    <p>
+      The operator sets the rules for this instance. Until custom rules are published here, the baseline is: be
+      respectful, no illegal content, no harassment, no spam. Reports are reviewed by the instance moderators via the
+      <em>Flag</em> action on posts and profiles.
+    </p>
+    <p>
+      For the full moderation policy or to report abuse, see <a href="/contact">Contact</a>. Admins can edit this page’s
+      copy to reflect their real community guidelines — replace this placeholder before operating a public service.
+    </p>
+
+    <h2 id="source">Source code</h2>
+    <p>
+      {appName} is free software licensed under <strong>AGPL-3.0-or-later</strong>. Per AGPL-3.0 §13, anyone who
+      interacts with this instance over a network is offered the Corresponding Source.
+    </p>
+    <p>
+      <a href={sourceUrl} target="_blank" rel="noopener noreferrer">Browse the source</a> — point this link at your fork when
+      you run a modified version.
+    </p>
+
+    <h2 id="contact">Contact</h2>
+    <p>
+      For general questions, account issues, or takedown requests: <a href="/contact">contact the operator</a>.
+    </p>
+  </div>
+</article>

--- a/apps/frontend/src/routes/contact/+page.svelte
+++ b/apps/frontend/src/routes/contact/+page.svelte
@@ -1,0 +1,69 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { page } from "$app/stores";
+  import { env } from "$env/dynamic/public";
+  import PageTitle from "$lib/components/PageTitle.svelte";
+  import type { InstanceInfo } from "$lib/types";
+
+  const instance = $derived(($page.data as { instance?: InstanceInfo | null }).instance ?? null);
+  const appName = $derived(instance?.name || env.PUBLIC_APP_NAME || "Omicron");
+  const domain = $derived(instance?.domain ?? "this instance");
+  const contactUrl = (env.PUBLIC_CONTACT_URL as string | undefined)?.trim() || "";
+  const contactEmail = (env.PUBLIC_CONTACT_EMAIL as string | undefined)?.trim() || "";
+  const abuseEmail = (env.PUBLIC_ABUSE_EMAIL as string | undefined)?.trim() || contactEmail;
+</script>
+
+<PageTitle text="Contact · {appName}" />
+
+<article class="mx-auto max-w-3xl">
+  <h1 class="text-3xl font-bold tracking-tight text-foreground">Contact</h1>
+  <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
+    Reach the operator of <strong>{domain}</strong> ({appName}) for general inquiries, data requests, and abuse reports.
+  </p>
+
+  <div class="prose-omicron mt-8">
+    <h2>General contact</h2>
+    {#if contactEmail}
+      <p><a href={`mailto:${contactEmail}`}>{contactEmail}</a></p>
+    {:else if contactUrl}
+      <p><a href={contactUrl} target="_blank" rel="noopener noreferrer">{contactUrl}</a></p>
+    {:else}
+      <p>
+        This instance has not published a dedicated contact address yet. If you have an account, use the <em>Flag</em>
+        action on the relevant post or profile — it creates a report for the moderators.
+      </p>
+      <p class="text-sm text-muted-foreground">
+        Operators: set <code>PUBLIC_CONTACT_EMAIL</code> or <code>PUBLIC_CONTACT_URL</code> to surface your address here,
+        and replace this placeholder with your imprint.
+      </p>
+    {/if}
+
+    <h2>Abuse and takedown</h2>
+    {#if abuseEmail}
+      <p><a href={`mailto:${abuseEmail}`}>{abuseEmail}</a></p>
+    {:else}
+      <p>Use the Flag action on the post or user, or write to the general contact above.</p>
+    {/if}
+    <p>
+      Include the URL of the content, a description of the issue, and your contact information. Moderators review
+      reports at <a href="/admin">/admin</a> when signed in as an admin.
+    </p>
+
+    <h2>Fediverse</h2>
+    <p>
+      This instance federates via ActivityPub{#if instance?.federationEnabled}
+        at
+        <code>{domain}</code>{:else}
+        when federation is enabled{/if}. You can follow authors from any compatible server.
+    </p>
+
+    <h2>Source</h2>
+    <p>
+      Source code per AGPL-3.0 §13: <a
+        href={env.PUBLIC_SOURCE_URL || "https://github.com/the-jk-labs/omicron"}
+        target="_blank"
+        rel="noopener noreferrer">Source</a
+      >.
+    </p>
+  </div>
+</article>

--- a/apps/frontend/src/routes/privacy/+page.svelte
+++ b/apps/frontend/src/routes/privacy/+page.svelte
@@ -1,0 +1,69 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { page } from "$app/stores";
+  import { env } from "$env/dynamic/public";
+  import PageTitle from "$lib/components/PageTitle.svelte";
+  import type { InstanceInfo } from "$lib/types";
+
+  const instance = $derived(($page.data as { instance?: InstanceInfo | null }).instance ?? null);
+  const appName = $derived(instance?.name || env.PUBLIC_APP_NAME || "Omicron");
+  const domain = $derived(instance?.domain ?? "this instance");
+</script>
+
+<PageTitle text="Privacy · {appName}" />
+
+<article class="mx-auto max-w-3xl">
+  <h1 class="text-3xl font-bold tracking-tight text-foreground">Privacy policy</h1>
+  <p class="mt-2 text-sm text-muted-foreground">
+    Last updated: {new Date().getFullYear()} · {domain}
+  </p>
+
+  <div class="prose-omicron mt-8">
+    <p>
+      This is a placeholder privacy notice for <strong>{appName} ({domain})</strong>. If you operate a public instance
+      in the EU/EEA you <em>must</em> replace it with your own policy before offering the service — it is not legal advice.
+    </p>
+
+    <h2>Data we collect</h2>
+    <ul>
+      <li>Account data you provide (username, display name, email, profile content).</li>
+      <li>Content you publish (posts, comments, media, reading lists).</li>
+      <li>Usage data necessary to operate the service (logs, federation delivery, rate-limit counters).</li>
+    </ul>
+
+    <h2>How we use it</h2>
+    <p>
+      To provide the blogging and federation features, moderate the community, and keep the service secure. We do not
+      sell your data.
+    </p>
+
+    <h2>Federation</h2>
+    <p>
+      Public posts and your public profile federate over ActivityPub to other instances that follow you or are otherwise
+      addressed. Those instances apply their own privacy policies once they receive your data.
+    </p>
+
+    <h2>Cookies and storage</h2>
+    <p>
+      A session cookie authenticates you. A timezone cookie improves date rendering. Local storage keeps your editor
+      drafts and preferences. No tracking cookies.
+    </p>
+
+    <h2>Your rights</h2>
+    <p>
+      You can edit or delete your content and account from <a href="/settings">Settings</a>. Contact the operator via
+      <a href="/contact">Contact</a> for access, correction, or deletion requests.
+    </p>
+
+    <h2>Contact</h2>
+    <p>
+      Questions about this policy: <a href="/contact">contact the operator</a>. For abuse reports, use the Flag action
+      on the relevant post or profile, or the contact page.
+    </p>
+
+    <p class="text-sm text-muted-foreground">
+      Operator: replace this template with the identity and contact details required for your jurisdiction (e.g. GDPR
+      controller, imprint).
+    </p>
+  </div>
+</article>

--- a/apps/frontend/src/routes/status/+page.svelte
+++ b/apps/frontend/src/routes/status/+page.svelte
@@ -1,0 +1,54 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import { page } from "$app/stores";
+  import { env } from "$env/dynamic/public";
+  import PageTitle from "$lib/components/PageTitle.svelte";
+  import type { InstanceInfo } from "$lib/types";
+
+  const instance = $derived(($page.data as { instance?: InstanceInfo | null }).instance ?? null);
+  const appName = $derived(instance?.name || env.PUBLIC_APP_NAME || "Omicron");
+  const statusExternal = (env.PUBLIC_STATUS_URL as string | undefined)?.trim() || "";
+</script>
+
+<PageTitle text="Status · {appName}" />
+
+<article class="mx-auto max-w-3xl">
+  <h1 class="text-3xl font-bold tracking-tight text-foreground">Status</h1>
+  <p class="mt-3 text-sm leading-relaxed text-muted-foreground">
+    Operational status for <strong>{instance?.domain ?? appName}</strong>.
+  </p>
+
+  <div class="prose-omicron mt-8">
+    {#if statusExternal}
+      <p>
+        External status page: <a href={statusExternal} target="_blank" rel="noopener noreferrer">{statusExternal}</a>
+      </p>
+    {:else}
+      <p>This instance does not publish an external status page.</p>
+      <p class="text-sm text-muted-foreground">
+        Operators: set <code>PUBLIC_STATUS_URL</code> to link your status page here.
+      </p>
+    {/if}
+
+    <h2>Health endpoints</h2>
+    <ul>
+      <li><code>/api/healthz</code> — liveness</li>
+      <li><code>/api/version</code> — build version and federation state</li>
+    </ul>
+
+    <h2>Federation</h2>
+    <p>
+      {instance?.federationEnabled ? "Federation is enabled." : "Federation is disabled."}
+      {#if instance?.domain}Instance domain: <code>{instance.domain}</code>{/if}
+    </p>
+
+    <h2>Source</h2>
+    <p>
+      Source code per AGPL-3.0 §13: <a
+        href={env.PUBLIC_SOURCE_URL || "https://github.com/the-jk-labs/omicron"}
+        target="_blank"
+        rel="noopener noreferrer">Source</a
+      >.
+    </p>
+  </div>
+</article>

--- a/apps/frontend/src/test/mocks/$env/dynamic/public.ts
+++ b/apps/frontend/src/test/mocks/$env/dynamic/public.ts
@@ -1,2 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-export const env = { PUBLIC_APP_NAME: "Omicron" };
+export const env = {
+  PUBLIC_APP_NAME: "Omicron",
+  PUBLIC_SOURCE_URL: "https://github.com/the-jk-labs/omicron",
+  PUBLIC_STATUS_URL: "",
+  PUBLIC_CONTACT_URL: "",
+  PUBLIC_CONTACT_EMAIL: "",
+  PUBLIC_ABUSE_EMAIL: "",
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -146,6 +146,11 @@ services:
     environment:
       INTERNAL_API_URL: ${INTERNAL_API_URL:-http://backend:8000}
       PUBLIC_APP_NAME: ${PUBLIC_APP_NAME:-Omicron}
+      PUBLIC_SOURCE_URL: ${PUBLIC_SOURCE_URL:-https://github.com/the-jk-labs/omicron}
+      PUBLIC_STATUS_URL: ${PUBLIC_STATUS_URL:-}
+      PUBLIC_CONTACT_URL: ${PUBLIC_CONTACT_URL:-}
+      PUBLIC_CONTACT_EMAIL: ${PUBLIC_CONTACT_EMAIL:-}
+      PUBLIC_ABUSE_EMAIL: ${PUBLIC_ABUSE_EMAIL:-}
       APP_DOMAIN: ${APP_DOMAIN:-localhost:5173}
       PORT: 3000
       # Behind Caddy the app is reached over TLS on the public domain; trust the


### PR DESCRIPTION
## Symptom
Footer was only `© YEAR Omicron · Federated blogging` inside the discovery rail (`apps/frontend/src/lib/components/Discover.svelte:117-120`), so most pages had no footer at all and the legal links required for a public EU service were absent. README claims "Omicron surfaces a Source link in the UI" per AGPL-3.0 §13, but no `Source` link was rendered anywhere (`grep PUBLIC_SOURCE` empty). Issue #17: About, Instance rules, Privacy, Contact/abuse, Source (fork link), Status, Fediverse profile missing.

## Root cause
Footer lived only in `Discover` (shown on `/` and `/[@handle]` via `showDiscover`) with a single copyright line. No site-wide `Footer` existed in `+layout.svelte`. No `PUBLIC_SOURCE_URL` wiring, no legal placeholder routes, so links would 404 anyway.

## Fix
- Add site-wide `apps/frontend/src/lib/components/Footer.svelte` (`contentinfo`, `data-testid=site-footer`) rendered from `+layout.svelte` (all pages except `/setup`). Contains: About (`/about`), Instance rules (`/about#rules`), Privacy (`/privacy`), Contact (`PUBLIC_CONTACT_URL`→`/contact`), Source (`PUBLIC_SOURCE_URL`→ upstream `https://github.com/the-jk-labs/omicron`, `target=_blank rel=noopener`, shown twice: brand line + nav), Status (`PUBLIC_STATUS_URL`→`/status`), Fediverse profile (`https://<domain>` when federating else `joinmastodon.org/servers` with `rel=me`). Brand line includes `© YEAR appName · Federated blogging · AGPL-3.0 · Source` + domain.
- Add placeholder routes `/about`, `/privacy`, `/contact`, `/status` (prose-omicron, PageTitle, imprint/AGPL §13 notices) so no footer link 404s.
- Wire env: `.env.example` + `docker-compose.yml` expose `PUBLIC_SOURCE_URL/STATUS/CONTACT*" with sensible defaults; extend `src/test/mocks/$env/dynamic/public.ts`.
- Styling uses theme tokens (`text-foreground`, `muted-foreground`, `border`, `background`) — no ad-hoc colors, matches Bits UI docs.

## Verified
- `pnpm fmt` — 174 files
- `pnpm svelte-check` — 0 errors, 0 warnings
- `pnpm lint` (oxlint) — only pre-existing warnings
- `pnpm test` — 7 files, 26 tests passed (added `Footer.test.ts`: checks all 7 links, AGPL notice, Source external, Fediverse)

## Deploy notes
- `docker compose up -d --build` enough; no migration.
- Operators running a modified fork should set `PUBLIC_SOURCE_URL=https://<your-fork>` so the footer satisfies AGPL-3.0 §13.
