### PR TITLE
fix(frontend): redesign footer to Mastodon-style compact sidebar

### DIFF
--- a/apps/frontend/src/lib/components/Discover.svelte
+++ b/apps/frontend/src/lib/components/Discover.svelte
@@ -1,7 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
   import { page } from "$app/state";
-  import { env } from "$env/dynamic/public";
   import FollowButton from "$lib/components/FollowButton.svelte";
   import Icon from "$lib/components/Icon.svelte";
   import ReactionCount from "$lib/components/ReactionCount.svelte";
@@ -16,13 +15,7 @@
   // in the initial SSR HTML rather than popping in after client hydration. Each
   // section renders only when it has something to show.
   type Discover = { posts: Post[]; people: SuggestedUser[]; tags: TagWithCount[] };
-  let {
-    data = null,
-    appName = env.PUBLIC_APP_NAME || "Omicron",
-  }: {
-    data?: Discover | null;
-    appName?: string;
-  } = $props();
+  let { data = null }: { data?: Discover | null } = $props();
   const signedIn = $derived(!!page.data.user);
 
   const posts = $derived(data?.posts ?? []);
@@ -113,9 +106,4 @@
       </div>
     </section>
   {/if}
-
-  <p class="border-t border-border pt-4 text-xs text-muted-foreground">
-    © {new Date().getFullYear()}
-    {appName} · Federated blogging
-  </p>
 </aside>

--- a/apps/frontend/src/lib/components/Footer.svelte
+++ b/apps/frontend/src/lib/components/Footer.svelte
@@ -6,9 +6,11 @@
   let {
     appName = env.PUBLIC_APP_NAME || "Omicron",
     instance = null,
+    class: className = "",
   }: {
     appName?: string;
     instance?: InstanceInfo | null;
+    class?: string;
   } = $props();
 
   const year = new Date().getFullYear();
@@ -16,78 +18,55 @@
     (env.PUBLIC_SOURCE_URL as string | undefined)?.trim() || "https://github.com/the-jk-labs/omicron",
   );
   const statusUrl = $derived((env.PUBLIC_STATUS_URL as string | undefined)?.trim() || "/status");
-  // Fediverse profile: the instance itself when federation is on. Falls back to
-  // a generic fediverse directory link when not federating — keeps the slot
-  // occupied rather than shifting layout between instances.
+  const contactHref = $derived((env.PUBLIC_CONTACT_URL as string | undefined)?.trim() || "/contact");
   const fediverseUrl = $derived.by(() => {
     if (instance?.federationEnabled && instance.domain) return `https://${instance.domain}`;
     return "https://joinmastodon.org/servers";
   });
+  const domainLabel = $derived(instance?.domain || appName);
   const fediverseLabel = $derived(instance?.federationEnabled && instance.domain ? `@${instance.domain}` : "Fediverse");
-  const contactHref = $derived((env.PUBLIC_CONTACT_URL as string | undefined)?.trim() || "/contact");
 </script>
 
