### PR TITLE
fix(search): replace '/' kbd badge with subtle ⌘K hint

### DIFF
--- a/apps/frontend/src/lib/components/SearchBar.svelte
+++ b/apps/frontend/src/lib/components/SearchBar.svelte
@@ -79,11 +79,11 @@
       class="w-40 bg-transparent text-sm outline-hidden placeholder:text-muted-foreground md:w-48 lg:w-64"
     />
     <kbd
-      class="hidden items-center gap-0.5 rounded-5px border border-border bg-background px-1.5 py-0.5 text-xs leading-none font-medium text-muted-foreground shadow-mini md:inline-flex"
+      class="hidden text-[11px] font-medium tracking-wide text-muted-foreground/60 md:inline"
       aria-hidden="true"
-      title="Press / or ⌘K to search"
+      title="Press ⌘K or / to search"
     >
-      <span class="text-[11px]">/</span>
+      ⌘K
     </kbd>
   </div>
 </form>


### PR DESCRIPTION
## Symptom
The '/' badge on the right side of the header search pill used a boxed kbd style (border, bg, shadow) that looked heavy on dark bg (see screenshot).

## Fix
- `SearchBar.svelte:81` — replace the boxed '/' with a minimal muted '⌘K' text hint (`text-muted-foreground/60`, no border/bg/shadow, hidden below md). Title still mentions '/ or ⌘K', shortcut logic unchanged. Keeps discoverability but stays subtle.

Verified: `pnpm fmt`, `svelte-check` 0.

Follow-up available: remove hint entirely or revert to boxed ⌘K if preferred.