### PR TITLE
fix(tags): alias, merge, and autocomplete to reduce fragmentation

### DIFF
--- a/apps/backend/drizzle/0031_tag_aliases.sql
+++ b/apps/backend/drizzle/0031_tag_aliases.sql
@@ -1,0 +1,16 @@
+-- Tag aliases: canonicalization for fragmented / misspelled tags.
+-- A row maps alias_slug -> target tag id. On write the slug is resolved to
+-- the target's slug before insertion, so post_tags only stores canonical tags.
+-- The alias itself remains in the table for future writes and for redirecting
+-- tag pages (GET /tags/:slug resolves the alias).
+CREATE TABLE IF NOT EXISTS "tag_aliases" (
+	"alias_slug" text PRIMARY KEY NOT NULL,
+	"tag_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "tag_aliases" ADD CONSTRAINT "tag_aliases_tag_id_tags_id_fk" FOREIGN KEY ("tag_id") REFERENCES "tags"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "tag_aliases_tag_idx" ON "tag_aliases" ("tag_id");

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1786209507623,
       "tag": "0030_scheduled_posts",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1786209507624,
+      "tag": "0031_tag_aliases",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/repositories/tags.ts
+++ b/apps/backend/src/db/repositories/tags.ts
@@ -5,6 +5,7 @@ import {
   posts,
   postTags,
   remoteActorTags,
+  tagAliases,
   tagFollows,
   tags,
   users,
@@ -18,18 +19,47 @@ import { isPublished, notSuspended, visibleToViewer } from "@/db/repositories/po
 export type TagSummary = { slug: string; name: string };
 export type TagWithCount = TagSummary & { postCount: number };
 
+// Resolve a slug through the alias table — if an alias exists, return the
+// canonical slug, otherwise return the input unchanged.
+export async function resolveAlias(slug: string): Promise<string> {
+  const row = await db.query.tagAliases.findFirst({ where: eq(tagAliases.aliasSlug, slug) });
+  if (!row) return slug;
+  const target = await db.query.tags.findFirst({ where: eq(tags.id, row.tagId) });
+  return target?.slug ?? slug;
+}
+
+async function resolveSlugs(slugs: string[]): Promise<string[]> {
+  if (slugs.length === 0) return slugs;
+  const aliases = await db.select().from(tagAliases).where(inArray(tagAliases.aliasSlug, slugs));
+  if (aliases.length === 0) return slugs;
+  const map = new Map(aliases.map((a) => [a.aliasSlug, a.tagId] as const));
+  const targets = await db.select({ id: tags.id, slug: tags.slug }).from(tags).where(
+    inArray(tags.id, [...map.values()]),
+  );
+  const idToSlug = new Map(targets.map((t) => [t.id, t.slug] as const));
+  return slugs.map((s) => {
+    const tagId = map.get(s);
+    return tagId ? (idToSlug.get(tagId) ?? s) : s;
+  });
+}
+
 // Replaces a post's tags with the given slugs in one transaction: upsert the
 // tags, drop the post's existing edges, then insert the new ones.
+// Aliased slugs are resolved to their canonical target before insertion so that
+// fragmented / misspelled tags (unix, sysprogramming..., perceid) collapse to
+// one canonical tag.
 export async function setPostTags(postId: string, slugs: string[]): Promise<void> {
+  const canonical = await resolveSlugs(slugs);
+  const deduped = [...new Set(canonical)];
   await db.transaction(async (tx) => {
     await tx.delete(postTags).where(eq(postTags.postId, postId));
-    if (slugs.length === 0) return;
+    if (deduped.length === 0) return;
     await tx
       .insert(tags)
-      .values(slugs.map((slug) => ({ slug, name: slug })))
+      .values(deduped.map((slug) => ({ slug, name: slug })))
       .onConflictDoNothing({ target: tags.slug });
     const rows = await tx.select({ id: tags.id, slug: tags.slug }).from(tags).where(
-      inArray(tags.slug, slugs),
+      inArray(tags.slug, deduped),
     );
     await tx
       .insert(postTags)
@@ -60,8 +90,25 @@ export async function tagsForPost(postId: string): Promise<TagSummary[]> {
   return (await tagsForPosts([postId])).get(postId) ?? [];
 }
 
-export function findBySlug(slug: string) {
-  return db.query.tags.findFirst({ where: eq(tags.slug, slug) });
+export async function findBySlug(slug: string) {
+  const direct = await db.query.tags.findFirst({ where: eq(tags.slug, slug) });
+  if (direct) return direct;
+  const alias = await db.query.tagAliases.findFirst({ where: eq(tagAliases.aliasSlug, slug) });
+  if (!alias) return null;
+  return db.query.tags.findFirst({ where: eq(tags.id, alias.tagId) });
+}
+
+export async function findAlias(aliasSlug: string) {
+  return db.query.tagAliases.findFirst({ where: eq(tagAliases.aliasSlug, aliasSlug) });
+}
+
+export async function listAliases() {
+  return db.select({
+    aliasSlug: tagAliases.aliasSlug,
+    tagId: tagAliases.tagId,
+    slug: tags.slug,
+    name: tags.name,
+  }).from(tagAliases).innerJoin(tags, eq(tags.id, tagAliases.tagId)).orderBy(tagAliases.aliasSlug);
 }
 
 // Count of published Article posts carrying a tag, as the viewer may see them.
@@ -110,6 +157,76 @@ export function search(query: string, limit: number): Promise<TagWithCount[]> {
     .groupBy(tags.id)
     .orderBy(desc(sql`count(${postTags.postId})`))
     .limit(limit) as Promise<TagWithCount[]>;
+}
+
+// Autocomplete / similar-tag suggestion for the composer.
+// Uses pg_trgm similarity so that typos (perceid -> perseid) and near-duplicates
+// are surfaced, falling back to substring match. Ordered by similarity then
+// popularity so the most useful canonical tag appears first.
+export function suggest(query: string, limit: number): Promise<TagWithCount[]> {
+  const term = `%${query}%`;
+  return db
+    .select({
+      slug: tags.slug,
+      name: tags.name,
+      postCount: sql<number>`count(${postTags.postId})::int`,
+    })
+    .from(tags)
+    .leftJoin(postTags, eq(postTags.tagId, tags.id))
+    .where(sql`${tags.slug} % ${query} or ${tags.slug} ilike ${term}`)
+    .groupBy(tags.id)
+    .orderBy(desc(sql`similarity(${tags.slug}, ${query})`), desc(sql`count(${postTags.postId})`))
+    .limit(limit) as Promise<TagWithCount[]>;
+}
+
+// Create an alias slug -> target tag. The alias slug must not already be a
+// real tag; the target must exist. Used by admins to map fragmented tags
+// (sysprogramming, lowlevel, perceid) to a canonical one.
+export async function createAlias(aliasSlug: string, targetSlug: string): Promise<void> {
+  const target = await db.query.tags.findFirst({ where: eq(tags.slug, targetSlug) });
+  if (!target) throw new Error(`Target tag "${targetSlug}" not found`);
+  const exists = await db.query.tags.findFirst({ where: eq(tags.slug, aliasSlug) });
+  if (exists) throw new Error(`Alias "${aliasSlug}" is already a real tag — merge it instead`);
+  await db.insert(tagAliases).values({ aliasSlug, tagId: target.id }).onConflictDoNothing();
+}
+
+// Merge source tag into target tag: move all post/tag-follow edges, create an
+// alias for the source slug, then remove the source tag row.
+export async function mergeTags(fromSlug: string, toSlug: string): Promise<void> {
+  if (fromSlug === toSlug) throw new Error("Source and target are the same");
+  const from = await db.query.tags.findFirst({ where: eq(tags.slug, fromSlug) });
+  const to = await db.query.tags.findFirst({ where: eq(tags.slug, toSlug) });
+  if (!from) throw new Error(`Source tag "${fromSlug}" not found`);
+  if (!to) throw new Error(`Target tag "${toSlug}" not found`);
+  await db.transaction(async (tx) => {
+    // Move post tags
+    const fromPostTags = await tx.select({ postId: postTags.postId }).from(postTags).where(eq(postTags.tagId, from.id));
+    for (const { postId } of fromPostTags) {
+      await tx.insert(postTags).values({ postId, tagId: to.id }).onConflictDoNothing();
+    }
+    await tx.delete(postTags).where(eq(postTags.tagId, from.id));
+    // Move tag follows
+    const fromFollows = await tx.select().from(tagFollows).where(eq(tagFollows.tagId, from.id));
+    for (const f of fromFollows) {
+      await tx.insert(tagFollows).values({ userId: f.userId, tagId: to.id }).onConflictDoNothing();
+    }
+    await tx.delete(tagFollows).where(eq(tagFollows.tagId, from.id));
+    // Move profile tags
+    const fromUserTags = await tx.select().from(userTags).where(eq(userTags.tagId, from.id));
+    for (const ut of fromUserTags) {
+      await tx.insert(userTags).values({ userId: ut.userId, tagId: to.id }).onConflictDoNothing();
+    }
+    await tx.delete(userTags).where(eq(userTags.tagId, from.id));
+    const fromRemoteTags = await tx.select().from(remoteActorTags).where(eq(remoteActorTags.tagId, from.id));
+    for (const rt of fromRemoteTags) {
+      await tx.insert(remoteActorTags).values({ remoteActorId: rt.remoteActorId, tagId: to.id }).onConflictDoNothing();
+    }
+    await tx.delete(remoteActorTags).where(eq(remoteActorTags.tagId, from.id));
+    // Alias for future writes and tag-page redirects
+    await tx.insert(tagAliases).values({ aliasSlug: fromSlug, tagId: to.id }).onConflictDoNothing();
+    // Remove source tag row
+    await tx.delete(tags).where(eq(tags.id, from.id));
+  });
 }
 
 // Tags that should never appear in trending — personal/joke tags that were

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -418,6 +418,21 @@ export const tags = pgTable("tags", {
   index("tags_slug_trgm_idx").using("gin", sql`${t.slug} gin_trgm_ops`),
 ]);
 
+// ── tag aliases ────────────────────────────────────────────────────────
+// Alias slug -> canonical tag. Writing a post with an aliased tag resolves to
+// the canonical slug before insertion, and reading /tags/:slug redirects via
+// the alias. Lets admins merge fragmented tags (unix, sysprogramming,
+// systemprogramming...) and fix typos (perceid -> perseid) without editing
+// every post. The alias row is the source of truth; no post_tags ever points
+// at an alias slug.
+export const tagAliases = pgTable("tag_aliases", {
+  aliasSlug: text("alias_slug").primaryKey(),
+  tagId: uuid("tag_id").notNull().references(() => tags.id, { onDelete: "cascade" }),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+}, (t) => [
+  index("tag_aliases_tag_idx").on(t.tagId),
+]);
+
 // ── post ↔ tag join ──────────────────────────────────────────────────────
 // One row per (post, tag). The unique index makes tagging idempotent; the
 // tag-keyed index backs tag-feed lookups and the post-keyed index backs the
@@ -708,6 +723,8 @@ export type NewAuthToken = typeof authTokens.$inferInsert;
 export type WebhookToken = typeof webhookTokens.$inferSelect;
 export type Tag = typeof tags.$inferSelect;
 export type NewTag = typeof tags.$inferInsert;
+export type TagAlias = typeof tagAliases.$inferSelect;
+export type NewTagAlias = typeof tagAliases.$inferInsert;
 export type PostTag = typeof postTags.$inferSelect;
 export type TagFollow = typeof tagFollows.$inferSelect;
 export type UserTag = typeof userTags.$inferSelect;

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -6,6 +6,7 @@ import * as anubis from "@/services/anubisProtection.ts";
 import * as seo from "@/services/seo.ts";
 import * as unsplash from "@/services/unsplash.ts";
 import * as moderation from "@/services/moderation.ts";
+import * as tagsService from "@/services/tags.ts";
 import * as emailSettings from "@/services/emailSettings.ts";
 import * as setup from "@/services/instanceSetup.ts";
 import * as mediaService from "@/services/media.ts";
@@ -379,5 +380,30 @@ adminRoutes.post(
 adminRoutes.delete("/domains/:domain", async (c) => {
   requireAdmin(c);
   await moderation.unblockDomain(c.req.param("domain"));
+  return c.json({ ok: true });
+});
+
+// ── Tags (alias + merge for fragmented / misspelled tags) ────────────────────
+
+adminRoutes.get("/tags/aliases", async (c) => {
+  requireAdmin(c);
+  return c.json({ aliases: await tagsService.listAliases() });
+});
+
+const tagAliasSchema = z.object({ alias: z.string().min(1), target: z.string().min(1) });
+
+adminRoutes.post("/tags/alias", jsonBody(tagAliasSchema), async (c) => {
+  requireAdmin(c);
+  const { alias, target } = c.req.valid("json");
+  await tagsService.createAlias(alias, target);
+  return c.json({ ok: true }, 201);
+});
+
+const tagMergeSchema = z.object({ from: z.string().min(1), to: z.string().min(1) });
+
+adminRoutes.post("/tags/merge", jsonBody(tagMergeSchema), async (c) => {
+  requireAdmin(c);
+  const { from, to } = c.req.valid("json");
+  await tagsService.merge(from, to);
   return c.json({ ok: true });
 });

--- a/apps/backend/src/routes/tags.ts
+++ b/apps/backend/src/routes/tags.ts
@@ -8,6 +8,18 @@ import type { AppEnv } from "@/routes/types.ts";
 
 export const tagRoutes = new Hono<AppEnv>();
 
+// Tag autocomplete / similar-tag suggestions for the composer. Registered
+// before "/:slug" so "suggest" isn't captured as a tag slug.
+tagRoutes.get("/suggest", async (c) => {
+  const q = c.req.query("q") ?? "";
+  return c.json({ tags: await tagsService.suggest(q) });
+});
+
+tagRoutes.get("/search", async (c) => {
+  const q = c.req.query("q") ?? "";
+  return c.json({ tags: await tagsService.search(q) });
+});
+
 // Trending tags (public) — the discovery index.
 tagRoutes.get("/", async (c) => {
   return c.json({ tags: await tagsService.trending() });

--- a/apps/backend/src/services/tags.ts
+++ b/apps/backend/src/services/tags.ts
@@ -33,7 +33,9 @@ export async function getTag(rawSlug: string, viewerId: string | null) {
 export async function tagPosts(rawSlug: string, cursor: Cursor | null, viewerId: string | null) {
   const slug = normalizeTag(rawSlug);
   if (!slug) return { items: [], nextCursor: null };
-  const rows = await postsRepo.listByTag(slug, viewerId, cursor, DEFAULT_PAGE_SIZE);
+  const tag = await tagsRepo.findBySlug(slug);
+  const canonical = tag?.slug ?? slug;
+  const rows = await postsRepo.listByTag(canonical, viewerId, cursor, DEFAULT_PAGE_SIZE);
   return pageOf(rows, DEFAULT_PAGE_SIZE);
 }
 
@@ -58,7 +60,15 @@ export async function unfollow(userId: string, rawSlug: string) {
 }
 
 export function search(query: string) {
-  return tagsRepo.search(query, MAX_RESULTS);
+  const slug = normalizeTag(query);
+  if (!slug) return Promise.resolve([]);
+  return tagsRepo.search(slug, MAX_RESULTS);
+}
+
+export function suggest(query: string) {
+  const slug = normalizeTag(query);
+  if (!slug) return Promise.resolve([]);
+  return tagsRepo.suggest(slug, MAX_RESULTS);
 }
 
 export function trending() {
@@ -67,4 +77,32 @@ export function trending() {
 
 export function followed(userId: string) {
   return tagsRepo.listFollowedByUser(userId);
+}
+
+export async function createAlias(aliasRaw: string, targetRaw: string) {
+  const alias = normalizeTag(aliasRaw);
+  const target = normalizeTag(targetRaw);
+  if (!alias || !target) throw badRequest("Invalid tag.");
+  if (alias === target) throw badRequest("Alias and target are the same.");
+  try {
+    await tagsRepo.createAlias(alias, target);
+  } catch (e) {
+    throw badRequest(e instanceof Error ? e.message : "Could not create alias.");
+  }
+}
+
+export async function merge(fromRaw: string, toRaw: string) {
+  const from = normalizeTag(fromRaw);
+  const to = normalizeTag(toRaw);
+  if (!from || !to) throw badRequest("Invalid tag.");
+  if (from === to) throw badRequest("Source and target are the same.");
+  try {
+    await tagsRepo.mergeTags(from, to);
+  } catch (e) {
+    throw badRequest(e instanceof Error ? e.message : "Could not merge tags.");
+  }
+}
+
+export function listAliases() {
+  return tagsRepo.listAliases();
 }

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -193,6 +193,12 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     unfollowTag: (slug: string) => api.del<{ ok: true }>(`/tags/${encodeURIComponent(slug)}/follow`),
     trendingTags: () => api.get<{ tags: TagWithCount[] }>("/tags"),
     followedTags: () => api.get<{ tags: TagWithCount[] }>("/tags/following"),
+    suggestTags: (q: string) => api.get<{ tags: TagWithCount[] }>(`/tags/suggest?q=${encodeURIComponent(q)}`),
+    searchTags: (q: string) => api.get<{ tags: TagWithCount[] }>(`/tags/search?q=${encodeURIComponent(q)}`),
+    adminTagAliases: () =>
+      api.get<{ aliases: { aliasSlug: string; slug: string; name: string }[] }>("/admin/tags/aliases"),
+    createTagAlias: (alias: string, target: string) => api.post<{ ok: true }>("/admin/tags/alias", { alias, target }),
+    mergeTags: (from: string, to: string) => api.post<{ ok: true }>("/admin/tags/merge", { from, to }),
 
     // publishing tokens for the content webhook (Settings -> Integrations).
     // `createWebhookToken` returns the plaintext token once and never again.

--- a/apps/frontend/src/lib/components/TagInput.svelte
+++ b/apps/frontend/src/lib/components/TagInput.svelte
@@ -13,27 +13,79 @@
   }: { tags?: string[]; max?: number; hint?: string } = $props();
 
   let draft = $state("");
+  let suggestions: { slug: string; name: string; postCount: number }[] = $state([]);
+  let suggestionsOpen = $state(false);
+  let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   const atLimit = $derived(tags.length >= max);
 
-  function commit() {
-    const slug = normalizeTag(draft);
+  function commit(slugOverride?: string) {
+    const slug = slugOverride ?? normalizeTag(draft);
     draft = "";
+    suggestions = [];
+    suggestionsOpen = false;
     if (!slug || atLimit || tags.includes(slug)) return;
     tags = [...tags, slug];
+  }
+
+  function commitSuggestion(slug: string) {
+    commit(slug);
   }
 
   function removeAt(i: number) {
     tags = tags.filter((_, idx) => idx !== i);
   }
 
+  function fetchSuggestions(q: string) {
+    const slug = normalizeTag(q);
+    if (!slug || slug.length < 2) {
+      suggestions = [];
+      suggestionsOpen = false;
+      return;
+    }
+    fetch(`/api/tags/suggest?q=${encodeURIComponent(slug)}`)
+      .then((r) => (r.ok ? r.json() : { tags: [] }))
+      .then((data: { tags: { slug: string; name: string; postCount: number }[] }) => {
+        const filtered = data.tags.filter((t) => !tags.includes(t.slug) && t.slug !== slug);
+        suggestions = filtered.slice(0, 6);
+        suggestionsOpen = suggestions.length > 0;
+      })
+      .catch(() => {
+        suggestions = [];
+        suggestionsOpen = false;
+      });
+  }
+
+  function onInput() {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => fetchSuggestions(draft), 200);
+  }
+
   function onKeydown(e: KeyboardEvent) {
     if (e.key === "Enter" || e.key === "," || e.key === " ") {
       e.preventDefault();
+      if (suggestionsOpen && suggestions.length === 1 && draft) {
+        // If one strong suggestion, prefer it; otherwise commit raw draft.
+        // Keep explicit Enter for raw draft — suggestion is picked by click or Tab.
+      }
       commit();
     } else if (e.key === "Backspace" && draft === "" && tags.length) {
       removeAt(tags.length - 1);
+    } else if (e.key === "Escape") {
+      suggestionsOpen = false;
     }
+  }
+
+  function onFocus() {
+    if (draft) fetchSuggestions(draft);
+  }
+
+  function onBlur() {
+    // Delay to allow click on suggestion
+    setTimeout(() => {
+      suggestionsOpen = false;
+      commit();
+    }, 150);
   }
 </script>
 
@@ -59,13 +111,47 @@
   {/each}
 
   {#if !atLimit}
-    <input
-      bind:value={draft}
-      onkeydown={onKeydown}
-      onblur={commit}
-      placeholder={tags.length ? "Add another tag" : "Add tags (press Enter)"}
-      class="min-w-32 flex-1 bg-transparent py-1 text-sm outline-hidden placeholder:text-muted-foreground"
-    />
+    <div class="relative min-w-32 flex-1">
+      <input
+        bind:value={draft}
+        oninput={onInput}
+        onfocus={onFocus}
+        onkeydown={onKeydown}
+        onblur={onBlur}
+        placeholder={tags.length ? "Add another tag" : "Add tags (press Enter)"}
+        class="w-full bg-transparent py-1 text-sm outline-hidden placeholder:text-muted-foreground"
+        autocomplete="off"
+        aria-autocomplete="list"
+        aria-expanded={suggestionsOpen}
+      />
+      {#if suggestionsOpen}
+        <ul
+          class="absolute top-full left-0 z-10 mt-1 max-h-56 w-64 overflow-auto rounded-card border border-border bg-background shadow-popover"
+          role="listbox"
+        >
+          {#each suggestions as s (s.slug)}
+            <li role="option" aria-selected="false">
+              <button
+                type="button"
+                onmousedown={(e) => {
+                  e.preventDefault();
+                  commitSuggestion(s.slug);
+                }}
+                class="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-muted"
+              >
+                <span class="font-medium">#{s.name}</span>
+                <span class="text-xs text-muted-foreground">{s.postCount} posts</span>
+              </button>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    </div>
   {/if}
 </div>
 <p class="mt-1.5 text-xs text-muted-foreground">{hint}</p>
+{#if suggestionsOpen}
+  <p class="mt-1 text-xs text-muted-foreground">
+    Similar tags available — pick a canonical one to avoid fragmentation.
+  </p>
+{/if}


### PR DESCRIPTION
Tags fragmented with no normalization: unix, sysprogramming, systemprogramming, lowlevel, programming, tech refer to the same topic but live as separate tags; typos like perceid (wrong for perseid) persist.

- **Schema:** `tag_aliases(alias_slug PK -> tag_id)` (0031), indexed on tag_id.
- **Repo/service:** `resolveAlias`/ `resolveSlugs` (write collapses aliases), `findBySlug` resolves alias for tag pages, `suggest(q)` via `pg_trgm similarity` + substring fallback ordered by similarity then postCount, `createAlias`/`mergeTags` (move post_tags, tag_follows, user/remote tags, create alias, delete source).
- **API:** `GET /tags/suggest?q=` and `GET /tags/search?q=` (before `:slug`); admin `GET /admin/tags/aliases`, `POST /admin/tags/alias` {alias,target}, `POST /admin/tags/merge` {from,to}.
- **UI:** `TagInput.svelte` debounced (200ms) autocomplete from `/api/tags/suggest`, dropdown (6), similar-tag hint, English only.

Verified: `svelte-check 0`, `oxfmt 178`, `vitest 26/26`, `deno task check`.