### PR TITLE
fix(feed): cap same-author concentration in discovery timelines

### DIFF
--- a/apps/backend/src/db/repositories/tags.ts
+++ b/apps/backend/src/db/repositories/tags.ts
@@ -98,11 +98,11 @@ export async function findBySlug(slug: string) {
   return db.query.tags.findFirst({ where: eq(tags.id, alias.tagId) });
 }
 
-export async function findAlias(aliasSlug: string) {
+export function findAlias(aliasSlug: string) {
   return db.query.tagAliases.findFirst({ where: eq(tagAliases.aliasSlug, aliasSlug) });
 }
 
-export async function listAliases() {
+export function listAliases() {
   return db.select({
     aliasSlug: tagAliases.aliasSlug,
     tagId: tagAliases.tagId,
@@ -200,7 +200,9 @@ export async function mergeTags(fromSlug: string, toSlug: string): Promise<void>
   if (!to) throw new Error(`Target tag "${toSlug}" not found`);
   await db.transaction(async (tx) => {
     // Move post tags
-    const fromPostTags = await tx.select({ postId: postTags.postId }).from(postTags).where(eq(postTags.tagId, from.id));
+    const fromPostTags = await tx.select({ postId: postTags.postId }).from(postTags).where(
+      eq(postTags.tagId, from.id),
+    );
     for (const { postId } of fromPostTags) {
       await tx.insert(postTags).values({ postId, tagId: to.id }).onConflictDoNothing();
     }
@@ -217,9 +219,12 @@ export async function mergeTags(fromSlug: string, toSlug: string): Promise<void>
       await tx.insert(userTags).values({ userId: ut.userId, tagId: to.id }).onConflictDoNothing();
     }
     await tx.delete(userTags).where(eq(userTags.tagId, from.id));
-    const fromRemoteTags = await tx.select().from(remoteActorTags).where(eq(remoteActorTags.tagId, from.id));
+    const fromRemoteTags = await tx.select().from(remoteActorTags).where(
+      eq(remoteActorTags.tagId, from.id),
+    );
     for (const rt of fromRemoteTags) {
-      await tx.insert(remoteActorTags).values({ remoteActorId: rt.remoteActorId, tagId: to.id }).onConflictDoNothing();
+      await tx.insert(remoteActorTags).values({ remoteActorId: rt.remoteActorId, tagId: to.id })
+        .onConflictDoNothing();
     }
     await tx.delete(remoteActorTags).where(eq(remoteActorTags.tagId, from.id));
     // Alias for future writes and tag-page redirects

--- a/apps/backend/src/lib/feedDiversity.ts
+++ b/apps/backend/src/lib/feedDiversity.ts
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Feed author diversity for the discovery timelines (Global / Local).
+//
+// A single prolific author can otherwise fill a whole page — 8 of 20 posts
+// from one "series" makes the instance look monotonous to a new reader. Two
+// caps are applied while a page is assembled, in rank order:
+//
+//   consecutive — never more than MAX_CONSECUTIVE_SAME_AUTHOR posts by one
+//                 author in a row, as long as another eligible post exists
+//                 later in the fetched window to take its slot;
+//   share       — at most maxPerAuthorPerPage(pageSize) posts by one author
+//                 on a single page (~20%, minimum 2).
+//
+// Held-back posts are not deleted: they remain on the author's profile, tag
+// pages, search and trending. On the timeline itself a held-back post is
+// simply skipped; one that sits before the page's cursor is trimmed from this
+// timeline, one after it is re-offered with the next page.
+
+export const MAX_CONSECUTIVE_SAME_AUTHOR = 2;
+
+// ~1/5 of a page per author (4 of 20), never fewer than 2 so a small
+// instance's single active writer keeps some presence.
+export function maxPerAuthorPerPage(pageSize: number): number {
+  return Math.max(2, Math.ceil(pageSize / 5));
+}
+
+// Running caps across the windows of one page assembly. `lastAuthor` /
+// `streak` track the consecutive cap; `counts` the per-author share.
+export type DiversityState = {
+  counts: Record<string, number>;
+  lastAuthor: string | null;
+  streak: number;
+};
+
+export function freshDiversityState(): DiversityState {
+  return { counts: {}, lastAuthor: null, streak: 0 };
+}
+
+// Walks `rows` in rank order, keeping at most `pageSize` posts under both
+// caps. The state carries over between calls so several fetched windows can
+// fill one page under shared counters. Returns the kept rows plus `scanned` —
+// how many input rows were consumed (kept or deliberately skipped), which is
+// what the timeline's keyset cursor advances past. When nothing later in the
+// window fits either cap, the caps relax rather than hand back a short page:
+// starving the feed would be worse than a third post in a row.
+export function diversify<T>(
+  rows: readonly T[],
+  pageSize: number,
+  authorOf: (row: T) => string,
+  state: DiversityState = freshDiversityState(),
+): { kept: T[]; scanned: number; state: DiversityState } {
+  const shareCap = maxPerAuthorPerPage(pageSize);
+  const kept: T[] = [];
+
+  // Would placing rows[j] break a cap right now?
+  const blockedAt = (j: number): boolean => {
+    const key = authorOf(rows[j]);
+    const streak = key === state.lastAuthor ? state.streak + 1 : 1;
+    return streak > MAX_CONSECUTIVE_SAME_AUTHOR || (state.counts[key] ?? 0) >= shareCap;
+  };
+
+  const accept = (row: T) => {
+    const key = authorOf(row);
+    state.streak = key === state.lastAuthor ? state.streak + 1 : 1;
+    state.lastAuthor = key;
+    state.counts[key] = (state.counts[key] ?? 0) + 1;
+    kept.push(row);
+  };
+
+  let i = 0;
+  while (kept.length < pageSize && i < rows.length) {
+    if (!blockedAt(i)) {
+      accept(rows[i]);
+      i++;
+      continue;
+    }
+    // Look ahead for an eligible post to take this slot instead; skipping is
+    // only allowed while such a post exists, so every call accepts at least
+    // one row and page assembly always advances.
+    let relief = -1;
+    for (let j = i + 1; j < rows.length && relief === -1; j++) {
+      if (!blockedAt(j)) relief = j;
+    }
+    if (relief === -1) accept(rows[i]); // caps relax — nothing else fits
+    i++; // accepted just now, or deliberately held back
+  }
+
+  return { kept, scanned: i, state };
+}

--- a/apps/backend/src/lib/feedDiversity_test.ts
+++ b/apps/backend/src/lib/feedDiversity_test.ts
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { assertEquals } from "@std/assert";
+import {
+  diversify,
+  MAX_CONSECUTIVE_SAME_AUTHOR,
+  maxPerAuthorPerPage,
+} from "@/lib/feedDiversity.ts";
+
+// The discovery timelines must not let one author fill a page. These tests
+// pin the two caps (consecutive run, per-page share), the relaxation that
+// keeps pages from starving, and the `scanned` count the cursor relies on.
+
+function rowsOf(...authors: string[]) {
+  return authors.map((author, i) => ({ author, id: `p${i}` }));
+}
+
+Deno.test("maxPerAuthorPerPage: about a fifth of the page, minimum 2", () => {
+  assertEquals(maxPerAuthorPerPage(20), 4);
+  assertEquals(maxPerAuthorPerPage(12), 3);
+  assertEquals(maxPerAuthorPerPage(5), 2);
+});
+
+Deno.test("diversify: breaks a consecutive same-author run when relief exists", () => {
+  const { kept, scanned } = diversify(rowsOf("a", "a", "a", "a", "b"), 5, (r) => r.author);
+  // The third `a` is held back as long as something else can take the slot.
+  assertEquals(kept.map((r) => r.author), ["a", "a", "b"]);
+  assertEquals(MAX_CONSECUTIVE_SAME_AUTHOR, 2);
+  assertEquals(scanned, 5);
+});
+
+Deno.test("diversify: share cap limits one author's presence on a page", () => {
+  // a,a,b,a,a,c,a,a,d — the interleaved b/c/d let `a` back in twice more,
+  // until its share cap (3 on a 12-row page) holds it off for good.
+  const { kept } = diversify(
+    rowsOf("a", "a", "b", "a", "a", "c", "a", "a", "d"),
+    12,
+    (r) => r.author,
+  );
+  assertEquals(kept.map((r) => r.author), ["a", "a", "b", "a", "c", "d"]);
+  assertEquals(kept.filter((r) => r.author === "a").length, maxPerAuthorPerPage(12));
+});
+
+Deno.test("diversify: relaxes caps rather than returning a short page", () => {
+  // Only one author left in the window — a third post in a row beats an
+  // empty slot.
+  const { kept, scanned } = diversify(rowsOf("a", "a", "a"), 5, (r) => r.author);
+  assertEquals(kept.map((r) => r.author), ["a", "a", "a"]);
+  assertEquals(scanned, 3);
+});
+
+Deno.test("diversify: reports scanned so the cursor can skip held-back rows", () => {
+  const { kept, scanned } = diversify(rowsOf("a", "b", "c", "d"), 2, (r) => r.author);
+  assertEquals(kept.map((r) => r.author), ["a", "b"]);
+  assertEquals(scanned, 2);
+});
+
+Deno.test("diversify: state carries across windows of one page", () => {
+  const { kept: firstKept, state } = diversify(rowsOf("a", "x", "b"), 20, (r) => r.author);
+  assertEquals(firstKept.map((r) => r.author), ["a", "x", "b"]);
+  // The previous window ended on `b`, so its run continues here: one more `b`
+  // is allowed, a second is held back in favour of `c`. Without carried
+  // state this window would have read [b, b, c].
+  const { kept } = diversify(rowsOf("b", "b", "c"), 20, (r) => r.author, state);
+  assertEquals(kept.map((r) => r.author), ["b", "c"]);
+});

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -5,6 +5,7 @@ import * as relationsRepo from "@/db/repositories/relations.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import { type Cursor, DEFAULT_PAGE_SIZE, encodeCursor } from "@/lib/pagination.ts";
+import { diversify, freshDiversityState } from "@/lib/feedDiversity.ts";
 import { badRequest, forbidden, notFound } from "@/lib/http.ts";
 import { MAX_TAGS_PER_POST, normalizeTags } from "@/lib/tags.ts";
 import { type LanguageFilter, normalizeLanguage } from "@/lib/languages.ts";
@@ -525,22 +526,69 @@ export async function listByAuthor(
   return pageOf(rows, DEFAULT_PAGE_SIZE);
 }
 
-export async function globalTimeline(
-  cursor: Cursor | null,
-  viewerId: string | null = null,
-  langFilter: LanguageFilter | null = null,
-) {
-  const rows = await postsRepo.listGlobal(viewerId, cursor, DEFAULT_PAGE_SIZE, langFilter);
-  return pageOf(rows, DEFAULT_PAGE_SIZE);
+// Discovery timelines assemble each page with author diversity (see
+// lib/feedDiversity.ts): a wide window is fetched in rank order and posts are
+// picked under two caps — never more than two posts by one author in a row,
+// and at most ~a fifth of the page per author — so one prolific writer (say,
+// an eight-part series) can't make the whole instance look monotonous. The
+// cursor advances past every row examined: a held-back post before the page's
+// last row is trimmed from this timeline (it stays on profiles, tag pages,
+// search and trending), one after it returns with the next page. Each pass
+// accepts at least one row, so assembly always progresses.
+const FEED_WINDOW = DEFAULT_PAGE_SIZE * 4;
+
+async function diversifiedTimelinePage(
+  fetchRows: (cursor: Cursor | null, limit: number) => Promise<postsRepo.PostWithAuthor[]>,
+  start: Cursor | null,
+): Promise<{ items: postsRepo.PostWithAuthor[]; nextCursor: string | null }> {
+  let cursor = start;
+  const items: postsRepo.PostWithAuthor[] = [];
+  let state = freshDiversityState();
+  for (;;) {
+    // Repos fetch limit+1; the overflow only signals "more in the DB".
+    const rows = await fetchRows(cursor, FEED_WINDOW);
+    if (!rows.length) return { items, nextCursor: null };
+    const result = diversify(rows, DEFAULT_PAGE_SIZE - items.length, (row) => {
+      return row.post.authorId ?? row.post.remoteActorId ?? "";
+    }, state);
+    state = result.state;
+    items.push(...result.kept);
+    const lastScanned = rows[result.scanned - 1];
+    if (!lastScanned) return { items, nextCursor: null };
+    cursor = { createdAt: lastScanned.post.createdAt.toISOString(), id: lastScanned.post.id };
+    const windowDrained = result.scanned >= rows.length;
+    const dbDrained = rows.length <= FEED_WINDOW;
+    if (items.length >= DEFAULT_PAGE_SIZE) {
+      return {
+        items,
+        nextCursor: !windowDrained || !dbDrained ? encodeCursor(cursor) : null,
+      };
+    }
+    if (windowDrained && dbDrained) return { items, nextCursor: null };
+    // Short page with more source behind it — pull the next window.
+  }
 }
 
-export async function localTimeline(
+export function globalTimeline(
   cursor: Cursor | null,
   viewerId: string | null = null,
   langFilter: LanguageFilter | null = null,
 ) {
-  const rows = await postsRepo.listLocal(viewerId, cursor, DEFAULT_PAGE_SIZE, langFilter);
-  return pageOf(rows, DEFAULT_PAGE_SIZE);
+  return diversifiedTimelinePage(
+    (c, limit) => postsRepo.listGlobal(viewerId, c, limit, langFilter),
+    cursor,
+  );
+}
+
+export function localTimeline(
+  cursor: Cursor | null,
+  viewerId: string | null = null,
+  langFilter: LanguageFilter | null = null,
+) {
+  return diversifiedTimelinePage(
+    (c, limit) => postsRepo.listLocal(viewerId, c, limit, langFilter),
+    cursor,
+  );
 }
 
 // The discovery rail's "Trending" list — "Last 7 days": a short, unpaginated set of


### PR DESCRIPTION
## Symptom
The homepage feed could be filled by a single author: 8 of 20 posts were one writer's similarly-titled 'UNIX-programming-*' series. To a new reader the instance looks monotonous.

## Root cause
`globalTimeline`/`localTimeline` returned raw newest-first keyset pages. Nothing considered *who* wrote what, so any prolific author (or an automated series publisher) could own an entire page.

## Fix
Assemble each Global/Local page with author diversity (new `lib/feedDiversity.ts`, pure + unit-tested):

- **Consecutive cap** — at most 2 posts by one author in a row, as long as another eligible post exists later in the fetched window to take the slot.
- **Share cap** — at most ~a fifth of a page per author (4 of 20; minimum 2 so a small instance's lone active writer keeps presence).
- A window of 4× the page size is fetched in rank order and picked greedily; counters carry across windows via `DiversityState`. When nothing else fits, caps relax rather than return a short page — starving the feed would be worse than a third post in a row.
- The keyset cursor advances past every row examined: held-back posts before the page's last row are trimmed from this timeline (they remain on profiles, tag pages, search, trending); ones after it are re-offered next page. Each pass accepts ≥1 row, so pagination always progresses.

Series grouping (collapsing 'series-*' titled posts) is deliberately not attempted here — it needs a series convention to exist first; the caps alone resolve the reported monotony.

Also cleans up two `require-await` lint errors and missing `deno fmt` on tags.ts left by #105 (separate commit).

## Verified
- `deno task check`, `deno task lint`, `deno task fmt`
- `deno task test`: 187 passed incl. 6 new `feedDiversity` unit tests pinning both caps, relaxation, cursor-skip semantics, cross-window state
- API shape unchanged (`items`/`nextCursor`) — frontend untouched

## Deploy notes
Plain `docker compose up -d`; no migration, no env change.