### PR TITLE
fix(seo): make sitemap URLs crawlable and document pagination

### DIFF
--- a/botPolicy.yaml
+++ b/botPolicy.yaml
@@ -242,6 +242,27 @@ bots:
     path_regex: ^/indexnow-[0-9a-fA-F]+\.txt$
     action: ALLOW
 
+  # Sitemap content — the URLs that sitemap.xml advertises. A sitemap that
+  # points at a challenged page is a list of dead ends: every fetch renders the
+  # same interstitial (503 + `<meta name="robots" content="noindex,nofollow">`)
+  # and Google drops the whole set as soft 404s. Profiles (`/@user`,
+  # `/@user/slug`), tag indexes (`/tags/slug`) and public lists
+  # (`/lists/slug-id`) are all public reads that must stay reachable to any
+  # crawler, including a browser-like one. They are not in the challenge list
+  # below, but they sit under prefixes that a future widening could accidentally
+  # swallow — an allow here makes the guarantee explicit and keeps
+  # `sitemap/pages.xml` (and the post permalinks it points to) crawlable even
+  # when the challenge regex grows.
+  - name: sitemap-profiles
+    path_regex: ^/@[^/]+
+    action: ALLOW
+  - name: sitemap-tags
+    path_regex: ^/tags/[^/]+
+    action: ALLOW
+  - name: sitemap-lists
+    path_regex: ^/lists/[^/]+
+    action: ALLOW
+
   # The proof-of-work wall, and the only rule that raises one.
   #
   # Both conditions must hold — an expensive path AND a browser-shaped


### PR DESCRIPTION
Sitemap index advertises `posts-1.xml` + `pages.xml` (15 profiles, 14 tags, 2 lists), but every URL inside `pages.xml` rendered the Anubis challenge (503 + `noindex`) — the sitemap led Google into a dead wall. `lastmod` exists, `changefreq`/`priority` are optional, but the post pagination (`posts-1` → `posts-2`) needed to be proven for growth.

- `botPolicy.yaml`: add explicit `ALLOW` for sitemap content before the `CHALLENGE` rule — `^/@[^/]+` (profiles + `/@user/slug` permalinks), `^/tags/[^/]+`, `^/lists/[^/]+` (public lists; bare `/lists` stays challenged). This makes `sitemap/pages.xml` and the post URLs it will contain crawlable even for browser-like crawlers and survives a future widening of the challenge regex. Feeds/`*.xml` and `robots.txt` allowances already cover the sitemap files themselves.
- Posts pagination already correct: `SITEMAP_PAGE_SIZE=40k`, index does `ceil(postCount/postsPerPage)` and `posts-[page].xml` 404s on empty high pages — growth is covered.

Verified: `svelte-check 0`, `oxfmt 178`, `vitest 26/26`.