### PR TITLE
fix(auth): 12+ password policy, HIBP k-anonymity, register validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,8 @@
 #SMTP_TLS=false            # implicit TLS (465); false = STARTTLS (587)
 # Require email confirmation before sign-in (for closed/invite instances).
 #EMAIL_VERIFICATION_REQUIRED=false
+# Have I Been Pwned check for leaked passwords (k-anonymity, no plaintext leaves the server).
+#HIBP_CHECK_ENABLED=true
 
 # ── Public entrypoint / HTTPS (Caddy) ──
 # The bundled Caddy is the public entrypoint. It gets a Let's Encrypt cert for

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -185,6 +185,13 @@ const schema = z.object({
     .string()
     .transform((v) => v.toLowerCase() === "true")
     .default(false),
+
+  // Have I Been Pwned k-anonymity check. When false, leaked-password checks are
+  // skipped entirely (air-gapped installs).
+  HIBP_CHECK_ENABLED: z
+    .string()
+    .transform((v) => v.toLowerCase() !== "false")
+    .default(true),
 });
 
 function load() {
@@ -214,6 +221,7 @@ function load() {
     SMTP_PASSWORD: Deno.env.get("SMTP_PASSWORD"),
     SMTP_TLS: Deno.env.get("SMTP_TLS"),
     EMAIL_VERIFICATION_REQUIRED: Deno.env.get("EMAIL_VERIFICATION_REQUIRED"),
+    HIBP_CHECK_ENABLED: Deno.env.get("HIBP_CHECK_ENABLED"),
   });
 
   if (!parsed.success) {

--- a/apps/backend/src/lib/hibp.ts
+++ b/apps/backend/src/lib/hibp.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Have I Been Pwned k-anonymity check for leaked passwords.
+// Only the first 5 hex chars of the SHA-1 are sent; the full hash never leaves the process.
+
+const HIBP_API = "https://api.pwnedpasswords.com/range/";
+const TIMEOUT_MS = 3500;
+
+function sha1HexUpper(input: string): Promise<string> {
+  const data = new TextEncoder().encode(input);
+  return crypto.subtle.digest("SHA-1", data).then((buf) => {
+    const bytes = new Uint8Array(buf);
+    let hex = "";
+    for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+    return hex.toUpperCase();
+  });
+}
+
+// Returns true when the password appears in the HIBP corpus.
+// Fail-open on network/timeout errors so registration is not blocked by an
+// external dependency (logged, but not surfaced to the caller).
+export async function isPwnedPassword(password: string): Promise<boolean> {
+  if (!password) return false;
+  try {
+    const hash = await sha1HexUpper(password);
+    const prefix = hash.slice(0, 5);
+    const suffix = hash.slice(5);
+    const controller = new AbortController();
+    const id = setTimeout(() => controller.abort(), TIMEOUT_MS);
+    let res: Response;
+    try {
+      res = await fetch(`${HIBP_API}${prefix}`, {
+        headers: { "Add-Padding": "true", "User-Agent": "omicron" },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(id);
+    }
+    if (!res.ok) {
+      // 429 or transient failure — don't block the user.
+      console.warn(`hibp: unexpected status ${res.status} for prefix ${prefix}`);
+      return false;
+    }
+    const text = await res.text();
+    const lines = text.split("\n");
+    for (const line of lines) {
+      const [hashSuffix] = line.trim().split(":");
+      if (hashSuffix && hashSuffix.toUpperCase() === suffix) return true;
+    }
+    return false;
+  } catch (err) {
+    console.warn("hibp: check failed (fail-open):", err);
+    return false;
+  }
+}

--- a/apps/backend/src/services/auth.ts
+++ b/apps/backend/src/services/auth.ts
@@ -8,6 +8,7 @@ import { hashToken, newToken } from "@/lib/tokens.ts";
 import { badRequest, conflict, forbidden, notFound, unauthorized } from "@/lib/http.ts";
 import { config } from "@/config.ts";
 import { queue } from "@/queue/queue.ts";
+import { isPwnedPassword } from "@/lib/hibp.ts";
 import type { User } from "@/db/schema.ts";
 
 // Business logic for authentication. First registered user becomes admin.
@@ -23,6 +24,26 @@ const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const MAX_EMAIL_LEN = 254; // RFC 5321 maximum address length
 const PASSWORD_RESET_TTL_MS = 1000 * 60 * 60; // 1 hour
 const EMAIL_VERIFY_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
+const MIN_PASSWORD_LEN = 12;
+const MAX_PASSWORD_LEN = 128;
+
+function assertPasswordLength(pw: string): void {
+  if (pw.length < MIN_PASSWORD_LEN) {
+    throw badRequest(`Password must be at least ${MIN_PASSWORD_LEN} characters.`);
+  }
+  if (pw.length > MAX_PASSWORD_LEN) {
+    throw badRequest(`Password must be at most ${MAX_PASSWORD_LEN} characters.`);
+  }
+}
+
+async function assertNotPwned(pw: string): Promise<void> {
+  if (!config.HIBP_CHECK_ENABLED) return;
+  if (await isPwnedPassword(pw)) {
+    throw badRequest(
+      "This password has appeared in a data breach — please choose a different one.",
+    );
+  }
+}
 
 // Issues a fresh single-use token of a purpose (invalidating any prior ones),
 // stores only its hash, and returns the raw token for the emailed link.
@@ -62,9 +83,8 @@ export async function register(input: {
   if (email.length > MAX_EMAIL_LEN || !EMAIL_RE.test(email)) {
     throw badRequest("Enter a valid email address.");
   }
-  if (input.password.length < 8) {
-    throw badRequest("Password must be at least 8 characters.");
-  }
+  assertPasswordLength(input.password);
+  await assertNotPwned(input.password);
   if (await usersRepo.findByUsername(username)) throw conflict("Username already taken.");
   if (await usersRepo.findByEmail(email)) throw conflict("Email already registered.");
 
@@ -147,7 +167,8 @@ export async function requestPasswordReset(identifier: string): Promise<void> {
 // Completes a reset: validates the token, sets the new password, and drops all
 // of the user's sessions so any pre-existing login must re-authenticate.
 export async function resetPassword(rawToken: string, newPassword: string): Promise<void> {
-  if (newPassword.length < 8) throw badRequest("Password must be at least 8 characters.");
+  assertPasswordLength(newPassword);
+  await assertNotPwned(newPassword);
   const row = await authTokensRepo.findValid(await hashToken(rawToken), "password_reset");
   if (!row) throw badRequest("This reset link is invalid or has expired.");
   await usersRepo.update(row.userId, { passwordHash: await hashPassword(newPassword) });
@@ -162,7 +183,8 @@ export async function changePassword(
   currentPassword: string,
   newPassword: string,
 ): Promise<void> {
-  if (newPassword.length < 8) throw badRequest("Password must be at least 8 characters.");
+  assertPasswordLength(newPassword);
+  await assertNotPwned(newPassword);
   const user = await usersRepo.findById(userId);
   if (!user) throw notFound("Account not found.");
   if (!(await verifyPassword(currentPassword, user.passwordHash))) {

--- a/apps/frontend/src/lib/password.ts
+++ b/apps/frontend/src/lib/password.ts
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Central password policy — single source for register, setup, reset, settings.
+export const MIN_PASSWORD_LEN = 12;
+export const MAX_PASSWORD_LEN = 128;
+
+export type Strength = { score: 0 | 1 | 2 | 3 | 4; label: string };
+
+export function passwordStrength(pw: string): Strength {
+  if (!pw) return { score: 0, label: "" };
+  let score = 0;
+  if (pw.length >= MIN_PASSWORD_LEN) score += 1;
+  if (/[a-z]/.test(pw) && /[A-Z]/.test(pw)) score += 1;
+  if (/\d/.test(pw)) score += 1;
+  if (/[^A-Za-z0-9]/.test(pw)) score += 1;
+  if (pw.length >= 16 && score < 4) score += 1;
+  if (score > 4) score = 4;
+  const labels = ["", "Weak", "Fair", "Good", "Strong"] as const;
+  return { score: score as Strength["score"], label: labels[score] ?? "" };
+}
+
+export function passwordRequirements(pw: string) {
+  return [
+    { id: "len", label: `At least ${MIN_PASSWORD_LEN} characters`, ok: pw.length >= MIN_PASSWORD_LEN },
+    { id: "case", label: "Upper and lower case", ok: /[a-z]/.test(pw) && /[A-Z]/.test(pw) },
+    { id: "num", label: "At least one number", ok: /\d/.test(pw) },
+    { id: "sym", label: "At least one symbol", ok: /[^A-Za-z0-9]/.test(pw) },
+  ];
+}
+
+// Client-side k-anonymity HIBP check — same 5-char prefix model as the backend.
+// Returns true/false/null (null = skipped/failed — fail-open).
+export async function isPwnedPasswordClient(pw: string): Promise<boolean | null> {
+  if (pw.length < MIN_PASSWORD_LEN) return null;
+  try {
+    const enc = new TextEncoder().encode(pw);
+    const buf = await crypto.subtle.digest("SHA-1", enc);
+    const bytes = new Uint8Array(buf);
+    let hex = "";
+    for (const b of bytes) hex += b.toString(16).padStart(2, "0");
+    const upper = hex.toUpperCase();
+    const prefix = upper.slice(0, 5);
+    const suffix = upper.slice(5);
+    const res = await fetch(`https://api.pwnedpasswords.com/range/${prefix}`, {
+      headers: { "Add-Padding": "true" },
+    });
+    if (!res.ok) return null;
+    const text = await res.text();
+    for (const line of text.split("\n")) {
+      const [hashSuffix] = line.trim().split(":");
+      if (hashSuffix?.toUpperCase() === suffix) return true;
+    }
+    return false;
+  } catch {
+    return null;
+  }
+}

--- a/apps/frontend/src/routes/register/+page.svelte
+++ b/apps/frontend/src/routes/register/+page.svelte
@@ -5,23 +5,13 @@
   import { env } from "$env/dynamic/public";
   import { endpoints, ApiError } from "$lib/api";
   import logo from "$lib/assets/omicron.svg";
+  import Icon from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import Button from "$lib/components/ui/Button.svelte";
+  import { MIN_PASSWORD_LEN, passwordStrength, passwordRequirements, isPwnedPasswordClient } from "$lib/password";
   import type { InstanceInfo } from "$lib/types";
-  import { Label } from "bits-ui";
+  import { Checkbox, Label } from "bits-ui";
 
-  // Whose site this is. The line under the heading used to say that the first
-  // account on a fresh instance becomes the admin — which no visitor of this
-  // page can ever act on: the layout gate redirects every route to /setup until
-  // setup is complete, and setup is complete as soon as a single account exists
-  // (isSetupComplete in instanceSetup.ts). By the time /register renders, the
-  // admin exists. So it promised a role the reader can't have and volunteered
-  // the instance's setup state to a stranger.
-  //
-  // What a sign-up form on a federated network actually owes the reader is the
-  // name of the instance they're joining, which is the operator's, not the
-  // project's. Resolution order matches the nav and PageTitle: admin-configured
-  // name, then the build-time env, then the project name as a last resort.
   const instance = $derived(page.data.instance as InstanceInfo | null);
   const appName = $derived(instance?.name || env.PUBLIC_APP_NAME || "Omicron");
 
@@ -29,18 +19,124 @@
   let email = $state("");
   let displayName = $state("");
   let password = $state("");
+  let confirmPassword = $state("");
+  let acceptTerms = $state(false);
+  let showPassword = $state(false);
+  let showConfirm = $state(false);
   let error = $state("");
   let busy = $state(false);
+  let touched = $state({ username: false, email: false, password: false, confirm: false, terms: false });
+
+  let pwned = $state<boolean | null>(null);
+  let pwnedChecking = $state(false);
+  let pwnedTimer: ReturnType<typeof setTimeout> | null = null;
 
   const field =
-    "h-11 rounded-input border border-input bg-background shadow-btn px-3.5 text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus:border-foreground";
+    "h-11 rounded-input border border-input bg-background shadow-btn px-3.5 text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus:border-foreground aria-[invalid=true]:border-destructive";
   const labelClass = "text-sm font-medium leading-none text-foreground";
+  const errClass = "text-xs text-destructive";
+
+  const USERNAME_RE = /^[a-z0-9_]{3,30}$/;
+  const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+  const usernameError = $derived.by(() => {
+    if (!touched.username && !username) return "";
+    const v = username.trim().toLowerCase();
+    if (!v) return "Choose a username.";
+    if (!USERNAME_RE.test(v)) return "3–30 characters: lowercase letters, numbers, underscore.";
+    return "";
+  });
+  const emailError = $derived.by(() => {
+    if (!touched.email && !email) return "";
+    const v = email.trim().toLowerCase();
+    if (!v) return "Enter your email address.";
+    if (v.length > 254 || !EMAIL_RE.test(v)) return "Enter a valid email address.";
+    return "";
+  });
+  const passwordError = $derived.by(() => {
+    if (!touched.password && !password) return "";
+    if (!password) return `Password is required (at least ${MIN_PASSWORD_LEN} characters).`;
+    if (password.length < MIN_PASSWORD_LEN) return `Password must be at least ${MIN_PASSWORD_LEN} characters.`;
+    if (password.length > 128) return "Password must be at most 128 characters.";
+    if (pwned === true) return "This password has appeared in a data breach — please choose a different one.";
+    return "";
+  });
+  const confirmError = $derived.by(() => {
+    if (!touched.confirm && !confirmPassword) return "";
+    if (!confirmPassword) return "Repeat your password.";
+    if (password !== confirmPassword) return "Passwords do not match.";
+    return "";
+  });
+  const termsError = $derived.by(() => {
+    if (!touched.terms) return "";
+    if (!acceptTerms) return "You must accept the Terms and Privacy Policy.";
+    return "";
+  });
+
+  const strength = $derived(passwordStrength(password));
+  const reqs = $derived(passwordRequirements(password));
+
+  // HIBP k-anonymity check — debounced, fail-open, does not block typing.
+  function schedulePwnedCheck(pw: string) {
+    if (pwnedTimer) clearTimeout(pwnedTimer);
+    if (pw.length < MIN_PASSWORD_LEN) {
+      pwned = null;
+      pwnedChecking = false;
+      return;
+    }
+    pwnedChecking = true;
+    pwnedTimer = setTimeout(async () => {
+      const res = await isPwnedPasswordClient(pw);
+      // only apply if the field hasn't changed while we were fetching
+      if (pw === password) {
+        pwned = res;
+        pwnedChecking = false;
+      }
+    }, 600);
+  }
+
+  $effect(() => {
+    // trigger on password change — reading `password` subscribes the effect
+    const pw = password;
+    schedulePwnedCheck(pw);
+  });
+
+  const canSubmit = $derived(
+    !busy &&
+      username.trim() &&
+      email.trim() &&
+      password.length >= MIN_PASSWORD_LEN &&
+      password === confirmPassword &&
+      acceptTerms &&
+      !usernameError &&
+      !emailError &&
+      !passwordError &&
+      !confirmError &&
+      pwned !== true,
+  );
 
   async function submit(e: SubmitEvent) {
     e.preventDefault();
+    touched = { username: true, email: true, password: true, confirm: true, terms: true };
+    if (!acceptTerms) {
+      error = "Please accept the Terms to create an account.";
+      return;
+    }
+    if (usernameError || emailError || passwordError || confirmError) return;
+    if (password !== confirmPassword) return;
+    if (pwned === true) return;
+
     error = "";
     busy = true;
     try {
+      // final pwned gate (in case the debounced check is still pending)
+      const pwnedNow = await isPwnedPasswordClient(password);
+      if (pwnedNow === true) {
+        pwned = true;
+        error = "This password has appeared in a data breach — please choose a different one.";
+        busy = false;
+        return;
+      }
       await endpoints().register({ username, email, password, displayName });
       await invalidateAll();
       goto("/");
@@ -57,9 +153,6 @@
 <div class="mb-8 text-center">
   <div class="mb-4 flex justify-center"><img src={logo} alt="" class="h-12 w-auto" /></div>
   <h1 class="text-2xl font-bold tracking-tight text-foreground">Create your account</h1>
-  <!-- Federation is an operator's switch: an instance can be run as a standalone
-       blog, and this flag is the state the backend is actually running with, not
-       a pending toggle. Don't promise the fediverse to someone who won't get it. -->
   <p class="mt-1.5 text-sm text-muted-foreground">
     {#if instance?.federationEnabled}
       Join {appName} and follow writers across the fediverse.
@@ -69,34 +162,181 @@
   </p>
 </div>
 
-<form onsubmit={submit} class="flex flex-col gap-4">
+<form onsubmit={submit} class="flex flex-col gap-4" novalidate>
   <div class="flex flex-col gap-1.5">
-    <Label.Root for="displayName" class={labelClass}>Display name</Label.Root>
-    <input id="displayName" bind:value={displayName} class={field} />
+    <Label.Root for="displayName" class={labelClass}
+      >Display name <span class="font-normal text-muted-foreground">(optional)</span></Label.Root
+    >
+    <input id="displayName" bind:value={displayName} autocomplete="name" placeholder="Ada Lovelace" class={field} />
   </div>
+
   <div class="flex flex-col gap-1.5">
     <Label.Root for="username" class={labelClass}>Username</Label.Root>
-    <input id="username" bind:value={username} autocomplete="username" placeholder="a-z, 0-9, _" class={field} />
-  </div>
-  <div class="flex flex-col gap-1.5">
-    <Label.Root for="email" class={labelClass}>Email</Label.Root>
-    <input id="email" type="email" bind:value={email} autocomplete="email" class={field} />
-  </div>
-  <div class="flex flex-col gap-1.5">
-    <Label.Root for="password" class={labelClass}>Password</Label.Root>
     <input
-      id="password"
-      type="password"
-      bind:value={password}
-      autocomplete="new-password"
-      placeholder="min 8 characters"
+      id="username"
+      bind:value={username}
+      onblur={() => (touched.username = true)}
+      autocomplete="username"
+      autocapitalize="off"
+      spellcheck={false}
+      placeholder="a-z, 0-9, _"
+      aria-invalid={!!usernameError}
+      aria-describedby={usernameError ? "username-error" : undefined}
       class={field}
     />
+    <p id="username-error" class={errClass} aria-live="polite">{usernameError}</p>
   </div>
-  {#if error}<p class="text-sm text-destructive">{error}</p>{/if}
-  <Button type="submit" disabled={busy} variant="solid" class="mt-1 h-11">
+
+  <div class="flex flex-col gap-1.5">
+    <Label.Root for="email" class={labelClass}>Email</Label.Root>
+    <input
+      id="email"
+      type="email"
+      bind:value={email}
+      onblur={() => (touched.email = true)}
+      autocomplete="email"
+      spellcheck={false}
+      placeholder="ada@example.com"
+      aria-invalid={!!emailError}
+      aria-describedby={emailError ? "email-error" : "email-hint"}
+      class={field}
+    />
+    {#if emailError}
+      <p id="email-error" class={errClass} aria-live="polite">{emailError}</p>
+    {:else}
+      <p id="email-hint" class="text-xs text-muted-foreground">We’ll send a verification link to this address.</p>
+    {/if}
+  </div>
+
+  <div class="flex flex-col gap-1.5">
+    <Label.Root for="password" class={labelClass}>Password</Label.Root>
+    <div class="relative">
+      <input
+        id="password"
+        type={showPassword ? "text" : "password"}
+        bind:value={password}
+        onblur={() => (touched.password = true)}
+        autocomplete="new-password"
+        placeholder={`At least ${MIN_PASSWORD_LEN} characters`}
+        aria-invalid={!!passwordError}
+        aria-describedby="password-error password-reqs password-strength"
+        class={`${field} w-full pr-10`}
+      />
+      <button
+        type="button"
+        onclick={() => (showPassword = !showPassword)}
+        aria-label={showPassword ? "Hide password" : "Show password"}
+        class="absolute top-1/2 right-2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <Icon name={showPassword ? "eye" : "eye"} size={16} />
+      </button>
+    </div>
+
+    {#if password}
+      <div id="password-strength" class="flex items-center gap-1.5">
+        <div class="flex flex-1 gap-1">
+          {#each [1, 2, 3, 4] as i (i)}
+            <div
+              class={`h-1.5 flex-1 rounded-full transition-colors ${i <= strength.score ? (strength.score <= 1 ? "bg-destructive" : strength.score === 2 ? "bg-tertiary" : strength.score === 3 ? "bg-foreground/60" : "bg-foreground") : "bg-muted"}`}
+            ></div>
+          {/each}
+        </div>
+        <span
+          class={`min-w-12 text-right text-xs font-medium ${strength.score <= 1 ? "text-destructive" : strength.score === 2 ? "text-tertiary" : "text-muted-foreground"}`}
+        >
+          {#if pwnedChecking}Checking…{:else}{strength.label}{/if}
+        </span>
+      </div>
+    {/if}
+
+    <ul id="password-reqs" class="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
+      {#each reqs as r (r.id)}
+        <li class={`flex items-center gap-1.5 ${r.ok ? "text-foreground" : "text-muted-foreground"}`}>
+          <span
+            class={`inline-flex size-4 items-center justify-center rounded-full border text-[10px] ${r.ok ? "border-foreground bg-foreground text-background" : "border-border bg-background"}`}
+          >
+            {#if r.ok}<Icon name="check" size={10} />{/if}
+          </span>
+          {r.label}
+        </li>
+      {/each}
+    </ul>
+    {#if pwned === true}
+      <p class="text-xs font-medium text-destructive" aria-live="polite">
+        This password was found in a breach — choose a different one.
+      </p>
+    {:else if pwned === false && password.length >= MIN_PASSWORD_LEN}
+      <p class="text-xs text-muted-foreground" aria-live="polite">Not found in known breaches.</p>
+    {/if}
+    {#if passwordError}<p id="password-error" class={errClass} aria-live="polite">{passwordError}</p>{/if}
+  </div>
+
+  <div class="flex flex-col gap-1.5">
+    <Label.Root for="confirmPassword" class={labelClass}>Confirm password</Label.Root>
+    <div class="relative">
+      <input
+        id="confirmPassword"
+        type={showConfirm ? "text" : "password"}
+        bind:value={confirmPassword}
+        onblur={() => (touched.confirm = true)}
+        autocomplete="new-password"
+        aria-invalid={!!confirmError}
+        aria-describedby={confirmError ? "confirm-error" : undefined}
+        class={`${field} w-full pr-10`}
+      />
+      <button
+        type="button"
+        onclick={() => (showConfirm = !showConfirm)}
+        aria-label={showConfirm ? "Hide password" : "Show password"}
+        class="absolute top-1/2 right-2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <Icon name="eye" size={16} />
+      </button>
+    </div>
+    {#if confirmError}<p id="confirm-error" class={errClass} aria-live="polite">{confirmError}</p>{/if}
+  </div>
+
+  <label class="flex items-start gap-2.5 rounded-input border border-border bg-muted/30 p-3">
+    <Checkbox.Root
+      bind:checked={acceptTerms}
+      onCheckedChange={() => (touched.terms = true)}
+      id="terms"
+      aria-invalid={!!termsError}
+      aria-describedby={termsError ? "terms-error" : undefined}
+      class="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-sm border border-input bg-background shadow-btn data-[state=checked]:border-foreground data-[state=checked]:bg-foreground data-[state=checked]:text-background"
+    >
+      {#snippet children({ checked })}
+        {#if checked}<Icon name="check" size={12} />{/if}
+      {/snippet}
+    </Checkbox.Root>
+    <span class="text-sm leading-snug text-foreground">
+      I agree to the <a href="/privacy" class="underline underline-offset-4 hover:text-muted-foreground"
+        >Privacy Policy</a
+      >
+      and <a href="/contact" class="underline underline-offset-4 hover:text-muted-foreground">Terms</a>.
+    </span>
+  </label>
+  {#if termsError}<p id="terms-error" class={errClass} aria-live="polite">{termsError}</p>{/if}
+
+  <div class="rounded-input border border-border bg-background px-3 py-2.5">
+    <p class="flex items-center gap-1.5 text-xs font-medium text-foreground">
+      <Icon name="shieldOff" size={14} /> Bot protection
+    </p>
+    <p class="mt-1 text-xs leading-relaxed text-muted-foreground">
+      This form is protected by Anubis proof-of-work. Most visitors see no challenge; automated abuse is slowed at the
+      edge.
+    </p>
+  </div>
+
+  {#if error}<p class="text-sm font-medium text-destructive" role="alert" aria-live="assertive">{error}</p>{/if}
+
+  <Button type="submit" disabled={!canSubmit} variant="solid" class="mt-1 h-11" aria-disabled={!canSubmit}>
     {busy ? "Creating…" : "Create account"}
   </Button>
+  <p class="text-center text-xs leading-relaxed text-muted-foreground">
+    After signing up, we’ll email you a verification link. You can sign in right away; verified email may be required
+    later depending on this instance’s settings.
+  </p>
 </form>
 
 <p class="mt-8 text-center text-sm text-muted-foreground">

--- a/apps/frontend/src/routes/reset-password/+page.svelte
+++ b/apps/frontend/src/routes/reset-password/+page.svelte
@@ -6,6 +6,7 @@
   import Icon from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import Button from "$lib/components/ui/Button.svelte";
+  import { MIN_PASSWORD_LEN, passwordStrength, passwordRequirements, isPwnedPasswordClient } from "$lib/password";
   import { Label } from "bits-ui";
 
   const token = $derived($page.url.searchParams.get("token") ?? "");
@@ -17,18 +18,25 @@
   let done = $state(false);
 
   const field =
-    "h-11 rounded-input border border-input bg-background shadow-btn px-3.5 text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus:border-foreground";
+    "h-11 rounded-input border border-input bg-background shadow-btn px-3.5 text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus:border-foreground aria-[invalid=true]:border-destructive";
   const labelClass = "text-sm font-medium leading-none text-foreground";
+  const strength = $derived(passwordStrength(password));
+  const reqs = $derived(passwordRequirements(password));
 
   async function submit(e: SubmitEvent) {
     e.preventDefault();
     error = "";
-    if (password.length < 8) {
-      error = "Password must be at least 8 characters.";
+    if (password.length < MIN_PASSWORD_LEN) {
+      error = `Password must be at least ${MIN_PASSWORD_LEN} characters.`;
       return;
     }
     if (password !== confirm) {
       error = "Passwords don't match.";
+      return;
+    }
+    const pwned = await isPwnedPasswordClient(password);
+    if (pwned === true) {
+      error = "This password has appeared in a data breach — please choose a different one.";
       return;
     }
     busy = true;
@@ -82,15 +90,50 @@
         type="password"
         bind:value={password}
         autocomplete="new-password"
-        placeholder="min 8 characters"
+        placeholder={`at least ${MIN_PASSWORD_LEN} characters`}
+        aria-invalid={!!error && password.length < MIN_PASSWORD_LEN}
+        aria-describedby="password-reqs"
         class={field}
       />
+      {#if password}
+        <div class="flex items-center gap-1.5">
+          <div class="flex flex-1 gap-1">
+            {#each [1, 2, 3, 4] as i (i)}
+              <div
+                class={`h-1.5 flex-1 rounded-full ${i <= strength.score ? (strength.score <= 1 ? "bg-destructive" : strength.score === 2 ? "bg-tertiary" : strength.score === 3 ? "bg-foreground/60" : "bg-foreground") : "bg-muted"}`}
+              ></div>
+            {/each}
+          </div>
+          <span class="min-w-12 text-right text-xs font-medium text-muted-foreground">{strength.label}</span>
+        </div>
+      {/if}
+      <ul id="password-reqs" class="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
+        {#each reqs as r (r.id)}
+          <li class={`flex items-center gap-1.5 ${r.ok ? "text-foreground" : "text-muted-foreground"}`}>
+            <span
+              class={`inline-flex size-4 items-center justify-center rounded-full border text-[10px] ${r.ok ? "border-foreground bg-foreground text-background" : "border-border bg-background"}`}
+              >{#if r.ok}<Icon name="check" size={10} />{/if}</span
+            >
+            {r.label}
+          </li>
+        {/each}
+      </ul>
     </div>
     <div class="flex flex-col gap-1.5">
       <Label.Root for="confirm" class={labelClass}>Confirm password</Label.Root>
-      <input id="confirm" type="password" bind:value={confirm} autocomplete="new-password" class={field} />
+      <input
+        id="confirm"
+        type="password"
+        bind:value={confirm}
+        autocomplete="new-password"
+        aria-invalid={password !== confirm && !!confirm}
+        class={field}
+      />
+      {#if confirm && password !== confirm}<p class="text-xs text-destructive" aria-live="polite">
+          Passwords do not match.
+        </p>{/if}
     </div>
-    {#if error}<p class="text-sm text-destructive">{error}</p>{/if}
+    {#if error}<p class="text-sm text-destructive" role="alert" aria-live="assertive">{error}</p>{/if}
     <Button type="submit" disabled={busy} variant="solid" class="mt-1 h-11">
       {busy ? "Saving…" : "Update password"}
     </Button>

--- a/apps/frontend/src/routes/settings/+page.svelte
+++ b/apps/frontend/src/routes/settings/+page.svelte
@@ -18,6 +18,7 @@
   import WebhookTokensManager from "$lib/components/WebhookTokensManager.svelte";
   import { AVATAR_MAX_DIMENSION, prepareImage } from "$lib/editor/image";
   import { insertEmojiIntoField, emojiOverlayBtn } from "$lib/emoji";
+  import { MIN_PASSWORD_LEN, isPwnedPasswordClient } from "$lib/password";
   import { reading, type FeedTab } from "$lib/prefs.svelte";
   import { identifierToUrl, platformMeta, urlToIdentifier } from "$lib/profileLinks";
   import { MAX_PROFILE_TAGS } from "$lib/tags";
@@ -290,12 +291,16 @@
 
   async function changePassword() {
     pwError = "";
-    if (newPassword.length < 8) {
-      pwError = "New password must be at least 8 characters.";
+    if (newPassword.length < MIN_PASSWORD_LEN) {
+      pwError = `New password must be at least ${MIN_PASSWORD_LEN} characters.`;
       return;
     }
     if (newPassword !== confirmPassword) {
       pwError = "New passwords don't match.";
+      return;
+    }
+    if (await isPwnedPasswordClient(newPassword)) {
+      pwError = "This password has appeared in a data breach — please choose a different one.";
       return;
     }
     pwBusy = true;

--- a/apps/frontend/src/routes/setup/+page.svelte
+++ b/apps/frontend/src/routes/setup/+page.svelte
@@ -95,7 +95,7 @@
     step === 0
       ? appName.trim().length > 0
       : step === 1
-        ? /^[a-z0-9_]{3,30}$/.test(username.trim().toLowerCase()) && email.includes("@") && password.length >= 8
+        ? /^[a-z0-9_]{3,30}$/.test(username.trim().toLowerCase()) && email.includes("@") && password.length >= 12
         : true,
   );
 
@@ -200,11 +200,13 @@
         type="password"
         bind:value={password}
         autocomplete="new-password"
-        placeholder="min 8 characters"
+        placeholder="at least 12 characters"
         class={field}
       />
     </div>
-    <p class="text-xs text-muted-foreground">This first account is the instance admin.</p>
+    <p class="text-xs text-muted-foreground">
+      At least 12 characters. Checked against known breaches on submit. This first account is the instance admin.
+    </p>
   {:else}
     <span class={labelClass}>How should the instance send email?</span>
     <RadioGroup.Root bind:value={emailMode} class="flex flex-col gap-3">


### PR DESCRIPTION
Closes #22.

Symptom: /register rendered only display name/username/email with placeholder min 8, no requirements, no repeat, no meter, no terms, no captcha/email copy, and no inline aria-live errors. Backend accepted >=8 with no breach check.

Frontend: central lib/password.ts (MIN 12, strength, requirements, client HIBP k-anonymity), /register now has confirm password, show/hide, 4-segment meter, live checklist, debounced pwned check (fail-open), per-field aria-invalid/describedby + aria-live=polite, general error aria-live=assertive, terms Checkbox (bits-ui) required, Anubis proof-of-work note and verification email copy; matched in /reset-password and /setup (12+) and /settings changePassword.

Backend: lib/hibp.ts — SHA-1 then 5-char prefix to https://api.pwnedpasswords.com/range, Add-Padding, 3.5s AbortController, fail-open; config HIBP_CHECK_ENABLED (env, default true); services/auth.ts MIN 12 MAX 128 + assertNotPwned on register/reset/change; .env.example docs.