### PR TITLE
fix(seo): home title/desc 150-160, unique tag/profile titles

### DIFF
--- a/apps/frontend/src/lib/components/PageTitle.svelte
+++ b/apps/frontend/src/lib/components/PageTitle.svelte
@@ -15,7 +15,9 @@
   without threading layout data down to it.
 
   Omit `text` on a page that is the site itself (the home feed) and the title is
-  the instance name alone, with no leading separator.
+  the instance name plus its tagline — `Omicron: fediverse üzərində müstəqil
+  bloq platforması` — so the home tab, bookmark and search result carry the
+  same promise a reader sees in the hero.
 -->
 <script lang="ts">
   import { page } from "$app/stores";
@@ -27,8 +29,9 @@
   const appName = $derived(
     ($page.data as { instance?: InstanceInfo | null }).instance?.name || env.PUBLIC_APP_NAME || "Omicron",
   );
+  const homeTitle = $derived(`${appName}: fediverse üzərində müstəqil bloq platforması`);
 </script>
 
 <svelte:head>
-  <title>{text ? `${text} · ${appName}` : appName}</title>
+  <title>{text ? `${text} · ${appName}` : homeTitle}</title>
 </svelte:head>

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -35,7 +35,12 @@
   // name comes from the instance settings (wizard/admin), falling back to the
   // build-time env and then the default.
   const appName = $derived(data.instance?.name || env.PUBLIC_APP_NAME || "Omicron");
-  const description = "A place to read, write, and connect — powered by ActivityPub. No lock-in, fully self-hostable.";
+  const homeTitle = $derived(`${appName}: fediverse üzərində müstəqil bloq platforması`);
+  // 155 chars for `Omicron` (adjusts with instance name): hits the 150–160 target
+  // search engines show without truncation and matches the hero.
+  const description = $derived(
+    `${appName} — fediverse üzərində müstəqil bloq platforması. Yaz, paylaş, kəşf et. ActivityPub ilə birləş, məlumatların sənə aid olsun və öz instansiyanı işlət.`,
+  );
   // Every absolute URL we publish — the canonical link, og:url, the share image
   // — is built on the instance's configured origin rather than the hostname this
   // request happened to arrive on, so an article has one address wherever it is
@@ -60,10 +65,42 @@
   const creator = $derived(
     post ? (post.author.remote ? `@${post.author.username}` : `@${post.author.username}@${$page.url.host}`) : null,
   );
-  const ogTitle = $derived(post?.title || appName);
+  // Home, tag and profile reuse the same title pattern as PageTitle (homeTitle,
+  // `#tag · App`, `DisplayName · App`) so the tab and the link preview agree.
+  const ogTitle = $derived.by(() => {
+    if (post?.title) return post.title;
+    if ($page.route.id === "/") return homeTitle;
+    const pd = $page.data as {
+      profile?: { user: { displayName: string } };
+      detail?: { tag: { name: string } };
+    };
+    if ($page.route.id === "/[handle]" && pd.profile) return `${pd.profile.user.displayName} · ${appName}`;
+    if ($page.route.id === "/tags/[tag]" && pd.detail?.tag) return `#${pd.detail.tag.name} · ${appName}`;
+    return appName;
+  });
   // An ingested post carries the sender's own `description`; prefer it over a
-  // clipped body, which is only ever a stand-in for one.
-  const ogDescription = $derived(post ? post.summary?.trim() || ogExcerpt(post.contentHtml) : description);
+  // clipped body, which is only ever a stand-in for one. Tag/profile fall back
+  // to a unique per-page description so each URL has its own snippet in the
+  // index (home already has one via `description`).
+  const ogDescription = $derived.by(() => {
+    if (post) return post.summary?.trim() || ogExcerpt(post.contentHtml);
+    if ($page.route.id === "/") return description;
+    const pd = $page.data as {
+      profile?: { user: { displayName: string; username: string; bio: string } };
+      detail?: { tag: { name: string }; postCount: number; followerCount: number };
+    };
+    if ($page.route.id === "/[handle]" && pd.profile) {
+      const u = pd.profile.user;
+      const bio = u.bio?.trim();
+      if (bio) return bio.length > 160 ? `${bio.slice(0, 157)}…` : bio;
+      return `Read articles by ${u.displayName} (@${u.username.split("@")[0]}) on ${appName} — follow their writing across the fediverse.`;
+    }
+    if ($page.route.id === "/tags/[tag]" && pd.detail) {
+      const d = pd.detail;
+      return `Explore #${d.tag.name} on ${appName} — ${d.postCount} ${d.postCount === 1 ? "article" : "articles"}, ${d.followerCount} ${d.followerCount === 1 ? "follower" : "followers"}. Discover writers and posts tagged #${d.tag.name} across the fediverse.`;
+    }
+    return description;
+  });
   const ogType = $derived(post ? "article" : "website");
   // A post's banner becomes its share image, falling back to the instance's
   // brand image. `bannerUrl` rather than `coverUrl`, so a post whose banner is

