### PR TITLE
fix(date): localize format, add <time datetime> semantics, show zone/relative

### DIFF
--- a/apps/frontend/src/lib/components/AdminDomains.svelte
+++ b/apps/frontend/src/lib/components/AdminDomains.svelte
@@ -2,10 +2,9 @@
 <script lang="ts">
   import { endpoints, ApiError } from "$lib/api";
   import Icon from "$lib/components/Icon.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import { formatDate } from "$lib/format";
-  import { timeZone } from "$lib/timezone";
   import type { BlockedDomain } from "$lib/types";
   import { Label } from "bits-ui";
 
@@ -124,7 +123,7 @@
             <div class="min-w-0 flex-1">
               <p class="truncate font-medium text-foreground">{d.domain}</p>
               <p class="truncate text-xs text-muted-foreground">
-                {d.reason ? d.reason : "No reason given"} · {formatDate(d.createdAt, $timeZone)}
+                {d.reason ? d.reason : "No reason given"} · <Time iso={d.createdAt} kind="date" />
               </p>
             </div>
             <Button variant="outline" size="sm" disabled={busyDomain === d.domain} onclick={() => unblock(d)}>

--- a/apps/frontend/src/lib/components/AdminReports.svelte
+++ b/apps/frontend/src/lib/components/AdminReports.svelte
@@ -2,10 +2,9 @@
 <script lang="ts">
   import { endpoints, ApiError } from "$lib/api";
   import Icon from "$lib/components/Icon.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import { formatDate } from "$lib/format";
-  import { timeZone } from "$lib/timezone";
   import type { Report } from "$lib/types";
   import { Tabs } from "bits-ui";
 
@@ -156,7 +155,7 @@
             {:else}
               <span class="font-medium text-muted-foreground">{subjectLabel(r)}</span>
             {/if}
