### PR TITLE
fix(search): make ⌘K hint slightly larger and bolder

### DIFF
--- a/apps/frontend/src/lib/components/SearchBar.svelte
+++ b/apps/frontend/src/lib/components/SearchBar.svelte
@@ -79,7 +79,7 @@
       class="w-40 bg-transparent text-sm outline-hidden placeholder:text-muted-foreground md:w-48 lg:w-64"
     />
     <kbd
-      class="ml-auto hidden items-center self-center text-xs leading-none font-medium tracking-wide text-muted-foreground/70 md:inline-flex"
+      class="ml-auto hidden items-center self-center text-sm leading-none font-semibold tracking-wide text-muted-foreground md:inline-flex"
       aria-hidden="true"
       title="Press ⌘K or / to search"
     >


### PR DESCRIPTION
## Symptom\nAfter last fix still reads small/thin at 12px medium 70% opacity inside h-10 pill.\n\n## Fix\n- `SearchBar.svelte:81` — `text-xs font-medium text-muted-foreground/70` → `text-sm font-semibold text-muted-foreground` (14px, semibold, full muted) keeping `leading-none ml-auto self-center md:inline-flex` for vertical centering/flush right. Still muted/theme-consistent but more legible.\n\nVerified: `pnpm fmt`, `svelte-check` 0.