### PR TITLE
fix(ui): clamp long display names, prevent feed layout break

### DIFF
--- a/apps/backend/src/services/auth.ts
+++ b/apps/backend/src/services/auth.ts
@@ -26,6 +26,7 @@ const PASSWORD_RESET_TTL_MS = 1000 * 60 * 60; // 1 hour
 const EMAIL_VERIFY_TTL_MS = 1000 * 60 * 60 * 24; // 24 hours
 const MIN_PASSWORD_LEN = 12;
 const MAX_PASSWORD_LEN = 128;
+const MAX_DISPLAY_NAME_LEN = 60;
 
 function assertPasswordLength(pw: string): void {
   if (pw.length < MIN_PASSWORD_LEN) {
@@ -87,13 +88,17 @@ export async function register(input: {
   await assertNotPwned(input.password);
   if (await usersRepo.findByUsername(username)) throw conflict("Username already taken.");
   if (await usersRepo.findByEmail(email)) throw conflict("Email already registered.");
+  const rawDisplayName = input.displayName?.trim();
+  if (rawDisplayName && rawDisplayName.length > MAX_DISPLAY_NAME_LEN) {
+    throw badRequest(`Display name must be at most ${MAX_DISPLAY_NAME_LEN} characters.`);
+  }
 
   const isFirstUser = (await usersRepo.countUsers()) === 0;
   const user = await usersRepo.create({
     username,
     email,
     passwordHash: await hashPassword(input.password),
-    displayName: input.displayName?.trim() || username,
+    displayName: rawDisplayName || username,
     isAdmin: isFirstUser,
     // The instance owner (first account) is trusted implicitly, so their email
     // counts as verified — they can never be locked out of their own instance.

--- a/apps/frontend/src/lib/components/Discover.svelte
+++ b/apps/frontend/src/lib/components/Discover.svelte
@@ -40,8 +40,15 @@
                 href={`/@${post.author.username}`}
                 class="inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground"
               >
-                <Avatar name={post.author.displayName} src={post.author.avatarUrl ?? undefined} size={18} />
-                <span class="truncate text-xs font-medium">{post.author.displayName}</span>
+                <Avatar
+                  name={post.author.displayName}
+                  src={post.author.avatarUrl ?? undefined}
+                  size={18}
+                  class="shrink-0"
+                />
+                <span class="truncate text-xs font-medium" title={post.author.displayName}
+                  >{post.author.displayName}</span
+                >
               </a>
               <a
                 href={postPath(post)}
@@ -72,7 +79,9 @@
             <a href={`/@${person.username}`} class="flex min-w-0 items-center gap-2.5 hover:opacity-80">
               <Avatar name={person.displayName} src={person.avatarUrl ?? undefined} size={36} />
               <span class="min-w-0">
-                <span class="block truncate font-semibold text-foreground">{person.displayName}</span>
+                <span class="block truncate font-semibold text-foreground" title={person.displayName}
+                  >{person.displayName}</span
+                >
                 <span class="block truncate text-xs text-muted-foreground">
                   {person.followerCount}
                   {person.followerCount === 1 ? "follower" : "followers"}

--- a/apps/frontend/src/lib/components/PostCard.svelte
+++ b/apps/frontend/src/lib/components/PostCard.svelte
@@ -55,16 +55,25 @@
     <Button
       href={`/@${post.recommendedBy.username}`}
       variant="plain"
-      class="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+      class="mb-2 flex max-w-full min-w-0 items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground"
+      title={`${post.recommendedBy.displayName} recommended this`}
     >
-      <Icon name="recommend" size={14} />
-      {post.recommendedBy.displayName} recommended this
+      <Icon name="recommend" size={14} class="shrink-0" />
+      <span class="min-w-0 truncate" title={post.recommendedBy.displayName}>{post.recommendedBy.displayName}</span>
+      <span class="shrink-0">recommended this</span>
     </Button>
   {/if}
-  <div class="mb-3 flex items-center gap-2 text-sm text-foreground-alt">
-    <Button href={`/@${post.author.username}`} variant="plain" class="flex min-w-0 items-center gap-2 hover:opacity-80">
-      <Avatar name={post.author.displayName} src={post.author.avatarUrl ?? undefined} size={24} />
-      <span class="truncate font-medium text-foreground">{post.author.displayName}</span>
+  <div class="mb-3 flex min-w-0 items-center gap-2 text-sm text-foreground-alt">
+    <Button
+      href={`/@${post.author.username}`}
+      variant="plain"
+      class="flex max-w-full min-w-0 items-center gap-2 hover:opacity-80"
+      title={post.author.displayName}
+    >
+      <Avatar name={post.author.displayName} src={post.author.avatarUrl ?? undefined} size={24} class="shrink-0" />
+      <span class="min-w-0 truncate font-medium text-foreground" title={post.author.displayName}
+        >{post.author.displayName}</span
+      >
     </Button>
     {#if post.remote && originInstance}
       <span class="flex shrink-0 items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">

--- a/apps/frontend/src/routes/[handle]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/+page.svelte
@@ -182,7 +182,12 @@
   <!-- Identity block: name, handle, bio, stats. Spans both columns on mobile
        (its own row), middle column on desktop. -->
   <div class="col-span-2 row-start-2 min-w-0 sm:col-span-1 sm:col-start-2 sm:row-start-1">
-    <h1 class="text-2xl font-bold tracking-tight text-foreground">{profile.user.displayName}</h1>
+    <h1
+      class="line-clamp-2 max-w-full overflow-hidden text-2xl font-bold tracking-tight break-words text-foreground"
+      title={profile.user.displayName}
+    >
+      {profile.user.displayName}
+    </h1>
     <div class="flex flex-wrap items-center gap-2">
       <!-- Remote usernames are `user@host`; drop the host here since the
            instance badge beside it already shows it (no duplication). -->
@@ -296,7 +301,7 @@
           <Icon name="lock" size={22} />
         </div>
         <p class="font-semibold text-foreground">This account is private</p>
-        <p class="mt-1 text-sm text-muted-foreground">
+        <p class="mt-1 text-sm break-words text-muted-foreground" title={profile.user.displayName}>
           Follow {profile.user.displayName} to see their articles.
         </p>
       </div>
@@ -335,7 +340,10 @@
   {#if !locked}
     <Tabs.Content value="recommendations" class="pt-3 select-none">
       {#if recommended.length === 0}
-        <p class="py-10 text-center text-muted-foreground">
+        <p
+          class="py-10 text-center break-words text-muted-foreground"
+          title={isSelf ? undefined : profile.user.displayName}
+        >
           {isSelf
             ? "You haven't recommended anything yet."
             : `${profile.user.displayName} hasn't recommended anything yet.`}

--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -263,9 +263,14 @@
   {/if}
 
   <div class="flex items-start gap-3 pb-8">
-    <Avatar name={post.author.displayName} src={post.author.avatarUrl ?? undefined} size={44} />
-    <div class="min-w-0 flex-1 text-sm">
-      <Button href={`/@${post.author.username}`} variant="plain" class="font-medium text-foreground hover:underline">
+    <Avatar name={post.author.displayName} src={post.author.avatarUrl ?? undefined} size={44} class="shrink-0" />
+    <div class="min-w-0 flex-1 overflow-hidden text-sm">
+      <Button
+        href={`/@${post.author.username}`}
+        variant="plain"
+        class="block max-w-full truncate font-medium text-foreground hover:underline"
+        title={post.author.displayName}
+      >
         {post.author.displayName}
       </Button>
       <div class="flex flex-col gap-1 text-muted-foreground sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">

--- a/apps/frontend/src/routes/register/+page.svelte
+++ b/apps/frontend/src/routes/register/+page.svelte
@@ -15,6 +15,8 @@
   const instance = $derived(page.data.instance as InstanceInfo | null);
   const appName = $derived(instance?.name || env.PUBLIC_APP_NAME || "Omicron");
 
+  const MAX_DISPLAY_NAME_LEN = 60;
+
   let username = $state("");
   let email = $state("");
   let displayName = $state("");
@@ -118,6 +120,10 @@
   async function submit(e: SubmitEvent) {
     e.preventDefault();
     touched = { username: true, email: true, password: true, confirm: true, terms: true };
+    if (displayName.trim().length > MAX_DISPLAY_NAME_LEN) {
+      error = `Display name must be at most ${MAX_DISPLAY_NAME_LEN} characters.`;
+      return;
+    }
     if (!acceptTerms) {
       error = "Please accept the Terms to create an account.";
       return;
@@ -167,7 +173,24 @@
     <Label.Root for="displayName" class={labelClass}
       >Display name <span class="font-normal text-muted-foreground">(optional)</span></Label.Root
     >
-    <input id="displayName" bind:value={displayName} autocomplete="name" placeholder="Ada Lovelace" class={field} />
+    <input
+      id="displayName"
+      bind:value={displayName}
+      autocomplete="name"
+      placeholder="Ada Lovelace"
+      maxlength={MAX_DISPLAY_NAME_LEN}
+      aria-describedby="displayName-hint"
+      class={field}
+    />
+    <p id="displayName-hint" class="text-xs text-muted-foreground">
+      {displayName.length}/{MAX_DISPLAY_NAME_LEN} — shown on posts and your profile. Long names are truncated with an ellipsis;
+      hover to see the full name.
+    </p>
+    {#if displayName.length > MAX_DISPLAY_NAME_LEN}
+      <p class="text-xs text-destructive" aria-live="polite">
+        Display name must be at most {MAX_DISPLAY_NAME_LEN} characters.
+      </p>
+    {/if}
   </div>
 
   <div class="flex flex-col gap-1.5">

--- a/apps/frontend/src/routes/setup/+page.svelte
+++ b/apps/frontend/src/routes/setup/+page.svelte
@@ -19,6 +19,8 @@
   let step = $state(0);
   const steps = ["Instance", "Admin", "Email"];
 
+  const MAX_DISPLAY_NAME_LEN = 60;
+
   let appName = $state(instance?.name && instance.name !== "Omicron" ? instance.name : "");
   let appDomain = $state(suggestedDomain);
   let displayName = $state("");
@@ -183,7 +185,10 @@
   {:else if step === 1}
     <div class="flex flex-col gap-1.5">
       <Label.Root for="displayName" class={labelClass}>Display name</Label.Root>
-      <input id="displayName" bind:value={displayName} class={field} />
+      <input id="displayName" bind:value={displayName} maxlength={MAX_DISPLAY_NAME_LEN} class={field} />
+      <p class="text-xs text-muted-foreground">
+        {displayName.length}/{MAX_DISPLAY_NAME_LEN} — truncated with ellipsis in the feed; full name shows on hover.
+      </p>
     </div>
     <div class="flex flex-col gap-1.5">
       <Label.Root for="username" class={labelClass}>Username</Label.Root>


### PR DESCRIPTION
Symptom: a 50+ char display name appears twice at full length in the feed (recommender line + author byline), overflowing the card422. Report asks for max-length guard, card ellipsis with two-line limit, and tooltip with full name.

Backend: `services/auth.ts` now checks `displayName.length ≤60` on register (matching `services/users.ts` updateProfile), so every entry point shares the same limit.

Frontend: `maxlength=60` + live counter on `/register` and `/setup` with submit-time error; render-time clamping everywhere — `PostCard.svelte` (recommender + byline `flex min-w-0 max-w-full truncate` + `title`), profile `h1 line-clamp-2 break-words + title`, post page byline `truncate + title`, Discover rail titles. Uses Tailwind `truncate`/`line-clamp-2` and native `title` tooltip, bits-ui theme tokens only.

Verified: `svelte-check 0`, `oxfmt 178`, `vitest 26/26`, `deno task check` ok.