--- a/apps/frontend/src/routes/about/+page.svelte
+++ b/apps/frontend/src/routes/about/+page.svelte
@@ -11,7 +11,7 @@
   const sourceUrl = env.PUBLIC_SOURCE_URL || "https://github.com/the-jk-labs/omicron";
 </script>
 
-<PageTitle text="About · {appName}" />
+<PageTitle text="About" />
 
 <article class="mx-auto max-w-3xl">
   <h1 class="text-3xl font-bold tracking-tight text-foreground">About {appName}</h1>

--- a/apps/frontend/src/routes/contact/+page.svelte
+++ b/apps/frontend/src/routes/contact/+page.svelte
@@ -13,7 +13,7 @@
   const abuseEmail = (env.PUBLIC_ABUSE_EMAIL as string | undefined)?.trim() || contactEmail;
 </script>
 
-<PageTitle text="Contact · {appName}" />
+<PageTitle text="Contact" />
 
 <article class="mx-auto max-w-3xl">
   <h1 class="text-3xl font-bold tracking-tight text-foreground">Contact</h1>

--- a/apps/frontend/src/routes/privacy/+page.svelte
+++ b/apps/frontend/src/routes/privacy/+page.svelte
@@ -10,7 +10,7 @@
   const domain = $derived(instance?.domain ?? "this instance");
 </script>
 
-<PageTitle text="Privacy · {appName}" />
+<PageTitle text="Privacy" />
 
 <article class="mx-auto max-w-3xl">
   <h1 class="text-3xl font-bold tracking-tight text-foreground">Privacy policy</h1>

--- a/apps/frontend/src/routes/status/+page.svelte
+++ b/apps/frontend/src/routes/status/+page.svelte
@@ -10,7 +10,7 @@
   const statusExternal = (env.PUBLIC_STATUS_URL as string | undefined)?.trim() || "";
 </script>
 
-<PageTitle text="Status · {appName}" />
+<PageTitle text="Status" />
 
 <article class="mx-auto max-w-3xl">
   <h1 class="text-3xl font-bold tracking-tight text-foreground">Status</h1>


### PR DESCRIPTION
## Symptom
Ana səhifə `<title>` sadəcə "Omicron"dur (`PageTitle.svelte:33` fallback), halbuki `/login` üçün "Sign in · Omicron" düzgün qurulub — şablon var, sadəcə ana səhifədə istifadə olunmur. Meta təsvir 94 simvol generic ingiliscə ("A place to read…"), SERP-də kəsilir; teq/profil səhifələri eyni təsviri təkrarlayır, hər URL üçün unikal snippet yoxdur.

## Root cause
- `PageTitle.svelte:33` `text ? `${text} · ${appName}` : appName` — `<PageTitle />` (home) appName tək qaytarır.
- `+layout.svelte:38` description statik 94 simvol, `ogTitle/description:63` yalnız post-u nəzərə alır, tag/profile fallback generic-ə düşür → duplicate titles/descriptions.
- `about/contact/privacy/status/+page.svelte:14` `About · {appName}` ikiqat suffix → "About · App · App".

## Fix
- **PageTitle** — home fallback indi `${appName}: fediverse üzərində müstəqil bloq platforması` (spec-dəki "Omicron: …" tipli başlıq, hero ilə eyni vəd) `homeTitle` derived ilə.
- **Layout** — description `derived` olub 155 simvol: "${appName} — fediverse üzərində müstəqil bloq platforması. Yaz, paylaş, kəşf et. ActivityPub ilə birləş, məlumatların sənə aid olsun və öz instansiyanı işlət." (150–160 hədəf). `ogTitle/ogDescription:63` route-aware: "/" → homeTitle/description, "/[handle]" → "DisplayName · App" + bio və ya fallback, "/tags/[tag]" → "#tag · App" + "Explore #tag — N articles…" — hər teq/profil üçün unikal title/description (PageTitle ilə uyğun, OG preview də unikal).
- **Double-suffix** — 4 səhifə plain "About/Contact/Privacy/Status".

Verified: `pnpm fmt` 176, `svelte-check` 0, `vitest` 26/26.