### PR TITLE
fix(search): align and enlarge ⌘K hint in pill

### DIFF
--- a/apps/frontend/src/lib/components/SearchBar.svelte
+++ b/apps/frontend/src/lib/components/SearchBar.svelte
@@ -79,7 +79,7 @@
       class="w-40 bg-transparent text-sm outline-hidden placeholder:text-muted-foreground md:w-48 lg:w-64"
     />
     <kbd
-      class="hidden text-[11px] font-medium tracking-wide text-muted-foreground/60 md:inline"
+      class="ml-auto hidden items-center self-center text-xs leading-none font-medium tracking-wide text-muted-foreground/70 md:inline-flex"
       aria-hidden="true"
       title="Press ⌘K or / to search"
     >


### PR DESCRIPTION
## Symptom\nWas 11px inline `⌘K` in the header pill — looked too small and baseline-misaligned in the h-10 flex (see screenshot, dark pill).\n\n## Fix\n- `SearchBar.svelte:81` — `text-[11px] md:inline` → `text-xs leading-none md:inline-flex ml-auto items-center self-center text-muted-foreground/70` so it's 12px, vertically centered and pushed to the right edge inside the pill, still muted/theme-consistent, not distracting.\n\nVerified: `pnpm fmt`, `svelte-check` 0.