### PR TITLE
fix(discover): drop trending ranking note, restore plain header

### DIFF
--- a/apps/frontend/src/lib/components/Discover.svelte
+++ b/apps/frontend/src/lib/components/Discover.svelte
@@ -28,16 +28,7 @@
     <section>
       <h2 class="mb-3 flex items-center gap-2 text-base font-semibold text-foreground">
         <Icon name="trending" size={18} /> Trending
-        <span
-          class="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
-          title="Ranking: likes×1 + comments×2, then divided by (hours+2)^1.5 for recency decay — author's own likes/comments excluded"
-          >Last 7 days</span
-        >
       </h2>
-      <p class="-mt-1 mb-3 text-xs leading-relaxed text-muted-foreground">
-        Ranking: <span class="font-medium text-foreground">likes×1 + comments×2</span> ÷ (hours+2)<sup>1.5</sup> — author's
-        own votes excluded, older posts decay gradually.
-      </p>
       <ol class="space-y-4">
         {#each posts as post, i (post.id)}
           <li class="flex gap-3">


### PR DESCRIPTION
## Symptom
The Trending header in the right rail carried a 'Last 7 days' pill and a three-line formula explanation (likes×1 + comments×2 ÷ (hours+2)^1.5 …) between the header and the post list, added in #102.

## Fix
Removes the badge and the explanation paragraph, restoring the plain icon + 'Trending' header from before #102. The ranking behaviour itself (7-day window, weights, decay, self-vote filter) is unchanged in the backend.

## Verified
- `svelte-check --threshold error`: 0 errors, 0 warnings
- `vitest --run src/lib/components/Discover.test.ts`: 2 passed