### PR TITLE
fix(frontend): prevent orphan dots and improve footer alignment

### DIFF
--- a/apps/frontend/src/lib/components/Footer.svelte
+++ b/apps/frontend/src/lib/components/Footer.svelte
@@ -30,43 +30,59 @@
 <footer
   aria-label="Site footer"
   data-testid="site-footer"
-  class="border-t border-border pt-4 text-xs leading-relaxed text-muted-foreground {className}"
+  class="border-t border-border pt-3 text-[11px] leading-5 text-muted-foreground {className}"
 >
-  <div class="space-y-2">
-    <!-- Instance line — like mastodon.social: -->
-    <p class="flex flex-wrap items-baseline gap-x-1.5">
+  <div class="space-y-1.5">
+    <!-- Instance line — like mastodon.social: keep each · attached to the preceding
+         link (whitespace-nowrap group) so wrapping never leaves a bare dot at the
+         start of a line, and the dot stays at the end of the previous line. -->
+    <p class="flex flex-wrap gap-x-1 gap-y-0.5">
       <span class="font-semibold text-foreground">{domainLabel}:</span>
-      <a href="/about" class="hover:text-foreground hover:underline hover:underline-offset-2">About</a>
-      <span aria-hidden="true" class="opacity-60">·</span>
-      <a href={statusUrl} class="hover:text-foreground hover:underline hover:underline-offset-2">Status</a>
-      <span aria-hidden="true" class="opacity-60">·</span>
-      <a href="/about#rules" class="hover:text-foreground hover:underline hover:underline-offset-2">Instance rules</a>
-      <span aria-hidden="true" class="opacity-60">·</span>
-      <a href="/privacy" class="hover:text-foreground hover:underline hover:underline-offset-2">Privacy</a>
-      <span aria-hidden="true" class="opacity-60">·</span>
+      <span class="inline-flex items-center gap-1 whitespace-nowrap">
+        <a href="/about" class="hover:text-foreground hover:underline hover:underline-offset-2">About</a>
+        <span aria-hidden="true" class="opacity-60">·</span>
+      </span>
+      <span class="inline-flex items-center gap-1 whitespace-nowrap">
+        <a href={statusUrl} class="hover:text-foreground hover:underline hover:underline-offset-2">Status</a>
+        <span aria-hidden="true" class="opacity-60">·</span>
+      </span>
+      <span class="inline-flex items-center gap-1 whitespace-nowrap">
+        <a href="/about#rules" class="hover:text-foreground hover:underline hover:underline-offset-2">Instance rules</a>
+        <span aria-hidden="true" class="opacity-60">·</span>
+      </span>
+      <span class="inline-flex items-center gap-1 whitespace-nowrap">
+        <a href="/privacy" class="hover:text-foreground hover:underline hover:underline-offset-2">Privacy</a>
+        <span aria-hidden="true" class="opacity-60">·</span>
+      </span>
       <a href={contactHref} class="hover:text-foreground hover:underline hover:underline-offset-2">Contact</a>
     </p>
 
-    <!-- Project line — like Mastodon: -->
-    <p class="flex flex-wrap items-baseline gap-x-1.5">
+    <!-- Project line — like Mastodon: same wrapping fix -->
+    <p class="flex flex-wrap gap-x-1 gap-y-0.5">
       <span class="font-semibold text-foreground">{appName}:</span>
-      <a
-        href={sourceUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        class="hover:text-foreground hover:underline hover:underline-offset-2">Source</a
-      >
-      <span aria-hidden="true" class="opacity-60">·</span>
-      <a
-        href={fediverseUrl}
-        target={fediverseUrl.startsWith("http") ? "_blank" : undefined}
-        rel={fediverseUrl.startsWith("http") ? "me noopener noreferrer" : "me"}
-        class="hover:text-foreground hover:underline hover:underline-offset-2">{fediverseLabel}</a
-      >
-      <span aria-hidden="true" class="opacity-60">·</span>
-      <span>AGPL-3.0</span>
-      <span aria-hidden="true" class="opacity-60">·</span>
-      <span>© {year} {appName} · Federated blogging</span>
+      <span class="inline-flex items-center gap-1 whitespace-nowrap">
+        <a
+          href={sourceUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="hover:text-foreground hover:underline hover:underline-offset-2">Source</a
+        >
+        <span aria-hidden="true" class="opacity-60">·</span>
+      </span>
+      <span class="inline-flex items-center gap-1 whitespace-nowrap">
+        <a
+          href={fediverseUrl}
+          target={fediverseUrl.startsWith("http") ? "_blank" : undefined}
+          rel={fediverseUrl.startsWith("http") ? "me noopener noreferrer" : "me"}
+          class="hover:text-foreground hover:underline hover:underline-offset-2">{fediverseLabel}</a
+        >
+        <span aria-hidden="true" class="opacity-60">·</span>
+      </span>
+      <span class="inline-flex items-center gap-1 whitespace-nowrap">
+        <span>AGPL-3.0</span>
+        <span aria-hidden="true" class="opacity-60">·</span>
+      </span>
+      <span class="whitespace-nowrap">© {year} {appName} · Federated blogging</span>
     </p>
   </div>
 </footer>

--- a/apps/frontend/src/lib/components/SideNav.svelte
+++ b/apps/frontend/src/lib/components/SideNav.svelte
@@ -103,8 +103,10 @@
 
   <!-- Mastodon-style compact footer at the bottom of the left rail (desktop).
        Uses the same links as the mobile footer but lives inside the sticky rail
-       so it stays visible like Mastodon's left-column footer. -->
+       so it stays visible like Mastodon's left-column footer. Slight px keeps the
+       text aligned with the nav items' inset (px-3 + icon) instead of hugging
+       the rail edge. -->
   <div class="mt-6">
-    <Footer {appName} {instance} />
+    <Footer {appName} {instance} class="px-1" />
   </div>
 </nav>


### PR DESCRIPTION
## Symptom
After #83 the footer wrapped with a bare `·` at the start of a line: `About · Status` then `· Instance rules · ...` and `© ... · Federated` / `blogging` on the next line (screenshot). Left edge also hugged the rail while Settings was inset by `px-3`.

## Root cause
`Footer.svelte:37` used `flex flex-wrap gap-x-1.5` with the dot as its own flex item. Flex wrapping can break before any item, so the dot could become the first item on the next line, orphaned from its preceding link.

## Fix
- Keep each `·` attached to its preceding link via `inline-flex whitespace-nowrap gap-1` groups (`About ·`, `Status ·`, ...), so breaks can only fall after the dot, not before it. Final link in each line has no trailing dot. Same for the project line.
- Tighten to `text-[11px] leading-5 gap-x-1 gap-y-0.5 space-y-1.5 pt-3` for a more Mastodon-like density.
- Inset the left-rail copy slightly (`SideNav.svelte:107` `Footer ... class="px-1"`) so its text aligns with the nav items (`px-3` + icon) instead of the rail edge; border stays full-width. Mobile footer keeps its existing `px-4` wrapper.

## Verified
- `pnpm fmt` — 174 files
- `pnpm svelte-check` — 0 errors
- `pnpm test` — 7 files 26 tests