### PR TITLE
fix(trending): filter junk tags with thresholds and blocklist

### DIFF
--- a/apps/backend/src/db/repositories/tags.ts
+++ b/apps/backend/src/db/repositories/tags.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { and, desc, eq, gt, inArray, sql } from "drizzle-orm";
+import { and, desc, eq, gt, inArray, notInArray, sql } from "drizzle-orm";
 import { db } from "@/db/client.ts";
 import {
   posts,
@@ -112,10 +112,29 @@ export function search(query: string, limit: number): Promise<TagWithCount[]> {
     .limit(limit) as Promise<TagWithCount[]>;
 }
 
+// Tags that should never appear in trending — personal/joke tags that were
+// surfacing at the top (e.g. larp, idk, khazar, divineintellect). The list is
+// intentionally small and explicit; broader moderation is handled by the
+// distinct-author and minimum-use thresholds below. Keep lowercase slugs only.
+// Managed in code for now; a future admin panel could move this to
+// instance_settings (trending_blocked_tags).
+const TRENDING_BLOCKED_SLUGS = new Set([
+  "larp",
+  "idk",
+  "khazar",
+  "divineintellect",
+]);
+
 // Trending tags: most-used across posts published in the last 7 days
 // (matches the "Last 7 days" window used for trending posts).
+//
+// Quality gates: a tag must appear on at least 3 posts by at least 3 distinct
+// authors in the window to be eligible. This prevents a single author's
+// personal or joke tag from dominating the discovery rail. Blocklisted slugs
+// are excluded in the WHERE clause before aggregation.
 export function trending(limit: number, sinceDays = 7): Promise<TagWithCount[]> {
   const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
+  const blocked = [...TRENDING_BLOCKED_SLUGS];
   return db
     .select({
       slug: tags.slug,
@@ -137,9 +156,13 @@ export function trending(limit: number, sinceDays = 7): Promise<TagWithCount[]> 
         isPublished,
         notSuspended,
         visibleToViewer(null),
+        blocked.length ? notInArray(tags.slug, blocked) : undefined,
       ),
     )
     .groupBy(tags.id)
+    .having(
+      sql`count(${postTags.postId}) >= 3 and count(distinct coalesce(${posts.authorId}::text, ${posts.remoteActorId}::text)) >= 3`,
+    )
     .orderBy(desc(sql`count(${postTags.postId})`))
     .limit(limit) as Promise<TagWithCount[]>;
 }

--- a/apps/backend/tests/integration/visibility_test.ts
+++ b/apps/backend/tests/integration/visibility_test.ts
@@ -138,6 +138,14 @@ Deno.test("public listings exclude unpublished posts and suspended authors", opt
 
   const rust = await mkTag("rust");
   for (const p of [draft, scheduled, live, bySuspended, byPrivate]) await tagPost(p.id, rust.id);
+  // Trending now requires >=3 posts by >=3 distinct authors to filter
+  // personal/joke tags — add two more visible posts by different authors so
+  // the tag is eligible and the visible-only assertion remains meaningful.
+  const author2 = await mkUser("author2");
+  const author3 = await mkUser("author3");
+  const live2 = await mkPost(author2.id, "live-post-2");
+  const live3 = await mkPost(author3.id, "live-post-3");
+  for (const p of [live2, live3]) await tagPost(p.id, rust.id);
 
   const hiddenFromEveryone = [draft, scheduled, bySuspended, byPrivate];
 
@@ -164,7 +172,7 @@ Deno.test("public listings exclude unpublished posts and suspended authors", opt
   });
 
   await t.step("trending ranks the tag by visible posts only", async () => {
-    assertEquals((await tagsRepo.trending(5))[0]?.postCount, 1);
+    assertEquals((await tagsRepo.trending(5))[0]?.postCount, 3);
   });
 });
 


### PR DESCRIPTION
Trending topics filled with personal/joke tags (larp, idk, khazar, divineintellect) at the top because ranking counted only raw posts in the last 7 days.

- `tagsRepo.trending`: add `TRENDING_BLOCKED_SLUGS` exclusion, `having count>=3 and count(distinct author)>=3` (distinct coalesce of authorId/remoteActorId) to require at least 3 posts by 3 authors. Keeps single-author joke tags from dominating. Blocklist is explicit for now; comment notes a future admin panel via `instance_settings`.
- `visibility_test`: seed 3 distinct authors/posts for 'rust' so trending eligibility reflects the new threshold (expected count 3).

Verified: `deno task check`, `svelte-check 0`, `oxfmt 178`.