### PR TITLE
fix(feed): stop infinite refetch loop on Local/Global tabs

### DIFF
--- a/apps/frontend/src/routes/+page.svelte
+++ b/apps/frontend/src/routes/+page.svelte
@@ -113,15 +113,22 @@
   // is personal; guests have no filter UI and stay unfiltered.
   $effect(() => {
     if (!personalized) return;
-    // track
+    // Only the language prefs are tracked. Everything else — the active tab and
+    // the feeds' loaded/loading flags — must stay untracked: those flags are
+    // written when a fetch settles, and a tracked write here re-runs the effect,
+    // which refetches, which writes them again… an endless loop that kept the
+    // tab on "Loading…" forever. Tab loads don't need this effect anyway —
+    // `onValueChange={ensureLoaded}` handles them, and the fetch closures read
+    // the filter live at call time.
     void reading.feedLangs;
     void reading.feedLangMode;
-    if (activeTab === "for-you") return;
-    // don't refetch before the initial tab's first load has settled
-    const feed = feeds.find((f) => f.value === activeTab);
-    if (!feed?.loaded || feed.loading) return;
-    // use untrack to avoid re-triggering on feed mutation
-    untrack(() => refetch(activeTab));
+    untrack(() => {
+      if (activeTab === "for-you") return;
+      // don't refetch before the tab's first load has settled
+      const feed = feeds.find((f) => f.value === activeTab);
+      if (!feed?.loaded || feed.loading) return;
+      refetch(activeTab);
+    });
   });
 
   // Discards a feed's cached page and reloads it (used when the language filter


### PR DESCRIPTION
## Symptom

For most signed-in users the Local and Global feed tabs hang on "Loading…" forever. Guests and the For-you tab are unaffected.

## Root cause

The language-filter `` on the home page read `feed.loaded` / `feed.loading` **outside** its `untrack` block. `feeds` is a `` array, so those property reads are tracked. When a tab's fetch settled, `ensureLoaded` wrote `loaded = true`, which re-ran the effect; the effect saw `loaded && !loading` and called `refetch()`, which cleared the items and fetched again — whose completion wrote the flags again, re-running the effect, and so on forever. Every tab switch to an already-loaded Local/Global also triggered a spurious refetch, because `activeTab` was tracked too.

Introduced with the feed language filter (#91/#93, Aug 23). Signed-in viewers only (the effect returns early for guests) and Local/Global only (early return for For-you) — matching the "works for me, broken for most" reports.

## Fix

Track only what the effect exists for: `reading.feedLangs` / `reading.feedLangMode`. Everything else (active tab, feed flags) moves inside `untrack`. Tab loads don't need the effect — `onValueChange={ensureLoaded}` handles them, and the fetch closures read the filter live at call time.

## Verified

- `svelte-check`: 0 errors, 0 warnings
- `oxlint` / `oxfmt --check`: clean (pre-existing warnings in untouched files)
- `vitest run`: 26/26 pass

Not verified against a running instance (no reproduction env here); the loop mechanism is confirmed from the tracked-read → write cycle in the code.

## Deploy notes

None — takes effect with a normal frontend rebuild/redeploy.