-<footer aria-label="Site footer" class="border-t border-border bg-background" data-testid="site-footer">
-  <div class="mx-auto max-w-6xl px-4 py-8">
-    <div class="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
-      <!-- Brand + legal notice -->
-      <div class="space-y-1">
-        <p class="text-sm font-semibold text-foreground">{appName}</p>
-        <p class="text-xs leading-relaxed text-muted-foreground">
-          © {year}
-          {appName} · Federated blogging ·
-          <span class="whitespace-nowrap"
-            >AGPL-3.0 · <a
-              href={sourceUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              class="underline underline-offset-4 hover:text-foreground">Source</a
-            ></span
-          >
-        </p>
-        {#if instance?.domain}
-          <p class="text-xs text-muted-foreground">{instance.domain}</p>
-        {/if}
-      </div>
+<footer
+  aria-label="Site footer"
+  data-testid="site-footer"
+  class="border-t border-border pt-4 text-xs leading-relaxed text-muted-foreground {className}"
+>
+  <div class="space-y-2">
+    <!-- Instance line — like mastodon.social: -->
+    <p class="flex flex-wrap items-baseline gap-x-1.5">
+      <span class="font-semibold text-foreground">{domainLabel}:</span>
+      <a href="/about" class="hover:text-foreground hover:underline hover:underline-offset-2">About</a>
+      <span aria-hidden="true" class="opacity-60">·</span>
+      <a href={statusUrl} class="hover:text-foreground hover:underline hover:underline-offset-2">Status</a>
+      <span aria-hidden="true" class="opacity-60">·</span>
+      <a href="/about#rules" class="hover:text-foreground hover:underline hover:underline-offset-2">Instance rules</a>
+      <span aria-hidden="true" class="opacity-60">·</span>
+      <a href="/privacy" class="hover:text-foreground hover:underline hover:underline-offset-2">Privacy</a>
+      <span aria-hidden="true" class="opacity-60">·</span>
+      <a href={contactHref} class="hover:text-foreground hover:underline hover:underline-offset-2">Contact</a>
+    </p>
 
-      <!-- Footer navigation -->
-      <nav aria-label="Footer" class="flex flex-wrap gap-x-4 gap-y-2 text-sm">
-        <a href="/about" class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">About</a
-        >
-        <a href="/about#rules" class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-          >Instance rules</a
-        >
-        <a href="/privacy" class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-          >Privacy</a
-        >
-        <a href={contactHref} class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-          >Contact</a
-        >
-        <a
-          href={sourceUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">Source</a
-        >
-        <a href={statusUrl} class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
-          >Status</a
-        >
-        <a
-          href={fediverseUrl}
-          target={fediverseUrl.startsWith("http") ? "_blank" : undefined}
-          rel={fediverseUrl.startsWith("http") ? "me noopener noreferrer" : "me"}
-          class="text-muted-foreground underline-offset-4 hover:text-foreground hover:underline">{fediverseLabel}</a
-        >
-      </nav>
-    </div>
-
-    <!-- Secondary row: imprint / abuse hint for EU public services -->
-    <p class="mt-6 border-t border-border pt-4 text-xs leading-relaxed text-muted-foreground">
-      Self-hostable · No vendor lock-in ·
-      <a href="/privacy" class="underline underline-offset-4 hover:text-foreground">Privacy policy</a>
-      ·
-      <a href="/contact" class="underline underline-offset-4 hover:text-foreground">Abuse / Contact</a>
-      . Source code offered per AGPL-3.0 §13 via the “Source” link above.
+    <!-- Project line — like Mastodon: -->
+    <p class="flex flex-wrap items-baseline gap-x-1.5">
+      <span class="font-semibold text-foreground">{appName}:</span>
+      <a
+        href={sourceUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:text-foreground hover:underline hover:underline-offset-2">Source</a
+      >
+      <span aria-hidden="true" class="opacity-60">·</span>
+      <a
+        href={fediverseUrl}
+        target={fediverseUrl.startsWith("http") ? "_blank" : undefined}
+        rel={fediverseUrl.startsWith("http") ? "me noopener noreferrer" : "me"}
+        class="hover:text-foreground hover:underline hover:underline-offset-2">{fediverseLabel}</a
+      >
+      <span aria-hidden="true" class="opacity-60">·</span>
+      <span>AGPL-3.0</span>
+      <span aria-hidden="true" class="opacity-60">·</span>
+      <span>© {year} {appName} · Federated blogging</span>
     </p>
   </div>
 </footer>

--- a/apps/frontend/src/lib/components/SideNav.svelte
+++ b/apps/frontend/src/lib/components/SideNav.svelte
@@ -2,6 +2,7 @@
 <script lang="ts">
   import { page } from "$app/state";
   import welcomeBanner from "$lib/assets/welcome-banner.png";
+  import Footer from "$lib/components/Footer.svelte";
   import Icon, { type IconName } from "$lib/components/Icon.svelte";
   import UIButton from "$lib/components/ui/Button.svelte";
   import type { InstanceInfo, User } from "$lib/types";
@@ -99,4 +100,11 @@
       </div>
     </div>
   {/if}
+
+  <!-- Mastodon-style compact footer at the bottom of the left rail (desktop).
+       Uses the same links as the mobile footer but lives inside the sticky rail
+       so it stays visible like Mastodon's left-column footer. -->
+  <div class="mt-6">
+    <Footer {appName} {instance} />
+  </div>
 </nav>

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -347,14 +347,26 @@
       <!-- Right rail: discovery (home feed and profile pages only) -->
       <div class={showDiscover ? "hidden xl:block" : "hidden"}>
         <div class="sticky top-24">
-          <Discover data={data.discover} {appName} />
+          <Discover data={data.discover} />
         </div>
       </div>
     </div>
   {/if}
 
   {#if !isSetup}
-    <Footer {appName} instance={data.instance} />
+    {#if standalone}
+      <div class="mx-auto max-w-sm px-4 py-6">
+        <Footer {appName} instance={data.instance} />
+      </div>
+    {:else}
+      <!-- Mobile footer: the desktop footer lives in the left rail (SideNav), but the
+           rail is hidden below lg, so a compact copy is shown here on phones/tablets.
+           Matches Mastodon's pattern of a sidebar footer on desktop and a page footer
+           on mobile, kept compact and in our theme tokens. -->
+      <div class="mx-auto max-w-6xl px-4 pb-6 lg:hidden">
+        <Footer {appName} instance={data.instance} />
+      </div>
+    {/if}
   {/if}
 </div>
 


### PR DESCRIPTION
## Symptom
The full-width bottom bar added in #82 (py-8, brand left + nav right + secondary row) was flagged as not looking good (screenshot 1). It was visually heavy, disconnected from the 3-column layout, and duplicated the small copyright already in the right rail.

## Root cause
`Footer.svelte` used a large padded global bar (`mx-auto max-w-6xl px-4 py-8 flex flex-col md:flex-row ...`, second bordered row) rendered site-wide from `+layout.svelte`. Mastodon (screenshot 2) instead keeps its footer compact and in the left sidebar: two tiny lines with `·` separators (`mastodon.social: About · Status · ...` / `Mastodon: About · View source code · ...`) at the bottom of the rail, with a mobile fallback.

## Fix
- Rewrite `Footer.svelte:1` to Mastodon-style compact: `text-xs leading-relaxed text-muted-foreground`, `border-t pt-4`, two flex-wrap lines with `·` separators (`opacity-60 aria-hidden`), theme tokens only. Line 1 = instance (`{domain}:` About · Status · Instance rules · Privacy · Contact), line 2 = project (`{appName}:` Source · Fediverse · AGPL-3.0 · © YEAR · Federated blogging). Keeps all legal/AGPL links (About, Instance rules, Privacy, Contact, Source, Status, Fediverse, AGPL-3.0) required by #17.
- Move placement to match Mastodon and our layout: embed `Footer` at bottom of left rail `SideNav.svelte:1,105` (sticky, `mt-6`, visible on desktop via the rail's own `hidden lg:block`), remove old `Discover.svelte:117` copyright line, and in `+layout.svelte:356` show a mobile-only copy (`lg:hidden` inside `max-w-6xl px-4 pb-6`) because the rail is hidden below `lg`. Auth pages keep a centered footer; `/setup` stays without footer.
- `Discover.svelte` no longer takes `appName`; cleaned unused import.

## Verified
- `pnpm fmt` — 174 files
- `pnpm svelte-check` — 0 errors, 0 warnings
- `pnpm lint` — only pre-existing
- `pnpm test` — 7 files, 26 tests passed

## Deploy notes
No env/migration change. `docker compose up -d --build` is enough.

## Screenshots
Before: full-width bar with two rows under feed (image 1). After: compact two-line footer in left rail (desktop) and compact page footer on mobile, same dot-separated style as Mastodon's image 2 but using our Bits UI docs tokens (`foreground`, `muted-foreground`, `border`, `background`).