### PR TITLE
fix(test): tag advertised count expectation after trending seeds

### DIFF
--- a/apps/backend/tests/integration/visibility_test.ts
+++ b/apps/backend/tests/integration/visibility_test.ts
@@ -167,8 +167,9 @@ Deno.test("public listings exclude unpublished posts and suspended authors", opt
 
   await t.step("the tag's advertised count matches the listing it labels", async () => {
     // A count taken over a wider set than the list beneath it tells the reader
-    // how many posts are being withheld (#55).
-    assertEquals(await tagsRepo.postCount(rust.id, null), 1);
+    // how many posts are being withheld (#55). Three visible posts: `live`
+    // plus the two extra authors seeded above for trending eligibility.
+    assertEquals(await tagsRepo.postCount(rust.id, null), 3);
   });
 
   await t.step("trending ranks the tag by visible posts only", async () => {


### PR DESCRIPTION
## Symptom
CI on main (Backend job, integration tests): \`the tag's advertised count matches the listing it labels\` failed — AssertionError actual 3, expected 1 at visibility_test.ts:171.

## Root cause
#104 seeded two extra visible 'rust' posts by two extra authors so the tag clears the >=3-posts / >=3-distinct-authors trending gate. The trending step's expectation was updated to postCount 3, but the adjacent advertised-count step still asserted 1 — those same seeds changed that number too. PR CI doesn't run the integration suite, so it surfaced only on the main push.

## Fix
Expect 3 in the advertised-count step, with a comment tying it to the seeds.

## Verified
- Reproduced locally against postgres:16-alpine before the fix (same failure)
- After: \`deno task test:integration\` 14 passed / 0 failed; \`deno task check\`, \`deno task lint\`, \`deno fmt --check\`, unit \`deno task test\` 187 all clean
