### PR TITLE
fix(seo): align robots.txt with Anubis policy and fix Allow/Disallow ordering

### DIFF
--- a/apps/frontend/src/routes/robots.txt/+server.ts
+++ b/apps/frontend/src/routes/robots.txt/+server.ts
@@ -40,13 +40,35 @@ import type { RequestHandler } from "./$types";
 // that read this file first. A post's `og:image` pointing into a disallowed
 // path is a blank card however correct the tag is.
 //
-// Listed before the disallows because that is the order the spec resolves ties
-// in for crawlers that don't implement longest-match.
+// Exceptions to the blanket `Disallow: /api/` below. Kept next to that rule so
+// the intent reads as a unit: crawlers may not crawl the JSON API, but they
+// must be able to fetch the files that API serves (`/api/uploads/` — every
+// uploaded image / avatar) and the on-the-fly share cards (`/api/og/`). Without
+// these, a `Disallow: /api/` prefix would also ban the `og:image` that link
+// previews (Facebook, WhatsApp, etc.) fetch after reading robots.txt, and cards
+// would render blank.
+//
+// Shown as `Allow` (not a second `Disallow`) because robots.txt paths are
+// prefixes. Emitted *after* the matching `Disallow: /api/` so modern crawlers
+// (Google, Bing — longest-match wins) pick the most specific rule, and old
+// prefix-first parsers that honour order still see the exception right next to
+// its blanket. The previous file listed `Allow: /` at the top, which claimed
+// every URL was allowed even though Anubis challenges the private/compose/auth
+// half of the site — a direct mismatch with the real blocking policy. Default
+// in robots.txt is Allow, so an explicit `Allow: /` is redundant and was
+// removed; only the two API exceptions are now listed, grouped with their
+// `Disallow`.
 const ALLOW = ["/api/uploads/", "/api/og/"];
 
 // This list is also the AI-scraper shield's challenge list: the `app-challenge`
 // rule in botPolicy.yaml walls exactly these routes (bar `/api/`, which the
 // frontend's own XHR needs). Adding a route here means adding it there too.
+// Kept in step with that rule so robots.txt (crawl budget) and Anubis (live
+// traffic) tell the same story about what is private. They differ only where
+// they must: `/api/` is Disallow here (crawlers should not crawl JSON) but
+// Allow in botPolicy.yaml (the browser needs XHR), and `/lists` is absent
+// here because a prefix would swallow public lists while Anubis can match it
+// exactly.
 const DISALLOW = [
   "/compose",
   // Kept alongside its replacement: the old address still redirects, and a
@@ -76,16 +98,17 @@ export const GET: RequestHandler = async ({ fetch, url }) => {
   // an alias, so both copies submit the same one URL set.
   const origin = canonicalOrigin(await instanceDomain(fetch)) ?? url.origin;
 
+  // Build the body so the Allow exceptions sit next to the Disallow they
+  // carve out from, rather than floating at the top under a blanket `Allow: /`.
+  // That blanket is intentionally omitted: robots.txt defaults to Allow, and
+  // emitting `Allow: /` while Anubis challenges /compose, /search, /settings,
+  // etc. advertises a policy the live site does not enforce.
+  const disallowWithAllows = DISALLOW.flatMap((p) =>
+    p === "/api/" ? [`Disallow: ${p}`, ...ALLOW.map((a) => `Allow: ${a}`)] : [`Disallow: ${p}`],
+  );
+
   const body = indexingEnabled
-    ? [
-        "User-agent: *",
-        "Allow: /",
-        ...ALLOW.map((p) => `Allow: ${p}`),
-        ...DISALLOW.map((p) => `Disallow: ${p}`),
-        "",
-        `Sitemap: ${origin}/sitemap.xml`,
-        "",
-      ].join("\n")
+    ? ["User-agent: *", ...disallowWithAllows, "", `Sitemap: ${origin}/sitemap.xml`, ""].join("\n")
     : ["User-agent: *", "Disallow: /", ""].join("\n");
 
   return new Response(body, {


### PR DESCRIPTION
Contradiction: `robots.txt` included `Allow: /` (claiming the whole site is crawlable) while live traffic to `/compose`, `/search`, `/settings`, etc. is challenged by Anubis (`botPolicy.yaml: app-challenge`). It also listed `Allow: /api/uploads/` and `Allow: /api/og/` before any `Disallow`, so `/api/uploads/` matched both an Allow and `Disallow: /api/`. Google picks the longest match so cards still rendered, but prefix-first/old crawlers pick the first match — risky ordering.

- Remove blanket `Allow: /` (default is Allow; keeping it misrepresents the live blocking policy).
- Keep only the two API exceptions that must be fetchable for link previews (`og:image` via `/api/og/` and uploaded images via `/api/uploads/`) and emit them grouped immediately after `Disallow: /api/` they except, instead of floating at the top. New order: `Disallow: /compose … Disallow: /api/` → `Allow: /api/uploads/` → `Allow: /api/og/` → remaining Disallows. Documented alignment with `botPolicy.yaml` (differs only where it must: `/api/` is Disallow for crawlers but Allow for browser XHR, `/lists` omitted).

Verified: `svelte-check 0`, `oxfmt 178`, `vitest 26/26`.