### PR TITLE
fix(trending): month window for posts, raw usage for tags

### DIFF
--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -583,9 +583,8 @@ export function searchPosts(
     .limit(limit);
 }
 
-// Trending: the most-engaged published Article posts from the last 7 days.
-// The UI shows "Last 7 days" so the window must match what the reader sees; a
-// post older than that never appears, no matter how many likes it once had.
+// Trending: the most-engaged published Article posts from the last 30 days.
+// A post older than that never appears, no matter how many likes it once had.
 // Score is intentionally documented here so the ranking is not a black box:
 //
 //   weighted = likes*1 + comments*2   (comments signal deeper engagement, so
@@ -604,7 +603,7 @@ export function searchPosts(
 // author are excluded from the counts (self-like / self-reply would otherwise
 // let an author push their own post). Remote posts have no local authorId and
 // are counted as-is. No pagination — this is a short discovery list.
-export function listTrending(viewerId: string | null, limit = 5, sinceDays = 7) {
+export function listTrending(viewerId: string | null, limit = 5, sinceDays = 30) {
   const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
   const score = sql<number>`(
     (

--- a/apps/backend/src/db/repositories/tags.ts
+++ b/apps/backend/src/db/repositories/tags.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { and, desc, eq, gt, inArray, notInArray, sql } from "drizzle-orm";
+import { and, desc, eq, inArray, sql } from "drizzle-orm";
 import { db } from "@/db/client.ts";
 import { isPublished, notSuspended, visibleToViewer } from "@/db/repositories/posts.ts";
 import { posts, postTags, remoteActorTags, tagAliases, tagFollows, tags, users, userTags } from "@/db/schema.ts";
@@ -217,56 +217,26 @@ export async function mergeTags(fromSlug: string, toSlug: string): Promise<void>
   });
 }
 
-// Tags that should never appear in trending — personal/joke tags that were
-// surfacing at the top (e.g. larp, idk, khazar, divineintellect). The list is
-// intentionally small and explicit; broader moderation is handled by the
-// distinct-author and minimum-use thresholds below. Keep lowercase slugs only.
-// Managed in code for now; a future admin panel could move this to
-// instance_settings (trending_blocked_tags).
-const TRENDING_BLOCKED_SLUGS = new Set(["larp", "idk", "khazar", "divineintellect"]);
-
-// Trending tags: most-used across posts published in the last 7 days
-// (matches the "Last 7 days" window used for trending posts).
-//
-// Quality gates: a tag must appear on at least 3 posts by at least 3 distinct
-// authors in the window to be eligible. This prevents a single author's
-// personal or joke tag from dominating the discovery rail. Blocklisted slugs
-// are excluded in the WHERE clause before aggregation.
-export function trending(limit: number, sinceDays = 7): Promise<TagWithCount[]> {
-  const since = new Date(Date.now() - sinceDays * 24 * 60 * 60 * 1000);
-  const blocked = [...TRENDING_BLOCKED_SLUGS];
-  return (
-    db
-      .select({
-        slug: tags.slug,
-        name: tags.name,
-        postCount: sql<number>`count(${postTags.postId})::int`,
-      })
-      .from(tags)
-      .innerJoin(postTags, eq(postTags.tagId, tags.id))
-      .innerJoin(posts, eq(posts.id, postTags.postId))
-      .leftJoin(users, eq(posts.authorId, users.id))
-      // Ranked over what a logged-out reader can see. Trending is a global
-      // ranking, not a personalized one, so it is computed as anonymous rather
-      // than threaded with a viewer — and a suspended or private author must not
-      // push a tag up a board that everyone sees.
-      .where(
-        and(
-          eq(posts.apType, "Article"),
-          gt(posts.createdAt, since),
-          isPublished,
-          notSuspended,
-          visibleToViewer(null),
-          blocked.length ? notInArray(tags.slug, blocked) : undefined,
-        ),
-      )
-      .groupBy(tags.id)
-      .having(
-        sql`count(${postTags.postId}) >= 3 and count(distinct coalesce(${posts.authorId}::text, ${posts.remoteActorId}::text)) >= 3`,
-      )
-      .orderBy(desc(sql`count(${postTags.postId})`))
-      .limit(limit)
-  );
+// Trending tags: the most-used tags across published posts, no time window
+// and no quality gates — raw usage is the ranking. Visibility still applies
+// (only published articles by non-suspended authors, as an anonymous reader
+// sees them), so a private or suspended post never pushes a tag up a board
+// that everyone sees.
+export function trending(limit: number): Promise<TagWithCount[]> {
+  return db
+    .select({
+      slug: tags.slug,
+      name: tags.name,
+      postCount: sql<number>`count(${postTags.postId})::int`,
+    })
+    .from(tags)
+    .innerJoin(postTags, eq(postTags.tagId, tags.id))
+    .innerJoin(posts, eq(posts.id, postTags.postId))
+    .leftJoin(users, eq(posts.authorId, users.id))
+    .where(and(eq(posts.apType, "Article"), isPublished, notSuspended, visibleToViewer(null)))
+    .groupBy(tags.id)
+    .orderBy(desc(sql`count(${postTags.postId})`))
+    .limit(limit);
 }
 
 // Tag pages for the XML sitemap: the slug, plus the newest post carrying it as

--- a/apps/backend/src/services/posts.ts
+++ b/apps/backend/src/services/posts.ts
@@ -580,8 +580,8 @@ export function localTimeline(
   return diversifiedTimelinePage((c, limit) => postsRepo.listLocal(viewerId, c, limit, langFilter), cursor);
 }
 
-// The discovery rail's "Trending" list — "Last 7 days": a short, unpaginated set of
-// the most engaged posts from the last 7 days, filtered by the viewer's
+// The discovery rail's "Trending" list: a short, unpaginated set of
+// the most engaged posts from the last 30 days, filtered by the viewer's
 // mutes/blocks. Rank = (likes×1 + comments×2, without self-votes) /
 // (hours+2)^1.5 so fresh engagement outranks stale bulk. See
 // db/repositories/posts.ts:listTrending for the documented formula.

--- a/apps/frontend/src/lib/components/Discover.svelte
+++ b/apps/frontend/src/lib/components/Discover.svelte
@@ -103,14 +103,7 @@
     <section>
       <h2 class="mb-3 flex items-center gap-2 text-base font-semibold text-foreground">
         <Icon name="tag" size={18} /> Topics
-        <span
-          class="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"
-          title="Most used tags in the last 7 days — counts are posts in that window">Last 7 days</span
-        >
       </h2>
-      <p class="-mt-1 mb-3 text-xs leading-relaxed text-muted-foreground">
-        Most used in the last 7 days — counts are posts in that window.
-      </p>
       <div class="flex flex-wrap gap-2">
         {#each tags as tag (tag.slug)}
           <Button
@@ -118,12 +111,12 @@
             variant="outline"
             size="xs"
             class="rounded-full font-medium!"
-            title={`${tag.postCount} posts in the last 7 days`}
+            title={`${tag.postCount} posts`}
           >
             <Icon name="tag" size={13} />
             {tag.name}
             <span class="text-muted-foreground">{tag.postCount}</span>
-            <span class="sr-only">posts in the last 7 days</span>
+            <span class="sr-only">posts</span>
           </Button>
         {/each}
       </div>


### PR DESCRIPTION
## Symptom
On a quiet instance the right rail's Topics section rendered empty (no hashtags at all) and Trending kept showing the same couple of posts, because both rankings were restricted to the last 7 days and tags additionally required ≥3 posts by ≥3 distinct authors plus a slug blocklist (#102, #104).

## Fix
- Trending posts: window widened from 7 to 30 days. Scoring (likes×1 + comments×2 over (hours+2)^1.5, self-votes excluded) is unchanged.
- Trending tags: ranked by all-time usage across published, visible (anonymous-view) Article posts — no time window, no thresholds, no blocklist. Basic visibility filters (published, non-suspended author, anonymous visibility) remain so private/suspended content can't surface.
- Topics header: 'Last 7 days' badge and window description removed to match the plain Trending header (#110); tooltips now just say "N posts".

## Verified
- `deno check` on the touched backend modules: clean
- oxlint + oxfmt on changed files: clean
- `svelte-check --threshold error`: 0 errors
- vitest Discover tests: 2 passed
- Not verified against a live database (no integration tests exist for these queries)