-            <span class="ml-auto text-xs text-muted-foreground">{formatDate(r.createdAt, $timeZone)}</span>
+            <span class="ml-auto text-xs text-muted-foreground"><Time iso={r.createdAt} kind="date" /></span>
           </div>
 
           {#if r.reason}

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -2,11 +2,10 @@
 <script lang="ts">
   import { endpoints, ApiError } from "$lib/api";
   import Icon from "$lib/components/Icon.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import { formatDate } from "$lib/format";
-  import { timeZone } from "$lib/timezone";
   import type { AdminUser } from "$lib/types";
 
   // The signed-in admin's own id, so the row for self can hide the suspend
@@ -110,7 +109,7 @@
               {/if}
             </div>
             <p class="truncate text-xs text-muted-foreground">
-              @{u.username} · {u.email} · joined {formatDate(u.createdAt, $timeZone)}
+              @{u.username} · {u.email} · joined <Time iso={u.createdAt} kind="date" />
             </p>
           </div>
           {#if u.id !== selfId && !u.isAdmin}

--- a/apps/frontend/src/lib/components/CommentNode.svelte
+++ b/apps/frontend/src/lib/components/CommentNode.svelte
@@ -11,11 +11,11 @@
   import type { CommentActions, CommentUiState } from "$lib/components/comments";
   import EmojiTrigger from "$lib/components/EmojiTrigger.svelte";
   import Icon from "$lib/components/Icon.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { insertEmojiIntoField, emojiOverlayBtn } from "$lib/emoji";
-  import { countLabel, formatDateTime } from "$lib/format";
-  import { timeZone } from "$lib/timezone";
+  import { countLabel } from "$lib/format";
   import type { Comment, User } from "$lib/types";
 
   let {
@@ -56,7 +56,7 @@
       <a href={`/@${comment.author.username}`} class="font-medium text-foreground hover:underline">
         {comment.author.displayName}
       </a>
-      <span class="text-xs text-muted-foreground">{formatDateTime(comment.createdAt, $timeZone)}</span>
+      <Time iso={comment.createdAt} relative class="text-xs text-muted-foreground" />
     </div>
     {#if ui.editingId === comment.id}
       <form onsubmit={(e) => actions.submitEdit(e, comment)} class="mt-2">

--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -6,11 +6,11 @@
   import RecommendButton from "$lib/components/RecommendButton.svelte";
   import SaveToListButton from "$lib/components/SaveToListButton.svelte";
   import TagList from "$lib/components/TagList.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
-  import { excerpt, formatDate, formatTime, readTime } from "$lib/format";
+  import { excerpt, readTime } from "$lib/format";
   import { postPath } from "$lib/links";
-  import { timeZone } from "$lib/timezone";
   import type { Post } from "$lib/types";
 
   let { post }: { post: Post } = $props();
@@ -124,14 +124,14 @@
        row the buttons stay on the meta's line while there is room and drop to
        their own right-aligned line when there is not. -->
   <div class="mt-4 flex flex-wrap items-center gap-x-3 gap-y-1.5 text-xs text-muted-foreground">
-    <!-- The clock time is what pushes this row past a phone's width, and a card
-         in a feed is a "when", not a timestamp — the post itself still carries
-         the exact one. -->
-    <span
-      >{formatDate(post.createdAt, $timeZone)}<span class="hidden sm:inline"
-        >, {formatTime(post.createdAt, $timeZone)}</span
-      ></span
-    >
+    <!-- Localized date with semantic <time>; clock time stays on `sm+` (phone
+         width). Time.svelte handles locale, timezone (title) and the
+         `datetime` attribute — no manual `, ` concatenation, so the stray
+         "2026 , 13:40" (space before comma) cannot happen. -->
+    <span class="inline-flex items-center gap-1">
+      <Time iso={post.createdAt} kind="date" />
+      <span class="hidden sm:inline">· <Time iso={post.createdAt} kind="time" /></span>
+    </span>
     <span class="flex items-center gap-1"><Icon name="clock" size={13} /> {minutes} min read</span>
     <ReactionCount icon="heart" count={post.likeCount} singular="like" size={13} />
     <ReactionCount icon="comment" count={post.commentCount} singular="response" size={13} />

--- a/apps/frontend/src/lib/components/SaveStatus.svelte
+++ b/apps/frontend/src/lib/components/SaveStatus.svelte
@@ -2,6 +2,8 @@
 <script lang="ts">
   import type { SaveState } from "$lib/autosave.svelte";
   import Icon from "$lib/components/Icon.svelte";
+  import { locale } from "$lib/locale";
+  import { timeZone } from "$lib/timezone";
 
   // The composer's autosave indicator: what the editor did with the author's
   // work and when. Its whole job is to make the missing "Save" click feel safe,
@@ -30,16 +32,29 @@
 
   function ago(at: number, from: number): string {
     const s = Math.max(0, Math.round((from - at) / 1000));
-    if (s < 45) return "just now";
-    const m = Math.round(s / 60);
-    if (m < 60) return `${m} minute${m === 1 ? "" : "s"} ago`;
-    const h = Math.round(m / 60);
-    if (h < 24) return `${h} hour${h === 1 ? "" : "s"} ago`;
+    const loc = $locale;
+    // Localized relative for recent saves — "just now" / "2 minutes ago" /
+    // "2 dəqiqə əvvəl" etc. via Intl.RelativeTimeFormat.
+    try {
+      const rtf = new Intl.RelativeTimeFormat(loc, { numeric: "auto" });
+      if (s < 45) return rtf.format(0, "second"); // "now" / "indi"
+      const m = Math.round(s / 60);
+      if (m < 60) return rtf.format(-m, "minute");
+      const h = Math.round(m / 60);
+      if (h < 24) return rtf.format(-h, "hour");
+    } catch {
+      if (s < 45) return "just now";
+      const m = Math.round(s / 60);
+      if (m < 60) return `${m} minute${m === 1 ? "" : "s"} ago`;
+      const h = Math.round(m / 60);
+      if (h < 24) return `${h} hour${h === 1 ? "" : "s"} ago`;
+    }
     // Past a day the clock time is the useful fact, not the count of hours.
-    return new Date(at).toLocaleTimeString("en-US", {
+    return new Date(at).toLocaleTimeString(loc, {
       hour: "2-digit",
       minute: "2-digit",
       hour12: false,
+      timeZone: $timeZone,
     });
   }
 

--- a/apps/frontend/src/lib/components/Time.svelte
+++ b/apps/frontend/src/lib/components/Time.svelte
@@ -1,0 +1,63 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<!--
+  Semantic `<time>` wrapper. Every date the reader sees goes through here so
+  the markup is correct (`datetime` for machines, localized text for humans),
+  the timezone is discoverable (title), and recent dates can show nisbi zaman
+  ("2 gün əvvəl") in the reader's own locale.
+
+  - `iso` — ISO-8601 string from the API (always UTC).
+  - `kind` — "date" | "datetime" | "time" (default "datetime").
+  - `relative` — when true, dates within ~30 days render as localized relative
+    time ("3 days ago" / "3 gün əvvəl") with the absolute time in the title.
+  - `withZone` — append the short zone label visibly (e.g. "GMT+4").
+-->
+<script lang="ts">
+  import { formatDate, formatDateTime, formatRelative, formatTime, zoneLabel } from "$lib/format";
+  import { locale } from "$lib/locale";
+  import { timeZone } from "$lib/timezone";
+
+  let {
+    iso,
+    kind = "datetime",
+    relative = false,
+    withZone = false,
+    class: klass = "",
+  }: {
+    iso: string;
+    kind?: "date" | "datetime" | "time";
+    relative?: boolean;
+    withZone?: boolean;
+    class?: string;
+  } = $props();
+
+  const display = $derived.by(() => {
+    const tz = $timeZone;
+    const loc = $locale;
+    if (relative) {
+      const age = Math.abs(Date.now() - new Date(iso).getTime());
+      // 30 days: beyond that "3 months ago" is less useful than the calendar date.
+      if (age < 30 * 24 * 60 * 60 * 1000) return formatRelative(iso, loc);
+    }
+    if (kind === "date") return formatDate(iso, tz, loc);
+    if (kind === "time") return formatTime(iso, tz, loc);
+    return formatDateTime(iso, tz, loc);
+  });
+
+  // Full absolute time + offset for the tooltip and for assistive tech.
+  // `Intl` already localizes the zone name when a locale is passed.
+  const tooltip = $derived.by(() => {
+    const tz = $timeZone;
+    const loc = $locale;
+    try {
+      const abs = formatDateTime(iso, tz, loc);
+      const zl = zoneLabel(tz, loc);
+      return zl ? `${abs} ${zl}` : abs;
+    } catch {
+      return iso;
+    }
+  });
+</script>
+
+<time datetime={iso} title={tooltip} class={klass}
+  >{display}{#if withZone}{" "}{zoneLabel($timeZone, $locale)}{/if}</time
+>

--- a/apps/frontend/src/lib/components/WebhookTokensManager.svelte
+++ b/apps/frontend/src/lib/components/WebhookTokensManager.svelte
@@ -7,10 +7,9 @@
 <script lang="ts">
   import { ApiError, endpoints } from "$lib/api";
   import Icon from "$lib/components/Icon.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import { formatDate } from "$lib/format";
-  import { timeZone } from "$lib/timezone";
   import type { WebhookToken } from "$lib/types";
   import { Label } from "bits-ui";
   import { onMount } from "svelte";
@@ -164,10 +163,8 @@
           <span class="min-w-0">
             <span class="block truncate text-sm font-medium text-foreground">{token.label}</span>
             <span class="block truncate text-xs text-muted-foreground">
-              {token.lastUsedAt ? `Last used ${formatDate(token.lastUsedAt, $timeZone)}` : "Never used"} · Created {formatDate(
-                token.createdAt,
-                $timeZone,
-              )}
+              {#if token.lastUsedAt}Last used <Time iso={token.lastUsedAt} kind="date" />{:else}Never used{/if} · Created
+              <Time iso={token.createdAt} kind="date" />
             </span>
           </span>
         </span>

--- a/apps/frontend/src/lib/editor/Editor.svelte
+++ b/apps/frontend/src/lib/editor/Editor.svelte
@@ -55,8 +55,8 @@
     stats = { characters, words, minutes: readTimeFromWords(words) };
   }
 
-  const LOCALE = "en-US";
-  const count = (n: number, one: string) => `${n.toLocaleString(LOCALE)} ${n === 1 ? one : one + "s"}`;
+  import { locale } from "$lib/locale";
+  const count = (n: number, one: string) => `${n.toLocaleString($locale ?? "en-US")} ${n === 1 ? one : one + "s"}`;
 
   // Heading levels offered in the text-style dropdown.
   const HEADING_LEVELS = [1, 2, 3, 4, 5, 6] as const;

--- a/apps/frontend/src/lib/format.ts
+++ b/apps/frontend/src/lib/format.ts
@@ -94,13 +94,15 @@ export function readTimeFromWords(words: number): number {
 // renders one way in the server's HTML and another on hydration, and the reader
 // sees it change under them. `$lib/timezone` resolves the zone to pass in.
 //
-// The locale is pinned for the same reason — the server's default locale is not
-// the browser's, and an unpinned one turns "Aug 3, 2026" into "3 avq 2026" on
-// hydration. The UI is English throughout, so en-US is the honest choice.
-const LOCALE = "en-US";
+// Locale is the same story — the server's default is not the browser's, and an
+// unpinned one turns "Aug 3, 2026" into "3 avq 2026" on hydration. Every helper
+// therefore takes an explicit `locale` (from `$lib/locale`, which mirrors the
+// timezone cookie/Accept-Language dance) and falls back to `en-US` only when
+// nothing was resolved yet. Callers should pass `$locale` alongside `$timeZone`.
+const FALLBACK_LOCALE = "en-US";
 
-export function formatDate(iso: string, timeZone?: string): string {
-  return new Date(iso).toLocaleDateString(LOCALE, {
+export function formatDate(iso: string, timeZone?: string, locale?: string): string {
+  return new Date(iso).toLocaleDateString(locale ?? FALLBACK_LOCALE, {
     month: "short",
     day: "numeric",
     year: "numeric",
@@ -110,7 +112,9 @@ export function formatDate(iso: string, timeZone?: string): string {
 
 // Compact relative time, e.g. "now", "5m", "3h", "2d", falling back to an
 // absolute date past a week. Used where space is tight (notification rows).
-export function timeAgo(iso: string, timeZone?: string): string {
+// `locale` only affects the absolute fallback (the compact tokens are
+// language-agnostic).
+export function timeAgo(iso: string, timeZone?: string, locale?: string): string {
   const diff = Date.now() - new Date(iso).getTime();
   const s = Math.max(0, Math.floor(diff / 1000));
   if (s < 60) return "now";
@@ -120,14 +124,43 @@ export function timeAgo(iso: string, timeZone?: string): string {
   if (h < 24) return `${h}h`;
   const d = Math.floor(h / 24);
   if (d < 7) return `${d}d`;
-  return formatDate(iso, timeZone);
+  return formatDate(iso, timeZone, locale);
+}
+
+// Localized, human relative time — e.g. "2 days ago", "2 gün əvvəl",
+// "vor 2 Tagen" via `Intl.RelativeTimeFormat`. Used where the spec asks for
+// nisbi zaman rather than the compact `timeAgo` above.
+export function formatRelative(iso: string, locale?: string): string {
+  const diffMs = new Date(iso).getTime() - Date.now();
+  const sec = Math.round(diffMs / 1000);
+  const absSec = Math.abs(sec);
+  const loc = locale ?? FALLBACK_LOCALE;
+  try {
+    const rtf = new Intl.RelativeTimeFormat(loc, { numeric: "auto" });
+    if (absSec < 60) return rtf.format(sec, "second");
+    const min = Math.round(sec / 60);
+    if (Math.abs(min) < 60) return rtf.format(min, "minute");
+    const hr = Math.round(sec / 3600);
+    if (Math.abs(hr) < 24) return rtf.format(hr, "hour");
+    const day = Math.round(sec / 86400);
+    if (Math.abs(day) < 7) return rtf.format(day, "day");
+    const week = Math.round(sec / 604800);
+    if (Math.abs(week) < 5) return rtf.format(week, "week");
+    const month = Math.round(sec / 2629746);
+    if (Math.abs(month) < 12) return rtf.format(month, "month");
+    const year = Math.round(sec / 31556952);
+    return rtf.format(year, "year");
+  } catch {
+    // Fallback for unknown locale — fall back to compact timeAgo logic.
+    return timeAgo(iso, undefined, loc);
+  }
 }
 
 // 24h hh:mm clock time, e.g. "14:05". Separate from `formatDateTime` so a
 // caller that has room for the day but not the time — a feed card on a phone —
 // can drop just the time rather than reformatting the whole stamp.
-export function formatTime(iso: string, timeZone?: string): string {
-  return new Date(iso).toLocaleTimeString(LOCALE, {
+export function formatTime(iso: string, timeZone?: string, locale?: string): string {
+  return new Date(iso).toLocaleTimeString(locale ?? FALLBACK_LOCALE, {
     hour: "2-digit",
     minute: "2-digit",
     hour12: false,
@@ -135,17 +168,40 @@ export function formatTime(iso: string, timeZone?: string): string {
   });
 }
 
-// Date plus 24h hh:mm time, e.g. "Jul 8, 2026, 14:05".
-export function formatDateTime(iso: string, timeZone?: string): string {
-  return `${formatDate(iso, timeZone)}, ${formatTime(iso, timeZone)}`;
+// Date plus 24h hh:mm time — e.g. "Aug 18, 2026, 13:40" in en-US or
+// "18 avq 2026 13:40" in az. A single `toLocaleString` call lets `Intl` handle
+// the punctuation for the active locale, rather than a manual
+// `${date}, ${time}` which produced the stray "2026 , 13:40" (space before
+// comma) and ignored the locale's own separator.
+export function formatDateTime(iso: string, timeZone?: string, locale?: string): string {
+  return new Date(iso).toLocaleString(locale ?? FALLBACK_LOCALE, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+    timeZone,
+  });
 }
 
 // The forward-looking counterpart to `timeAgo`, and deliberately wordier: this
 // one appears where the reader is deciding whether a time is what they meant
 // ("in 2 days"), not scanning a list of things that already happened.
-export function timeUntil(iso: string): string {
+export function timeUntil(iso: string, locale?: string): string {
   const ms = new Date(iso).getTime() - Date.now();
   if (ms <= 0) return "any moment now";
+  const loc = locale ?? FALLBACK_LOCALE;
+  // Prefer localized relative for future as well when a non-English locale is
+  // active — "2 gün sonra" reads better than "in 2 days" for an Azerbaijani
+  // reader. `formatRelative` already handles future via positive `diff`.
+  if (loc !== FALLBACK_LOCALE) {
+    try {
+      return formatRelative(iso, loc);
+    } catch {
+      // fall through to English wordy form
+    }
+  }
   const m = Math.round(ms / 60_000);
   if (m < 1) return "in under a minute";
   if (m < 60) return `in ${m} minute${m === 1 ? "" : "s"}`;
@@ -163,21 +219,24 @@ export function timeUntil(iso: string): string {
 // reader is confirming a time they are about to commit to rather than glancing
 // at one, so nothing is shortened: the weekday is spelled out because "is that
 // a Thursday?" is exactly the question someone scheduling a post asks.
-export function formatScheduleLong(iso: string, timeZone?: string): string {
-  const date = new Date(iso).toLocaleDateString(LOCALE, {
+export function formatScheduleLong(iso: string, timeZone?: string, locale?: string): string {
+  const date = new Date(iso).toLocaleDateString(locale ?? FALLBACK_LOCALE, {
     weekday: "long",
     day: "numeric",
     month: "long",
     year: "numeric",
     timeZone,
   });
-  return `${date} at ${formatTime(iso, timeZone)}`;
+  return `${date} at ${formatTime(iso, timeZone, locale)}`;
 }
 
 // The zone a time is being read in, as a short offset like "GMT+4". Shown
 // beside any time the author is choosing: a schedule is the one place where
 // "09:00 in whose morning?" has a wrong answer.
-export function zoneLabel(timeZone?: string): string {
-  const parts = new Intl.DateTimeFormat(LOCALE, { timeZone, timeZoneName: "shortOffset" }).formatToParts(new Date());
+export function zoneLabel(timeZone?: string, locale?: string): string {
+  const parts = new Intl.DateTimeFormat(locale ?? FALLBACK_LOCALE, {
+    timeZone,
+    timeZoneName: "shortOffset",
+  }).formatToParts(new Date());
   return parts.find((p) => p.type === "timeZoneName")?.value ?? "";
 }

--- a/apps/frontend/src/lib/locale.ts
+++ b/apps/frontend/src/lib/locale.ts
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { browser } from "$app/environment";
+import { page } from "$app/stores";
+import { derived, writable, type Readable } from "svelte/store";
+
+// User locale — mirrors `timezone.ts` but for `Intl` formatting. The server has
+// no navigator, so it reads the locale from a cookie (set by the browser) or
+// from the `Accept-Language` header. The browser writes its `navigator.language`
+// to the cookie on hydration, so server and client agree and no timestamp
+// flickers between `Aug 18` and `18 avq` (see `format.ts`).
+
+export const LOCALE_COOKIE = "locale";
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365;
+const FALLBACK = "en-US";
+
+const localLocale = writable<string | null>(null);
+
+/** The locale every date on the page is formatted with. Falls back to en-US. */
+export const locale: Readable<string> = derived([page, localLocale], ([$page, $local]) => {
+  const fromPage = ($page.data as { locale?: string | null }).locale;
+  return $local ?? fromPage ?? FALLBACK;
+});
+
+/** Publish the browser's locale to the cookie and to `locale`. Call once, on mount. */
+export function rememberLocale(): void {
+  if (!browser) return;
+  const raw = navigator.language;
+  const valid = validLocale(raw);
+  if (!valid) return;
+  localLocale.set(valid);
+  document.cookie = `${LOCALE_COOKIE}=${encodeURIComponent(valid)}; path=/; max-age=${COOKIE_MAX_AGE}; SameSite=Lax`;
+}
+
+/**
+ * Validate a locale string via `Intl`. Anything unknown is dropped and the
+ * caller falls back to `en-US`.
+ */
+export function validLocale(value: string | undefined | null): string | null {
+  if (!value) return null;
+  try {
+    const canonical = Intl.getCanonicalLocales(value)[0];
+    // Also ensure DateTimeFormat accepts it (e.g. "en-US" does, "xx" throws).
+    new Intl.DateTimeFormat(canonical);
+    return canonical;
+  } catch {
+    return null;
+  }
+}
+
+/** Parse the first valid locale from an `Accept-Language` header value. */
+export function localeFromAcceptLanguage(header: string | null | undefined): string | null {
+  if (!header) return null;
+  const parts = header
+    .split(",")
+    .map((part, index) => {
+      const [tag, ...params] = part
+        .trim()
+        .split(";")
+        .map((p) => p.trim());
+      const qMatch = params.map((p) => /^q=([\d.]+)$/i.exec(p)).find((m) => m != null);
+      const q = qMatch ? Number(qMatch[1]) : 1;
+      return { tag, q, index };
+    })
+    .filter((e) => e.tag && Number.isFinite(e.q) && e.q > 0)
+    .sort((a, b) => b.q - a.q || a.index - b.index);
+  for (const { tag } of parts) {
+    const v = validLocale(tag);
+    if (v) return v;
+  }
+  return null;
+}

--- a/apps/frontend/src/routes/+layout.server.ts
+++ b/apps/frontend/src/routes/+layout.server.ts
@@ -1,6 +1,7 @@
-import { endpoints } from "$lib/api";
-import { TZ_COOKIE, validTimeZone } from "$lib/timezone";
 // SPDX-License-Identifier: AGPL-3.0-or-later
+import { endpoints } from "$lib/api";
+import { LOCALE_COOKIE, localeFromAcceptLanguage, validLocale } from "$lib/locale";
+import { TZ_COOKIE, validTimeZone } from "$lib/timezone";
 import { redirect } from "@sveltejs/kit";
 import type { LayoutServerLoad } from "./$types";
 
@@ -11,13 +12,19 @@ const DISCOVER_ROUTES = new Set(["/", "/[handle]"]);
 // Resolves the current user once for every page (used by the nav + guards) and,
 // on the routes that show it, the discovery rail — server-side, in parallel, so
 // the rail renders with the page instead of popping in after client hydration.
-export const load: LayoutServerLoad = async ({ cookies, fetch, route }) => {
+export const load: LayoutServerLoad = async ({ cookies, fetch, route, request }) => {
   const api = endpoints(fetch);
 
   // The reader's own timezone, parked in a cookie by the browser on their last
   // visit, so dates render server-side in the zone they'll still be in after
   // hydration instead of flipping from UTC. See $lib/timezone.
   const timeZone = validTimeZone(cookies.get(TZ_COOKIE));
+
+  // Locale for date formatting: cookie wins, then Accept-Language, then fallback.
+  // Mirrors `timezone.ts` — server and client must agree or the timestamp
+  // flickers between `Aug 18` and `18 avq` on hydration.
+  const locale =
+    validLocale(cookies.get(LOCALE_COOKIE)) ?? localeFromAcceptLanguage(request.headers.get("accept-language")) ?? null;
 
   // First-run gate: until the instance is set up, every route is redirected to
   // the wizard; once set up, the wizard route redirects back into the app. If
@@ -58,5 +65,5 @@ export const load: LayoutServerLoad = async ({ cookies, fetch, route }) => {
 
   const seo = await seoPromise;
 
-  return { user, discover, instance, seo, timeZone };
+  return { user, discover, instance, seo, timeZone, locale };
 };

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -12,6 +12,7 @@
   import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
   import { absoluteBanner, postCardUrl } from "$lib/cover";
   import { excerpt } from "$lib/format";
+  import { rememberLocale } from "$lib/locale";
   import { blogPostingLd, breadcrumbLd, profilePageLd, serializeJsonLd, webSiteLd } from "$lib/seo";
   import { rememberTimeZone } from "$lib/timezone";
   import type { Post, Profile, ReadingList } from "$lib/types";
@@ -19,12 +20,14 @@
 
   let { data, children }: { data: LayoutData; children: import("svelte").Snippet } = $props();
 
-  // Hand the reader's timezone to the server for the *next* render, and switch
-  // this one over to it now that we're past hydration. On every visit but the
-  // very first the cookie is already there and this changes nothing on screen —
-  // which is the point: no timestamp flipping hours after the page paints.
+  // Hand the reader's timezone/locale to the server for the *next* render, and
+  // switch this one over to it now that we're past hydration. On every visit
+  // but the very first the cookies are already there and this changes nothing on
+  // screen — which is the point: no timestamp flickering between `Aug 18` and
+  // `18 avq` (locale) or jumping hours (timezone) after the page paints.
   $effect(() => {
     rememberTimeZone();
+    rememberLocale();
   });
 
   // Site-wide social-share defaults. Pages may set their own <title>; these

--- a/apps/frontend/src/routes/[handle]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/+page.svelte
@@ -13,11 +13,10 @@
   import ReadingListCard from "$lib/components/ReadingListCard.svelte";
   import RssButton from "$lib/components/RssButton.svelte";
   import TagList from "$lib/components/TagList.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
-  import { formatDate } from "$lib/format";
   import { platformMeta } from "$lib/profileLinks";
-  import { timeZone } from "$lib/timezone";
   import type { Post } from "$lib/types";
   import { Tabs, Separator } from "bits-ui";
   import { onMount, untrack } from "svelte";
@@ -417,7 +416,7 @@
           <dt class="flex items-center gap-2 text-sm text-muted-foreground">
             <Icon name="calendar" size={15} /> Joined
           </dt>
-          <dd class="text-sm text-foreground">{formatDate(data.profile.user.createdAt, $timeZone)}</dd>
+          <dd class="text-sm text-foreground"><Time iso={data.profile.user.createdAt} kind="date" /></dd>
         </div>
 
         {#if isAdmin}

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -9,12 +9,12 @@
   import RecommendButton from "$lib/components/RecommendButton.svelte";
   import SaveToListButton from "$lib/components/SaveToListButton.svelte";
   import TagList from "$lib/components/TagList.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import { countLabel, formatDateTime, readTime } from "$lib/format";
+  import { countLabel, readTime } from "$lib/format";
   import { languageLabel } from "$lib/languages";
-  import { timeZone } from "$lib/timezone";
   import { Dialog, DropdownMenu, Label, Separator } from "bits-ui";
   import { untrack } from "svelte";
   import type { PageData } from "./$types";
@@ -269,7 +269,7 @@
         {post.author.displayName}
       </Button>
       <div class="flex flex-col gap-1 text-muted-foreground sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
-        <span>{formatDateTime(post.createdAt, $timeZone)}</span>
+        <Time iso={post.createdAt} />
         <Separator.Root orientation="vertical" class="hidden shrink-0 bg-border sm:block sm:h-3 sm:w-px" />
         <span class="flex items-center gap-1"><Icon name="clock" size={13} /> {minutes} min read</span>
         {#if post.remote && originInstance}

--- a/apps/frontend/src/routes/dashboard/+page.svelte
+++ b/apps/frontend/src/routes/dashboard/+page.svelte
@@ -2,7 +2,8 @@
 <script lang="ts">
   import Icon, { type IconName } from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
-  import { formatDateTime } from "$lib/format";
+  import Time from "$lib/components/Time.svelte";
+  import { locale } from "$lib/locale";
   import { timeZone } from "$lib/timezone";
   import type { DashboardSummary, PostStat } from "$lib/types";
   import type { PageData } from "./$types";
@@ -117,7 +118,7 @@
   const engFrac = (p: PostStat) => engPerDay(p) / maxPerDay;
 
   function dayLabel(iso: string): string {
-    return new Date(iso).toLocaleDateString("en-US", {
+    return new Date(iso).toLocaleDateString($locale, {
       month: "short",
       day: "numeric",
       timeZone: $timeZone,
@@ -321,7 +322,7 @@
                     {p.title || "Untitled"}
                   </a>
                 </div>
-                <p class="mt-0.5 text-xs text-muted-foreground">{formatDateTime(p.createdAt, $timeZone)}</p>
+                <p class="mt-0.5 text-xs text-muted-foreground"><Time iso={p.createdAt} /></p>
               </td>
               {#if showViews}
                 <td class="px-3 py-3 text-right text-foreground tabular-nums">{fmt(p.views)}</td>

--- a/apps/frontend/src/routes/posts/manage/+page.svelte
+++ b/apps/frontend/src/routes/posts/manage/+page.svelte
@@ -5,10 +5,12 @@
   import Icon, { type IconName } from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import ScheduleDialog from "$lib/components/ScheduleDialog.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import { excerpt, formatDateTime, formatScheduleLong, timeUntil } from "$lib/format";
+  import { excerpt, formatScheduleLong, timeUntil } from "$lib/format";
   import { postPath } from "$lib/links";
+  import { locale } from "$lib/locale";
   import { timeZone } from "$lib/timezone";
   import type { OwnPostStatus, Post } from "$lib/types";
   import { DropdownMenu, Tabs } from "bits-ui";
@@ -273,13 +275,13 @@
                      record, so it says both when and how soon. -->
                 <span class="inline-flex items-center gap-1 font-medium text-foreground">
                   <Icon name="clock" size={12} />
-                  Publishes {formatScheduleLong(post.publishAt, $timeZone)}
+                  Publishes {formatScheduleLong(post.publishAt, $timeZone, $locale)}
                 </span>
-                · {timeUntil(post.publishAt)}
+                · {timeUntil(post.publishAt, $locale)}
               {:else if tab.value === "published"}
-                Published {formatDateTime(post.createdAt, $timeZone)}
+                Published <Time iso={post.createdAt} />
               {:else}
-                Last edited {formatDateTime(post.updatedAt ?? post.createdAt, $timeZone)}
+                Last edited <Time iso={post.updatedAt ?? post.createdAt} />
               {/if}
             </span>
           </Button>

--- a/apps/frontend/src/routes/settings/+page.svelte
+++ b/apps/frontend/src/routes/settings/+page.svelte
@@ -11,18 +11,17 @@
   import PageTitle from "$lib/components/PageTitle.svelte";
   import ProfileLinksEditor from "$lib/components/ProfileLinksEditor.svelte";
   import TagInput from "$lib/components/TagInput.svelte";
+  import Time from "$lib/components/Time.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import WebhookTokensManager from "$lib/components/WebhookTokensManager.svelte";
   import { AVATAR_MAX_DIMENSION, prepareImage } from "$lib/editor/image";
   import { insertEmojiIntoField, emojiOverlayBtn } from "$lib/emoji";
-  import { formatDate } from "$lib/format";
   import { LANGUAGES, languageLabel } from "$lib/languages";
   import { reading, type FeedLangMode, type FeedTab } from "$lib/prefs.svelte";
   import { identifierToUrl, platformMeta, urlToIdentifier } from "$lib/profileLinks";
   import { MAX_PROFILE_TAGS } from "$lib/tags";
   import { theme, type ThemePreference } from "$lib/theme.svelte";
-  import { timeZone } from "$lib/timezone";
   import type { ProfileLink } from "$lib/types";
   import { Button as ButtonPrimitive, Dialog, Label, Select, Switch } from "bits-ui";
   import { untrack } from "svelte";
@@ -779,7 +778,7 @@
       </div>
       <div class="flex items-center justify-between gap-4">
         <dt class="text-muted-foreground">Joined</dt>
-        <dd class="font-medium text-foreground">{formatDate(data.user.createdAt, $timeZone)}</dd>
+        <dd class="font-medium text-foreground"><Time iso={data.user.createdAt} kind="date" /></dd>
       </div>
     </dl>
 


### PR DESCRIPTION
## Symptom
Tarix formatı baqlıdır və lokalizə olunmayıb. Çıxış "Aug 18, 2026 , 13:40" — vergüldən əvvəl artıq boşluq, saat qurşağı yoxdur, bütün dillər üçün ingiliscə. No `<time datetime>`, no nisbi zaman ("2 gün əvvəl"), not user-locale aware. Hydration assumed en-US so "Aug 18" flickered to "18 avq".

## Root cause
- `format.ts:100-140` pinned `LOCALE="en-US"" with manual `${formatDate}, ${formatTime}`` — extra " , " and ignored locale. Every helper read no zone/locale from stores, so title had no zone/relative fallback.
- No locale cookie/header plumbing (unlike timezone), so SSR rendered en-US while browser wanted az/TR.

## Fix
- **Locale plumbing** — `locale.ts` (cookie `locale` + `Accept-Language` parser, mirrors `timezone.ts`), `+layout.server.ts:14` reads cookie → header → null, `+layout.svelte:27` calls `rememberLocale()` on mount. Both renders agree.
- **format.ts** — all helpers now `(iso, timeZone?, locale?)` with `en-US` fallback; `formatDateTime` uses single `toLocaleString` (date+time) so Intl handles punctuation per locale (fixes "2026 , 13:40"); added `formatRelative()` via `Intl.RelativeTimeFormat` ("2 days ago" / "2 gün öncə"); `zoneLabel(timeZone, locale)` and `timeUntil` localized.
- **Semantic time** — new `Time.svelte` renders `<time datetime={iso} title="abs + GMT+4">` localized via `$locale/$timeZone`, optional relative within 30d, `withZone` param; replaces spans in PostCard (`PostCard.svelte:11`), post header (`[handle]/[slug]/+page.svelte:15`), comments (`CommentNode.svelte:17`), dashboard/maranage/profile/settings/admin lists, SaveStatus/Editor.

Verified: `pnpm fmt` 176, `svelte-check` 0, `vitest` 26/26.