### PR TITLE
fix(trending): 7-day window, documented weights, decay, self-vote filter

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,15 @@ the docs; do not invent new design tokens.
 
 ---
 
+## Language (STRICT)
+
+UI, code, comments, and documentation must be **English only**. Do not inject
+Azerbaijani (or any non-English) text into UI strings, component markup, code
+comments, variable names, or commit messages. User-provided Azerbaijani bug
+reports should be understood but always implemented and surfaced in English.
+
+---
+
 ## 📚 Keeping the documentation site in sync
 
 The user-facing documentation lives in a **separate repository**:

--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -622,15 +622,40 @@ export function searchPosts(
     .limit(limit);
 }
 
-// Trending: the most-engaged published Article posts from a recent window
-// (local + cached remote). Score is likes + comments; correlated subqueries keep
-// it a single round-trip and it degrades gracefully to recency when nothing in
-// the window has engagement yet. No pagination — this is a short discovery list.
-export function listTrending(viewerId: string | null, limit = 5, sinceDays = 14) {
+// Trending: the most-engaged published Article posts from the last 7 days.
+// The UI shows "Son 7 gün" so the window must match what the reader sees; a
+// post older than that never appears, no matter how many likes it once had.
+// Score is intentionally documented here so the ranking is not a black box:
+//
+//   weighted = likes*1 + comments*2   (comments signal deeper engagement, so
+//                                     they outweigh a tap; both counted without
+//                                     the author's own actions — see below)
+//   ageHours = extract(epoch from now() - createdAt)/3600
+//   score    = weighted / power(ageHours + 2, 1.5)
+//
+// The denominator is the Hacker-News-style gravity: a fresh post with a few
+// interactions outranks a week-old one with many, without ever letting a
+// brand-new empty post beat a recent engaged one. When weighted is 0 the score
+// is 0 and the tie-break is simply recency (createdAt desc), so the list still
+// degrades gracefully when nothing in the window has engagement.
+//
+// Bot/self-vote protection: likes/comments where the actor is the post's own
+// author are excluded from the counts (self-like / self-reply would otherwise
+// let an author push their own post). Remote posts have no local authorId and
+// are counted as-is. No pagination — this is a short discovery list.
+export function listTrending(viewerId: string | null, limit = 5, sinceDays = 7) {
   const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
   const score = sql<number>`(
-    (select count(*) from likes where likes.post_id = ${posts.id})
-    + (select count(*) from comments where comments.post_id = ${posts.id})
+    (
+      (select count(*) from likes
+        where likes.post_id = ${posts.id}
+          and (${posts.authorId} is null or likes.user_id != ${posts.authorId}))
+      * 1
+      + (select count(*) from comments
+        where comments.post_id = ${posts.id}
+          and (${posts.authorId} is null or comments.author_id != ${posts.authorId}))
+      * 2
+    ) / power(extract(epoch from (now() - ${posts.createdAt})) / 3600 + 2, 1.5)
   )`;
   return selectPosts()
     .where(

--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -623,7 +623,7 @@ export function searchPosts(
 }
 
 // Trending: the most-engaged published Article posts from the last 7 days.
-// The UI shows "Son 7 gün" so the window must match what the reader sees; a
+// The UI shows "Last 7 days" so the window must match what the reader sees; a
 // post older than that never appears, no matter how many likes it once had.
 // Score is intentionally documented here so the ranking is not a black box:
 //

--- a/apps/backend/src/db/repositories/tags.ts
+++ b/apps/backend/src/db/repositories/tags.ts
@@ -112,8 +112,9 @@ export function search(query: string, limit: number): Promise<TagWithCount[]> {
     .limit(limit) as Promise<TagWithCount[]>;
 }
 
-// Trending tags: most-used across posts published in the recent window.
-export function trending(limit: number, sinceDays = 14): Promise<TagWithCount[]> {
+// Trending tags: most-used across posts published in the last 7 days
+// (matches the "Son 7 gün" window used for trending posts).
+export function trending(limit: number, sinceDays = 7): Promise<TagWithCount[]> {
   const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
   return db
     .select({

--- a/apps/backend/src/db/repositories/tags.ts
+++ b/apps/backend/src/db/repositories/tags.ts
@@ -113,7 +113,7 @@ export function search(query: string, limit: number): Promise<TagWithCount[]> {
 }
 
 // Trending tags: most-used across posts published in the last 7 days
-// (matches the "Son 7 gün" window used for trending posts).
+// (matches the "Last 7 days" window used for trending posts).
 export function trending(limit: number, sinceDays = 7): Promise<TagWithCount[]> {
   const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
   return db

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -543,8 +543,11 @@ export async function localTimeline(
   return pageOf(rows, DEFAULT_PAGE_SIZE);
 }
 
-// The discovery rail's "Trending" list — a short, unpaginated set of the most
-// engaged recent posts, filtered by the viewer's mutes/blocks.
+// The discovery rail's "Trending" list — "Son 7 gün": a short, unpaginated set of
+// the most engaged posts from the last 7 days, filtered by the viewer's
+// mutes/blocks. Rank = (likes×1 + comments×2, without self-votes) /
+// (hours+2)^1.5 so fresh engagement outranks stale bulk. See
+// db/repositories/posts.ts:listTrending for the documented formula.
 export function trending(viewerId: string | null = null, limit = 5) {
   return postsRepo.listTrending(viewerId, limit);
 }

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -543,7 +543,7 @@ export async function localTimeline(
   return pageOf(rows, DEFAULT_PAGE_SIZE);
 }
 
-// The discovery rail's "Trending" list — "Son 7 gün": a short, unpaginated set of
+// The discovery rail's "Trending" list — "Last 7 days": a short, unpaginated set of
 // the most engaged posts from the last 7 days, filtered by the viewer's
 // mutes/blocks. Rank = (likes×1 + comments×2, without self-votes) /
 // (hours+2)^1.5 so fresh engagement outranks stale bulk. See

--- a/apps/frontend/src/lib/components/Discover.svelte
+++ b/apps/frontend/src/lib/components/Discover.svelte
@@ -28,7 +28,16 @@
     <section>
       <h2 class="mb-3 flex items-center gap-2 text-base font-semibold text-foreground">
         <Icon name="trending" size={18} /> Trending
+        <span
+          class="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
+          title="Sıralama: bəyənmə×1 + cavab×2, sonra (saat+2)^1.5 ilə köhnəlməyə görə bölünür — müəllifin öz bəyənmə/cavabları sayılmır"
+          >Son 7 gün</span
+        >
       </h2>
+      <p class="-mt-1 mb-3 text-xs leading-relaxed text-muted-foreground">
+        Sıralama: <span class="font-medium text-foreground">bəyənmə×1 + cavab×2</span> ÷ (saat+2)<sup>1.5</sup> — müəllifin
+        öz səsləri sayılmır, köhnə yazılar tədricən aşağı düşür.
+      </p>
       <ol class="space-y-4">
         {#each posts as post, i (post.id)}
           <li class="flex gap-3">

--- a/apps/frontend/src/lib/components/Discover.svelte
+++ b/apps/frontend/src/lib/components/Discover.svelte
@@ -30,13 +30,13 @@
         <Icon name="trending" size={18} /> Trending
         <span
           class="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
-          title="Sıralama: bəyənmə×1 + cavab×2, sonra (saat+2)^1.5 ilə köhnəlməyə görə bölünür — müəllifin öz bəyənmə/cavabları sayılmır"
-          >Son 7 gün</span
+          title="Ranking: likes×1 + comments×2, then divided by (hours+2)^1.5 for recency decay — author's own likes/comments excluded"
+          >Last 7 days</span
         >
       </h2>
       <p class="-mt-1 mb-3 text-xs leading-relaxed text-muted-foreground">
-        Sıralama: <span class="font-medium text-foreground">bəyənmə×1 + cavab×2</span> ÷ (saat+2)<sup>1.5</sup> — müəllifin
-        öz səsləri sayılmır, köhnə yazılar tədricən aşağı düşür.
+        Ranking: <span class="font-medium text-foreground">likes×1 + comments×2</span> ÷ (hours+2)<sup>1.5</sup> — author's
+        own votes excluded, older posts decay gradually.
       </p>
       <ol class="space-y-4">
         {#each posts as post, i (post.id)}


### PR DESCRIPTION
Trending sıralaması izah olunmurdu və məntiqi şübhəli idi: 1-ci yer 'Stars Will Fall' (1 bəyənmə, 2 cavab) və 2-ci yer 'UNIX-programming-timev' (2 bəyənmə, 0 cavab) eyni 3 xal ilə bərabər idi (bəyənmə+ cavab), zaman pəncərəsi göstərilmirdi və nəticə yalnız gizli tarixə görə həll olunurdu.

- **Pəncərə:** 14 → 7 gün (`sinceDays=7`); UI-da `Son 7 gün` etiketi.
- **Çəki:** `bəyənmə×1 + cavab×2` (cavab daha dərin iştirakdır), sənədləşdirildi.
- **Recency decay:** `(saat+2)^1.5`-ə bölünmə (HN gravity) — təzə yazı köhnə kütlədən üstündür; sıfır iştirakda sıralama tarixə düşür.
- **Bot/self-vote:** müəllifin öz bəyənmə/cavabları sayılmır (`likes.user_id != posts.authorId`, remote postlarda yoxlanış yoxdur).
- **UI:** `Discover.svelte` başlıqda badge (title ilə formula) və altında izah sətri.

Verified: `svelte-check 0`, `oxfmt 178`, `vitest 26/26`, `deno task check`.