### PR TITLE
fix(i18n): card lang/hreflang, feed filter on home, og:locale/hreflang, oxuduğum dillər

### DIFF
--- a/apps/frontend/src/lib/components/FeedLanguageFilter.svelte
+++ b/apps/frontend/src/lib/components/FeedLanguageFilter.svelte
@@ -1,0 +1,101 @@
+<!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
+<script lang="ts">
+  import Icon from "$lib/components/Icon.svelte";
+  import { LANGUAGES, languageLabel } from "$lib/languages";
+  import { reading, type FeedLangMode } from "$lib/prefs.svelte";
+  import { Button as ButtonPrimitive, Select } from "bits-ui";
+
+  let { compact = false }: { compact?: boolean } = $props();
+
+  const langModeOptions: { value: FeedLangMode; label: string }[] = [
+    { value: "hide", label: "Hide these" },
+    { value: "show", label: "Show only these" },
+  ];
+  const availableLanguages = $derived(LANGUAGES.filter((l) => !reading.feedLangs.includes(l.code)));
+  let addLangValue = $state("");
+  function addLanguage(code: string) {
+    if (code) reading.addFeedLang(code);
+    addLangValue = "";
+  }
+</script>
+
+<div class={compact ? "" : "mt-6 border-t border-border pt-6"}>
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+    <div>
+      <p class="flex items-center gap-1.5 text-sm font-medium text-foreground">
+        <Icon name="languages" size={15} /> Oxuduğum dillər · Feed languages
+      </p>
+      <p class="text-xs text-muted-foreground">
+        Filter which languages appear in your Local and Global feeds. Articles with no set language are always shown.
+      </p>
+    </div>
+    <div
+      class="inline-flex items-center gap-1 self-start rounded-input border border-input bg-background-alt p-1 shadow-btn sm:self-auto"
+    >
+      {#each langModeOptions as opt (opt.value)}
+        <ButtonPrimitive.Root
+          onclick={() => reading.setFeedLangMode(opt.value)}
+          aria-pressed={reading.feedLangMode === opt.value}
+          class={`inline-flex h-8 items-center rounded-button px-3 text-sm font-medium whitespace-nowrap active:scale-[0.98] ${
+            reading.feedLangMode === opt.value
+              ? "bg-background text-foreground shadow-mini"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          {opt.label}
+        </ButtonPrimitive.Root>
+      {/each}
+    </div>
+  </div>
+
+  <div class="mt-4 flex flex-wrap items-center gap-2">
+    {#each reading.feedLangs as code (code)}
+      <span
+        class="inline-flex items-center gap-1.5 rounded-button border border-border bg-muted py-1 pr-1.5 pl-3 text-sm text-foreground"
+      >
+        {languageLabel(code)}
+        <ButtonPrimitive.Root
+          onclick={() => reading.removeFeedLang(code)}
+          aria-label={`Remove ${languageLabel(code)}`}
+          class="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground hover:bg-dark-10 hover:text-foreground"
+        >
+          <Icon name="close" size={13} />
+        </ButtonPrimitive.Root>
+      </span>
+    {/each}
+
+    {#if availableLanguages.length > 0}
+      <Select.Root type="single" value={addLangValue} onValueChange={addLanguage}>
+        <Select.Trigger
+          class="inline-flex h-9 items-center gap-1.5 rounded-input border border-border-input bg-background px-3 text-sm text-muted-foreground shadow-btn outline-hidden transition-colors hover:text-foreground focus:border-foreground"
+          aria-label="Add a language"
+        >
+          <Icon name="plus" size={15} /> Add language
+        </Select.Trigger>
+        <Select.Portal>
+          <Select.Content
+            class="z-50 max-h-72 w-52 overflow-y-auto rounded-card border border-muted bg-background p-1 shadow-popover"
+            sideOffset={6}
+          >
+            <Select.Viewport>
+              {#each availableLanguages as lang (lang.code)}
+                <Select.Item
+                  value={lang.code}
+                  label={lang.name}
+                  class="flex h-9 w-full items-center gap-2 rounded-button px-2 text-sm outline-hidden select-none data-highlighted:bg-muted"
+                >
+                  <span class="truncate">{lang.name}</span>
+                  <span class="truncate text-muted-foreground">{lang.native}</span>
+                </Select.Item>
+              {/each}
+            </Select.Viewport>
+          </Select.Content>
+        </Select.Portal>
+      </Select.Root>
+    {/if}
+  </div>
+
+  {#if reading.feedLangs.length === 0}
+    <p class="mt-2 text-xs text-muted-foreground">No filter set — articles in every language are shown.</p>
+  {/if}
+</div>

--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -47,7 +47,7 @@
   const originInstance = $derived(post.author.username.split("@")[1] ?? null);
 </script>
 
-<article class="py-5">
+<article class="py-5" lang={post.language ?? undefined}>
   {#if post.recommendedBy}
     <!-- "For you" feed only: this post reached the viewer because someone they
          follow recommended it, not because of its own author/date — flag that
@@ -78,6 +78,7 @@
     href={postPath(post)}
     variant="plain"
     aria-labelledby={post.title ? titleId : undefined}
+    hreflang={post.language ?? undefined}
     class="group block w-full text-left"
   >
     <div class="flex items-start gap-4">

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -306,6 +306,15 @@
       <meta property="article:author" content={creator} />
     {/if}
   {/if}
+  <!-- Language signals: per-card `lang`/`hreflang` covers the feed, this covers the page itself. A post declares its own language as the page language (hooks.server handles <html lang>) and advertises it via og:locale + hreflang so search engines don't misclassify AZ/PL/IT posts as English. -->
+  {#if post?.language}
+    <meta property="og:locale" content={post.language} />
+    <link rel="alternate" hreflang={post.language} href={canonical} />
+    <link rel="alternate" hreflang="x-default" href={canonical} />
+  {:else}
+    <meta property="og:locale" content="en" />
+    <link rel="alternate" hreflang="x-default" href={canonical} />
+  {/if}
   <!-- Screen readers reach a shared link through the card, not the page. -->
   <meta property="og:image:alt" content={post?.title ?? appName} />
   {#if feedLink}

--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -1,6 +1,7 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
   import { endpoints } from "$lib/api";
+  import FeedLanguageFilter from "$lib/components/FeedLanguageFilter.svelte";
   import Icon, { type IconName } from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import PostCard from "$lib/components/PostCard.svelte";
@@ -96,6 +97,21 @@
     if (reading.feedLangQuery() && activeTab !== "for-you") refetch(activeTab);
   });
 
+  // When the reader changes their language filter in the header or in settings,
+  // reload the currently visible timeline (Local/Global) so the mixed AZ/EN/PL/IT
+  // feed immediately reflects the choice. For-you is excluded — it is personal.
+  $effect(() => {
+    // track
+    void reading.feedLangs;
+    void reading.feedLangMode;
+    if (activeTab === "for-you") return;
+    // don't refetch before the initial tab's first load has settled
+    const feed = feeds.find((f) => f.value === activeTab);
+    if (!feed?.loaded || feed.loading) return;
+    // use untrack to avoid re-triggering on feed mutation
+    untrack(() => refetch(activeTab));
+  });
+
   // Discards a feed's cached page and reloads it (used when the language filter
   // must be re-applied to an already-loaded feed).
   function refetch(value: string) {
@@ -174,6 +190,11 @@
     {/if}
   {/if}
 {/snippet}
+
+<!-- Feed language filter — visible inline so AZ/EN/PL/IT posts are not a mixed wall. Saved in localStorage via reading prefs; Local/Global honour it, For you stays personal. Detailed control lives in Settings. -->
+<div class="mb-6 rounded-card border border-border bg-background p-4">
+  <FeedLanguageFilter compact />
+</div>
 
 <Tabs.Root bind:value={activeTab} onValueChange={ensureLoaded} class="w-full">
   <Tabs.List class="mb-2 flex items-center gap-6 text-sm font-medium">

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -251,7 +251,7 @@
 
 <PageTitle text={post.title ?? "Post"} />
 
-<article>
+<article lang={post.language ?? undefined}>
   {#if deleteError}
     <p class="mb-6 rounded-input border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
       {deleteError}

--- a/apps/frontend/src/routes/settings/+page.svelte
+++ b/apps/frontend/src/routes/settings/+page.svelte
@@ -6,6 +6,7 @@
   import ConnectionsManager from "$lib/components/ConnectionsManager.svelte";
   import CustomSectionEditor from "$lib/components/CustomSectionEditor.svelte";
   import EmojiTrigger from "$lib/components/EmojiTrigger.svelte";
+  import FeedLanguageFilter from "$lib/components/FeedLanguageFilter.svelte";
   import FollowedTagsManager from "$lib/components/FollowedTagsManager.svelte";
   import Icon, { type IconName } from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
@@ -17,13 +18,12 @@
   import WebhookTokensManager from "$lib/components/WebhookTokensManager.svelte";
   import { AVATAR_MAX_DIMENSION, prepareImage } from "$lib/editor/image";
   import { insertEmojiIntoField, emojiOverlayBtn } from "$lib/emoji";
-  import { LANGUAGES, languageLabel } from "$lib/languages";
-  import { reading, type FeedLangMode, type FeedTab } from "$lib/prefs.svelte";
+  import { reading, type FeedTab } from "$lib/prefs.svelte";
   import { identifierToUrl, platformMeta, urlToIdentifier } from "$lib/profileLinks";
   import { MAX_PROFILE_TAGS } from "$lib/tags";
   import { theme, type ThemePreference } from "$lib/theme.svelte";
   import type { ProfileLink } from "$lib/types";
-  import { Button as ButtonPrimitive, Dialog, Label, Select, Switch } from "bits-ui";
+  import { Button as ButtonPrimitive, Dialog, Label, Switch } from "bits-ui";
   import { untrack } from "svelte";
   import type { PageData } from "./$types";
 
@@ -88,19 +88,6 @@
 
   // Default to "For you" when no explicit choice has been saved yet.
   const currentFeed = $derived(reading.defaultFeed ?? "for-you");
-
-  // Feed language filter: a show/hide mode plus the chosen set of languages.
-  const langModeOptions: { value: FeedLangMode; label: string }[] = [
-    { value: "hide", label: "Hide these" },
-    { value: "show", label: "Show only these" },
-  ];
-  // Languages not already chosen — the options offered by the "Add" picker.
-  const availableLanguages = $derived(LANGUAGES.filter((l) => !reading.feedLangs.includes(l.code)));
-  let addLangValue = $state("");
-  function addLanguage(code: string) {
-    if (code) reading.addFeedLang(code);
-    addLangValue = "";
-  }
 
   const dirty = $derived(
     displayName !== data.user.displayName ||
@@ -573,88 +560,7 @@
       </div>
     </div>
 
-    <!-- Feed language filter -->
-    <div class="mt-6 border-t border-border pt-6">
-      <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
-        <div>
-          <p class="flex items-center gap-1.5 text-sm font-medium text-foreground">
-            <Icon name="languages" size={15} /> Feed languages
-          </p>
-          <p class="text-xs text-muted-foreground">
-            Filter which languages appear in your Local and Global feeds. Articles with no set language are always
-            shown.
-          </p>
-        </div>
-        <div
-          class="inline-flex items-center gap-1 self-start rounded-input border border-input bg-background-alt p-1 shadow-btn sm:self-auto"
-        >
-          {#each langModeOptions as opt (opt.value)}
-            <ButtonPrimitive.Root
-              onclick={() => reading.setFeedLangMode(opt.value)}
-              aria-pressed={reading.feedLangMode === opt.value}
-              class={`inline-flex h-8 items-center rounded-button px-3 text-sm font-medium whitespace-nowrap active:scale-[0.98] ${
-                reading.feedLangMode === opt.value
-                  ? "bg-background text-foreground shadow-mini"
-                  : "text-muted-foreground hover:text-foreground"
-              }`}
-            >
-              {opt.label}
-            </ButtonPrimitive.Root>
-          {/each}
-        </div>
-      </div>
-
-      <div class="mt-4 flex flex-wrap items-center gap-2">
-        {#each reading.feedLangs as code (code)}
-          <span
-            class="inline-flex items-center gap-1.5 rounded-button border border-border bg-muted py-1 pr-1.5 pl-3 text-sm text-foreground"
-          >
-            {languageLabel(code)}
-            <ButtonPrimitive.Root
-              onclick={() => reading.removeFeedLang(code)}
-              aria-label={`Remove ${languageLabel(code)}`}
-              class="inline-flex size-5 items-center justify-center rounded-full text-muted-foreground hover:bg-dark-10 hover:text-foreground"
-            >
-              <Icon name="close" size={13} />
-            </ButtonPrimitive.Root>
-          </span>
-        {/each}
-
-        {#if availableLanguages.length > 0}
-          <Select.Root type="single" value={addLangValue} onValueChange={addLanguage}>
-            <Select.Trigger
-              class="inline-flex h-9 items-center gap-1.5 rounded-input border border-border-input bg-background px-3 text-sm text-muted-foreground shadow-btn outline-hidden transition-colors hover:text-foreground focus:border-foreground"
-              aria-label="Add a language"
-            >
-              <Icon name="plus" size={15} /> Add language
-            </Select.Trigger>
-            <Select.Portal>
-              <Select.Content
-                class="z-50 max-h-72 w-52 overflow-y-auto rounded-card border border-muted bg-background p-1 shadow-popover"
-                sideOffset={6}
-              >
-                <Select.Viewport>
-                  {#each availableLanguages as lang (lang.code)}
-                    <Select.Item
-                      value={lang.code}
-                      label={lang.name}
-                      class="flex h-9 w-full items-center gap-2 rounded-button px-2 text-sm outline-hidden select-none data-highlighted:bg-muted"
-                    >
-                      <span class="truncate">{lang.name}</span>
-                      <span class="truncate text-muted-foreground">{lang.native}</span>
-                    </Select.Item>
-                  {/each}
-                </Select.Viewport>
-              </Select.Content>
-            </Select.Portal>
-          </Select.Root>
-        {/if}
-      </div>
-
-      {#if reading.feedLangs.length === 0}
-        <p class="mt-2 text-xs text-muted-foreground">No filter set — articles in every language are shown.</p>
-      {/if}
-    </div>
+    <FeedLanguageFilter />
   </section>
 
   <!-- Privacy -->


### PR DESCRIPTION
## Symptom
Məzmun çoxdilli, lakin dil metadata-sı zəif tətbiq olunub. Məqalə səhifəsində "English" etiketi var, deməli `post.language` bazada saxlanılır. Amma ana səhifə axınında AZ, EN, PL, IT postları qarışıq gəlir və kart səviyyəsində `lang` atributu görünmür — hər card screen reader və crawler üçün English. Feed-də dil filtri yalnız `/settings` dərinliyində, `hreflang`/`og:locale` heç yerdə.

## Root cause
- `PostCard.svelte:50` `<article>` `lang` yox, link `hreflang` yox — language stored but never rendered.
- `[handle]/[slug]/+page.svelte:254` `<article>` dil etiketi yox.
- `+layout.svelte:282` yalnız `description`/`ogTitle`, `hreflang`/`og:locale` yox; `hooks.server:108` `<html lang>` yalnız post page-də düzgündür, feed qarışıq qalır.
- `+page.svelte:67` Local/Global `reading.feedLangQuery()` honour edir, amma UI yalnız Settings-də — user feed-də filteri görmür, "oxuduğum dillər" profildə deyil.

## Fix
- **Per-card lang**: `PostCard` `article lang={post.language}` + `Button hreflang`, post article `<article lang>`. AZ/EN/PL/IT qarışığı hər card öz dilini bildirir.
- **Feed filter on home**: yeni `FeedLanguageFilter.svelte` (show/hide, chips, add language, başlıq "Oxuduğum dillər · Feed languages") — Settings və home-da reuse (`+page.svelte:178` tabs üstündə card). `$effect` feedLangs/mode dəyişəndə Local/Global refetch (For you excluded). LocalStorage-based, immediate.
- **hreflang/og:locale**: `+layout.svelte:283` post dilində `og:locale` + `hreflang={post.language}` + `x-default`, digər səhifələrdə `x-default`/`en`. Hooks.server `<html lang>` ilə birgə search engine dil siqnalı tamamlanır.
- **Settings**: label bilingual, component reuse.

Verified: `pnpm fmt` 177, `svelte-check` 0, `vitest` 26/26.
