### PR TITLE
feat(search): add header entry, keyboard shortcut and tag/author filters

### DIFF
--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -6,6 +6,7 @@ import {
   eq,
   getTableColumns,
   gt,
+  ilike,
   inArray,
   isNull,
   lt,
@@ -573,19 +574,46 @@ export function listGlobal(
 // weight B), backed by a GIN index — an index lookup, not a per-row recompute.
 // `websearch_to_tsquery` accepts plain user input (quoted phrases, `or`, `-term`)
 // and never throws on stray syntax. Ranked by relevance, then recency.
-export function searchPosts(viewerId: string | null, query: string, limit = DEFAULT_PAGE_SIZE) {
+// Optional `tag` (normalized slug) and `author` (substring on handle/name) narrow
+// the result set without changing the ranking — the filters cover "find this topic
+// via tag" and "find this author's writing".
+export function searchPosts(
+  viewerId: string | null,
+  query: string,
+  limit = DEFAULT_PAGE_SIZE,
+  opts?: { tag?: string; author?: string },
+) {
   const tsquery = sql`websearch_to_tsquery('english', ${query})`;
+  const filters = [
+    eq(posts.apType, "Article"),
+    isPublished,
+    notSuspended,
+    notHidden(viewerId),
+    visibleToViewer(viewerId),
+    sql`${posts.searchVector} @@ ${tsquery}`,
+  ];
+  if (opts?.tag) {
+    // Exact slug match via an exists subquery — keeps the main select's joins
+    // untouched and uses the `tags_slug_idx` + `post_tags_tag_idx` indexes.
+    filters.push(
+      sql`exists (select 1 from post_tags pt join tags t on t.id = pt.tag_id where pt.post_id = ${posts.id} and t.slug = ${opts.tag})`,
+    );
+  }
+  if (opts?.author) {
+    const term = `%${opts.author.replace(/[%_\\]/g, "\\$&")}%`;
+    // Matches either a local author's handle/display name or a cached remote
+    // actor's handle/display name — both are left-joined in selectPosts().
+    filters.push(
+      or(
+        ilike(users.username, term),
+        ilike(users.displayName, term),
+        ilike(remoteActors.handle, term),
+        ilike(remoteActors.displayName, term),
+      )!,
+    );
+  }
   return selectPosts()
-    .where(
-      and(
-        eq(posts.apType, "Article"),
-        isPublished,
-        notSuspended,
-        notHidden(viewerId),
-        visibleToViewer(viewerId),
-        sql`${posts.searchVector} @@ ${tsquery}`,
-      ),
-    )
+    .where(and(...filters))
     .orderBy(
       sql`ts_rank(${posts.searchVector}, ${tsquery}) desc`,
       desc(posts.createdAt),

--- a/apps/backend/src/routes/search.ts
+++ b/apps/backend/src/routes/search.ts
@@ -8,11 +8,14 @@ export const searchRoutes = new Hono<AppEnv>();
 
 // Site search (public). `?q=` is the query; `?scope=posts|people|tags` narrows
 // the response, otherwise all three are returned. A blank query yields empty
-// results.
+// results. `?tag=` and `?author=` narrow the *posts* side only — the people/tags
+// tabs still return the top matches for `q` alone, so tabs remain comparable.
 searchRoutes.get("/", async (c) => {
   const viewer = c.get("user");
   const query = (c.req.query("q") ?? "").trim();
   const scope = c.req.query("scope");
+  const tag = (c.req.query("tag") ?? "").trim() || undefined;
+  const author = (c.req.query("author") ?? "").trim() || undefined;
 
   if (!query) return c.json({ posts: [], people: [], tags: [] });
 
@@ -21,7 +24,7 @@ searchRoutes.get("/", async (c) => {
   const wantTags = !scope || scope === "tags";
 
   const [postRows, people, tags] = await Promise.all([
-    wantPosts ? searchService.searchPosts(viewer?.id ?? null, query) : Promise.resolve([]),
+    wantPosts ? searchService.searchPosts(viewer?.id ?? null, query, { tag, author }) : Promise.resolve([]),
     wantPeople ? searchService.searchPeople(query) : Promise.resolve([]),
     wantTags ? searchService.searchTags(query) : Promise.resolve([]),
   ]);

--- a/apps/backend/src/services/search.ts
+++ b/apps/backend/src/services/search.ts
@@ -15,8 +15,16 @@ const MAX_POSTS = 20;
 const MAX_PEOPLE = 10;
 const MAX_TAGS = 10;
 
-export async function searchPosts(viewerId: string | null, query: string) {
-  return await postsRepo.searchPosts(viewerId, query, MAX_POSTS);
+export async function searchPosts(
+  viewerId: string | null,
+  query: string,
+  opts?: { tag?: string; author?: string },
+) {
+  // Normalize tag if provided — empty after normalization means "no tag filter".
+  const normalizedTag = opts?.tag ? normalizeTag(opts.tag) : undefined;
+  const tag = normalizedTag || undefined;
+  const author = opts?.author?.trim() || undefined;
+  return await postsRepo.searchPosts(viewerId, query, MAX_POSTS, { tag, author });
 }
 
 export async function searchPeople(query: string) {

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -166,9 +166,22 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     markAllNotificationsRead: () => api.post<{ ok: true }>("/notifications/read"),
     markNotificationRead: (id: string) => api.post<{ ok: true }>(`/notifications/${id}/read`),
 
-    // search
-    search: (query: string, scope?: "posts" | "people" | "tags") =>
-      api.get<SearchResults>(`/search?q=${encodeURIComponent(query)}${scope ? `&scope=${scope}` : ""}`),
+    // search — `tag` and `author` narrow only the posts side (see backend routes/search.ts)
+    search: (
+      query: string,
+      scopeOrOpts?:
+        | "posts"
+        | "people"
+        | "tags"
+        | { scope?: "posts" | "people" | "tags"; tag?: string; author?: string },
+    ) => {
+      const opts = typeof scopeOrOpts === "string" ? { scope: scopeOrOpts } : (scopeOrOpts ?? {});
+      const params = new URLSearchParams({ q: query });
+      if (opts.scope) params.set("scope", opts.scope);
+      if (opts.tag) params.set("tag", opts.tag);
+      if (opts.author) params.set("author", opts.author);
+      return api.get<SearchResults>(`/search?${params.toString()}`);
+    },
 
     // tags
     tag: (slug: string) => api.get<TagDetail>(`/tags/${encodeURIComponent(slug)}`),

--- a/apps/frontend/src/lib/components/Nav.svelte
+++ b/apps/frontend/src/lib/components/Nav.svelte
@@ -97,8 +97,14 @@
 
     <div class="flex shrink-0 items-center gap-1.5">
       {#if !minimal}
-        <!-- Icon-only search fallback (below sm) -->
-        <Button href="/search" variant="icon" class="border-0! shadow-none! sm:hidden" aria-label="Search">
+        <!-- Icon-only search fallback (below sm) — the pill is hidden here -->
+        <Button
+          href="/search"
+          variant="icon"
+          class="border-0! shadow-none! sm:hidden"
+          aria-label="Search"
+          title="Search (press /)"
+        >
           <Icon name="search" size={18} />
         </Button>
       {/if}

--- a/apps/frontend/src/lib/components/SearchBar.svelte
+++ b/apps/frontend/src/lib/components/SearchBar.svelte
@@ -3,31 +3,87 @@
   Inline search pill for the top nav (`sm+`). Submitting navigates to
   `/search?q=…` — the page owns the actual results. The below-`sm` icon-only
   fallback lives in Nav.svelte so it can sit in the right-hand cluster.
+  Keyboard: `/` or `Ctrl/⌘ K` focuses it (desktop); on narrow screens the
+  shortcut jumps to `/search` where the field is visible.
 -->
 <script lang="ts">
   import { goto } from "$app/navigation";
   import { page } from "$app/state";
   import Icon from "$lib/components/Icon.svelte";
+  import { onMount } from "svelte";
 
   // Seed from the URL so the field reflects the active query on the results page.
   let query = $state(page.url.pathname === "/search" ? (page.url.searchParams.get("q") ?? "") : "");
+  let inputEl: HTMLInputElement | null = $state(null);
+
+  // Keep the pill in sync when the query changes via navigation (back/forward).
+  $effect(() => {
+    if (page.url.pathname === "/search") {
+      const q = page.url.searchParams.get("q") ?? "";
+      // Don't overwrite live typing — only sync when the URL's q diverges from
+      // what we already show, and the field isn't focused.
+      if (q !== query && document.activeElement !== inputEl) query = q;
+    } else if (query && page.url.pathname !== "/search") {
+      // Leaving search clears the pill so it doesn't carry a stale query elsewhere.
+      // Keep stale while focused to avoid fighting the user.
+      if (document.activeElement !== inputEl) query = "";
+    }
+  });
 
   function submit(e: SubmitEvent) {
     e.preventDefault();
     const q = query.trim();
     if (q) goto(`/search?q=${encodeURIComponent(q)}`);
+    else if (page.url.pathname === "/search") goto("/search");
   }
+
+  onMount(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      const isTyping =
+        !!target && (target.tagName === "INPUT" || target.tagName === "TEXTAREA" || target.isContentEditable);
+      // "/" — like GitHub / Mastodon. Only when not already typing.
+      if (e.key === "/" && !e.ctrlKey && !e.metaKey && !e.altKey && !isTyping) {
+        e.preventDefault();
+        if (window.innerWidth < 640) goto("/search");
+        else inputEl?.focus();
+        return;
+      }
+      // Ctrl+K / Cmd+K — like Slack / Linear.
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        if (window.innerWidth < 640) goto("/search");
+        else {
+          inputEl?.focus();
+          inputEl?.select();
+        }
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  });
 </script>
 
 <form onsubmit={submit} role="search">
-  <div class="flex h-10 items-center gap-2.5 rounded-full bg-muted/60 px-3.5 transition-colors focus-within:bg-muted">
+  <div
+    class="flex h-10 items-center gap-2.5 rounded-full bg-muted/60 px-3.5 transition-colors focus-within:bg-muted has-[input:focus]:bg-muted"
+  >
     <Icon name="search" size={16} class="shrink-0 text-muted-foreground" />
     <input
+      bind:this={inputEl}
       bind:value={query}
       type="search"
       placeholder="Search"
       aria-label="Search articles and people"
+      aria-keyshortcuts="/ Control+K Meta+K"
       class="w-40 bg-transparent text-sm outline-hidden placeholder:text-muted-foreground md:w-48 lg:w-64"
     />
+    <kbd
+      class="hidden items-center gap-0.5 rounded-5px border border-border bg-background px-1.5 py-0.5 text-xs leading-none font-medium text-muted-foreground shadow-mini md:inline-flex"
+      aria-hidden="true"
+      title="Press / or ⌘K to search"
+    >
+      <span class="text-[11px]">/</span>
+    </kbd>
   </div>
 </form>

--- a/apps/frontend/src/routes/search/+page.svelte
+++ b/apps/frontend/src/routes/search/+page.svelte
@@ -24,16 +24,38 @@
   // as the user types — debounced so we don't refetch on every keystroke.
   // The page's load function owns the actual results.
   let query = $state(untrack(() => data.query ?? ""));
-  // Keep the field in sync when the active query changes via navigation (a link
-  // or Back/Forward); reacts to `data.query` only, so live typing is untouched.
+  // Tag & author narrow only the Articles tab (see +page.ts). Seeded from the URL
+  // and kept in sync on navigation; live-typed values are debounced like `query`.
+  let tagFilter = $state(untrack(() => (data as { tag?: string }).tag ?? ""));
+  let authorFilter = $state(untrack(() => (data as { author?: string }).author ?? ""));
+
+  // Keep fields in sync when the active query/filters change via navigation
+  // (a link or Back/Forward); don't fight live typing when the field is focused.
   $effect(() => {
-    query = data.query ?? "";
+    if (document.activeElement?.getAttribute("data-search-input") !== "q") query = data.query ?? "";
+  });
+  $effect(() => {
+    const t = (data as { tag?: string }).tag ?? "";
+    if (document.activeElement?.getAttribute("data-search-input") !== "tag") tagFilter = t;
+  });
+  $effect(() => {
+    const a = (data as { author?: string }).author ?? "";
+    if (document.activeElement?.getAttribute("data-search-input") !== "author") authorFilter = a;
   });
 
-  function run(q: string) {
+  function buildUrl(q: string, tag: string, author: string) {
+    const params = new URLSearchParams();
+    if (q) params.set("q", q);
+    if (tag) params.set("tag", tag);
+    if (author) params.set("author", author);
+    const qs = params.toString();
+    return qs ? `/search?${qs}` : "/search";
+  }
+
+  function run(q: string, tag: string, author: string) {
     // replaceState keeps the query out of history so Back doesn't step through
     // every keystroke; keepFocus leaves the field active as results stream in.
-    goto(q ? `/search?q=${encodeURIComponent(q)}` : "/search", {
+    goto(buildUrl(q, tag, author), {
       keepFocus: true,
       replaceState: true,
     });
@@ -41,14 +63,19 @@
 
   function submit(e: SubmitEvent) {
     e.preventDefault();
-    run(query.trim());
+    run(query.trim(), tagFilter.trim(), authorFilter.trim());
   }
 
   $effect(() => {
     const q = query.trim();
-    if (q === (data.query ?? "")) return; // already showing this query
-    const t = setTimeout(() => run(q), 250);
-    return () => clearTimeout(t);
+    const t = tagFilter.trim();
+    const a = authorFilter.trim();
+    const curQ = data.query ?? "";
+    const curT = (data as { tag?: string }).tag ?? "";
+    const curA = (data as { author?: string }).author ?? "";
+    if (q === curQ && t === curT && a === curA) return; // already showing this state
+    const timeout = setTimeout(() => run(q, t, a), 250);
+    return () => clearTimeout(timeout);
   });
 </script>
 
@@ -61,6 +88,7 @@
     <Icon name="search" size={18} class="shrink-0 text-muted-foreground" />
     <!-- svelte-ignore a11y_autofocus -->
     <input
+      data-search-input="q"
       bind:value={query}
       type="search"
       placeholder="Search"
@@ -75,15 +103,133 @@
   <div class="py-20 text-center">
     <Icon name="search" size={32} class="mx-auto text-muted-foreground" />
     <p class="mt-3 text-sm text-muted-foreground">Search articles and people across the fediverse.</p>
+    <p class="mt-1 text-xs text-muted-foreground">
+      Tip: press <kbd class="rounded-5px border border-border bg-muted px-1 py-0.5">/</kbd> to search anywhere, filter by
+      tag or author on the results page.
+    </p>
   </div>
 {:else}
   <header class="mb-4">
     <h1 class="text-2xl font-bold tracking-tight text-foreground">
       Results for <span class="italic">“{data.query}”</span>
     </h1>
+    {#if (data as { tag?: string }).tag || (data as { author?: string }).author}
+      <p class="mt-1 text-sm text-muted-foreground">
+        Filtered
+        {#if (data as { tag?: string }).tag}
+          by tag <span class="font-medium text-foreground">#{(data as { tag?: string }).tag}</span>
+        {/if}
+        {#if (data as { tag?: string }).tag && (data as { author?: string }).author}
+          <span class="opacity-60"> · </span>
+        {/if}
+        {#if (data as { author?: string }).author}
+          by author <span class="font-medium text-foreground">{(data as { author?: string }).author}</span>
+        {/if}
+      </p>
+    {/if}
   </header>
 
-  {#key data.query}
+  <!-- Tag & author filters — narrow only the Articles results. Debounced like the query
+       so typing a filter re-runs search without a page reload. Theme tokens only. -->
+  <form onsubmit={submit} class="mb-4 flex flex-col gap-3 sm:flex-row" role="search" aria-label="Filter articles">
+    <label class="flex flex-1 flex-col gap-1.5">
+      <span class="text-xs font-medium text-foreground">Tag</span>
+      <div
+        class="flex h-9 items-center gap-2 rounded-input border border-border bg-background px-3 focus-within:border-foreground/20 focus-within:ring-1 focus-within:ring-foreground/10"
+      >
+        <Icon name="tag" size={14} class="shrink-0 text-muted-foreground" />
+        <input
+          data-search-input="tag"
+          bind:value={tagFilter}
+          type="search"
+          placeholder="e.g. technology"
+          aria-label="Filter articles by tag"
+          class="w-full bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
+        />
+        {#if tagFilter}
+          <button
+            type="button"
+            onclick={() => (tagFilter = "")}
+            class="shrink-0 rounded-5px p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Clear tag filter"
+          >
+            <Icon name="close" size={14} />
+          </button>
+        {/if}
+      </div>
+    </label>
+    <label class="flex flex-1 flex-col gap-1.5">
+      <span class="text-xs font-medium text-foreground">Author</span>
+      <div
+        class="flex h-9 items-center gap-2 rounded-input border border-border bg-background px-3 focus-within:border-foreground/20 focus-within:ring-1 focus-within:ring-foreground/10"
+      >
+        <Icon name="user" size={14} class="shrink-0 text-muted-foreground" />
+        <input
+          data-search-input="author"
+          bind:value={authorFilter}
+          type="search"
+          placeholder="username or name"
+          aria-label="Filter articles by author"
+          class="w-full bg-transparent text-sm outline-hidden placeholder:text-muted-foreground"
+        />
+        {#if authorFilter}
+          <button
+            type="button"
+            onclick={() => (authorFilter = "")}
+            class="shrink-0 rounded-5px p-1 text-muted-foreground hover:bg-muted hover:text-foreground"
+            aria-label="Clear author filter"
+          >
+            <Icon name="close" size={14} />
+          </button>
+        {/if}
+      </div>
+    </label>
+  </form>
+
+  {#if tagFilter.trim() || authorFilter.trim()}
+    <div class="mb-3 flex flex-wrap items-center gap-2 text-xs">
+      <span class="text-muted-foreground">Active filters:</span>
+      {#if tagFilter.trim()}
+        <span class="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 font-medium text-foreground">
+          <Icon name="tag" size={12} /> #{tagFilter.trim()}
+          <button
+            type="button"
+            onclick={() => (tagFilter = "")}
+            class="ml-1 rounded-full p-0.5 hover:bg-background"
+            aria-label="Remove tag filter"
+          >
+            <Icon name="close" size={12} />
+          </button>
+        </span>
+      {/if}
+      {#if authorFilter.trim()}
+        <span class="inline-flex items-center gap-1 rounded-full bg-muted px-2.5 py-1 font-medium text-foreground">
+          <Icon name="user" size={12} />
+          {authorFilter.trim()}
+          <button
+            type="button"
+            onclick={() => (authorFilter = "")}
+            class="ml-1 rounded-full p-0.5 hover:bg-background"
+            aria-label="Remove author filter"
+          >
+            <Icon name="close" size={12} />
+          </button>
+        </span>
+      {/if}
+      <button
+        type="button"
+        onclick={() => {
+          tagFilter = "";
+          authorFilter = "";
+        }}
+        class="text-muted-foreground hover:text-foreground hover:underline hover:underline-offset-2"
+      >
+        Clear all
+      </button>
+    </div>
+  {/if}
+
+  {#key `${data.query}-${(data as { tag?: string }).tag ?? ""}-${(data as { author?: string }).author ?? ""}`}
     <Tabs.Root value={defaultTab} class="w-full">
       <Tabs.List class="mb-2 flex items-center gap-6 text-sm font-medium">
         <Tabs.Trigger
@@ -111,7 +257,24 @@
 
       <Tabs.Content value="articles" class="pt-3">
         {#if posts.length === 0}
-          <p class="py-10 text-center text-muted-foreground">No articles match “{data.query}”.</p>
+          <p class="py-10 text-center text-muted-foreground">
+            No articles match “{data.query}”{#if (data as { tag?: string }).tag}
+              with tag
+              <span class="font-medium">#{(data as { tag?: string }).tag}</span
+              >{/if}{#if (data as { author?: string }).author}
+              by
+              <span class="font-medium">{(data as { author?: string }).author}</span>{/if}.
+            {#if (data as { tag?: string }).tag || (data as { author?: string }).author}
+              <button
+                type="button"
+                onclick={() => {
+                  tagFilter = "";
+                  authorFilter = "";
+                }}
+                class="ml-1 font-medium text-foreground underline underline-offset-2">Clear filters</button
+              >
+            {/if}
+          </p>
         {:else}
           {#each posts as post (post.id)}
             <PostCard {post} />

--- a/apps/frontend/src/routes/search/+page.ts
+++ b/apps/frontend/src/routes/search/+page.ts
@@ -3,10 +3,13 @@ import { endpoints } from "$lib/api";
 import type { PageLoad } from "./$types";
 
 // Read the query from the URL and fetch both articles and people in one call.
-// A blank query renders the empty prompt without hitting the API.
+// A blank query renders the empty prompt without hitting the API. `tag` and
+// `author` narrow only the posts side (see backend routes/search.ts).
 export const load: PageLoad = async ({ url, fetch }) => {
   const query = (url.searchParams.get("q") ?? "").trim();
-  if (!query) return { query, results: { posts: [], people: [], tags: [] } };
-  const results = await endpoints(fetch).search(query);
-  return { query, results };
+  const tag = (url.searchParams.get("tag") ?? "").trim() || undefined;
+  const author = (url.searchParams.get("author") ?? "").trim() || undefined;
+  if (!query) return { query, tag, author, results: { posts: [], people: [], tags: [] } };
+  const results = await endpoints(fetch).search(query, { tag, author });
+  return { query, tag, author, results };
 };


### PR DESCRIPTION
## Symptom
Saytda görünən axtarış giriş nöqtəsi yox idi — header-də axtarış sahəsi gizli (`hidden sm:block`) və ipucu olmadan, oxucu yalnız teq buludundan asılı idi. `robots.txt` düzgün olaraq `/search` üçün `Disallow` verir (hər `?q=` ayrı URL və nazik səhifə), amma görünən giriş yox idi. Oxucu xüsusi mövzunu teq və ya müəllif üzrə tapa bilmirdi.

## Root cause
- `SearchBar.svelte:7` yalnız query-ni URL-dən oxuyurdu, shortcut yox, hint yox
- `Nav.svelte:93` pill-i mərkəzdə `sm:block` gizli saxlayır, mobile yalnız icon — klaviatura ilə tapmaq mümkün deyil
- `search/+page.svelte:12` və `+page.ts:7` bütün axtarışı tək `q` ilə edir, teq/müəllif filtri yox; backend `posts.searchPosts` yalnız full-text edirdi

## Fix
**Frontend**
- `SearchBar.svelte`: global `/` və `Ctrl/⌘K` shortcut — desktop-da pill-i fokuslayır, dar ekranda `/search`-a gedir; hint `<kbd>/</kbd>` pills-in içində (`md:inline-flex`, theme tokens), `aria-keyshortcuts`; query-ni `page.url` ilə sinxron saxlayır
- `Nav.svelte:101`: mobile icon-a `title="Search (press /)"` 
- `lib/api/index.ts:170`: `search(query, {scope,tag,author})` — köhnə `string scope` çağırışları ilə geriyə uyğun
- `search/+page.ts:7`: `?tag=&author=` oxuyur, `endpoints.search(q,{tag,author})` ilə çağırır; boş `q` hələ də boş nəticə verir
- `search/+page.svelte:26`: `query/tagFilter/authorFilter` state-ləri, navigation ilə sinxron (`data-search-input` focus guard), debounced `buildUrl/goTo` (250ms), mobil input-a `data-search-input="q"`; filtrlər yalnız Articles tab-ını daraldır. Filter bar (`Tag` + `Author` inputları, clear düymələri, active chips, `Clear all`), header altında filter subtitle, empty state-də filter info + `Clear filters`. Key `q-tag-author` ilə tab state-i qorunur.

**Backend**
- `db/repositories/posts.ts:576`: `searchPosts(viewerId,q,limit,{tag,author?})` — tag üçün `exists (post_tags join tags where slug=?)`, author üçün `ilike(users.username/displayName/remoteActors.handle/displayName, %term%)` (escape `%_\`), trigram/GIN indeksləri ilə
- `services/search.ts:18`: `normalizeTag(tag)` + trim, `postsRepo.searchPosts` çağırışı
- `routes/search.ts:11`: `?tag=&author=` oxuyur, `searchPosts` yalnız posts üçün filtrli çağırır; people/tags hələ də `q` ilə axtarır

## Verified
- `pnpm --dir apps/frontend run fmt` — 174 files
- `pnpm --dir apps/frontend run svelte-check` — 0 errors/warnings
- `pnpm --dir apps/frontend test` — 7 files 26 tests
- `deno check src/routes/search.ts src/services/search.ts src/db/repositories/posts.ts` — ok

## Deploy notes
Normal `docker compose up -d`.