### PR TITLE
feat(highlight): widen code block language detection

### DIFF
--- a/apps/frontend/src/lib/codeLanguages.ts
+++ b/apps/frontend/src/lib/codeLanguages.ts
@@ -12,9 +12,10 @@
  * Each value is a name highlight.js knows (it is what ends up in
  * `class="language-…"` and what the reader highlights with) and that
  * lib/fileIcons.ts can resolve to a mark. The list is the common bundle's
- * useful half rather than all ~190: an author whose language is missing can
- * still name the file `main.nim` and get both the highlighting and the mark
- * from the extension.
+ * useful half plus the handful the reader registers on top (see
+ * lib/highlight.ts), rather than all ~190: an author whose language is still
+ * missing can name the file `main.nim` and get both the highlighting and the
+ * mark from the extension.
  */
 export const CODE_LANGUAGES: ReadonlyArray<{ value: string; label: string }> = [
   { value: "typescript", label: "TypeScript" },

--- a/apps/frontend/src/lib/highlight.test.ts
+++ b/apps/frontend/src/lib/highlight.test.ts
@@ -1,0 +1,63 @@
+import { highlightCodeBlocks } from "$lib/highlight";
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// The reader-side highlighter runs at read time over stored HTML. These tests
+// pin the contract per block kind: a declared language always highlights and
+// captions, a confident guess highlights without a caption (a caption would
+// present a guess as the author's fact), prose in a bare fence stays plain,
+// and the shell-command transcript — which relevance alone cannot vouch for,
+// since `sudo dnf install …` scores below an English sentence — is rescued by
+// the stopword guard rather than by a lower global threshold.
+import { describe, expect, it } from "vitest";
+
+const wrap = (code: string, codeAttrs = "", preAttrs = "") => `<pre${preAttrs}><code${codeAttrs}>${code}</code></pre>`;
+
+describe("highlightCodeBlocks", () => {
+  it("highlights and captions a declared language", () => {
+    const out = highlightCodeBlocks(wrap("const x = 1", ' class="language-typescript"'));
+    expect(out).toContain('class="hljs language-typescript"');
+    expect(out).toContain("<figcaption");
+    expect(out).toContain("TypeScript");
+  });
+
+  it("highlights a declared language the common bundle does not carry", () => {
+    const out = highlightCodeBlocks(wrap("FROM node:20-alpine\nRUN pnpm install", ' class="language-dockerfile"'));
+    expect(out).toContain('class="hljs language-dockerfile"');
+  });
+
+  it("captions an unregistered declared language without highlighting", () => {
+    const out = highlightCodeBlocks(wrap("let x = 1", ' class="language-nim"'));
+    expect(out).not.toContain("hljs");
+    expect(out).toContain("Nim");
+  });
+
+  it("colors a bare shell command transcript and does not caption the guess", () => {
+    const src = "sudo dnf install -y openssh-server\nsudo systemctl enable --now sshd";
+    const out = highlightCodeBlocks(wrap(src));
+    expect(out).toContain('class="hljs language-bash"');
+    expect(out).not.toContain("<figcaption");
+  });
+
+  it("colors a single low-scoring command line", () => {
+    const out = highlightCodeBlocks(wrap("sudo firewall-cmd --permanent --add-service=ssh"));
+    expect(out).toContain('class="hljs language-bash"');
+  });
+
+  it("leaves English prose in a bare fence plain", () => {
+    const src = "If it shows enabled we can do our next step. For now, we need to control it in our private network.";
+    const out = highlightCodeBlocks(wrap(src));
+    expect(out).toBe(wrap(src));
+  });
+
+  it("leaves a block with no shell signal plain", () => {
+    const src = "hostname -I";
+    const out = highlightCodeBlocks(wrap(src));
+    expect(out).toBe(wrap(src));
+  });
+
+  it("keeps the filename caption on an empty block", () => {
+    const out = highlightCodeBlocks(wrap("\n", "", ' data-title="notes.txt"'));
+    expect(out).toContain('data-title="notes.txt"');
+    expect(out).toContain("<figcaption");
+  });
+});

--- a/apps/frontend/src/lib/highlight.ts
+++ b/apps/frontend/src/lib/highlight.ts
@@ -1,7 +1,14 @@
 import { codeLanguageLabel } from "$lib/codeLanguages";
 import { type FileIcon, fileIcon } from "$lib/fileIcons";
+import type { LanguageFn } from "highlight.js";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import hljs from "highlight.js/lib/common";
+import dart from "highlight.js/lib/languages/dart";
+import dockerfile from "highlight.js/lib/languages/dockerfile";
+import elixir from "highlight.js/lib/languages/elixir";
+import haskell from "highlight.js/lib/languages/haskell";
+import powershell from "highlight.js/lib/languages/powershell";
+import scala from "highlight.js/lib/languages/scala";
 
 // Syntax highlighting for rendered post bodies.
 //
@@ -25,7 +32,11 @@ import hljs from "highlight.js/lib/common";
 //
 // The `common` bundle carries ~40 languages rather than all ~190. It is the
 // standard highlight.js subset and covers what people put in blog posts; an
-// unrecognised language falls back to plain text rather than failing.
+// unrecognised language falls back to plain text rather than failing. On top
+// of it we register the languages the editor's picker offers that the bundle
+// leaves out (Dockerfile, Elixir, …) — a language the picker promises but the
+// reader cannot highlight would be a silently broken promise, and every one
+// registered here also widens what auto-detection can find.
 
 // Post HTML is sanitizer-normalised, so a code block is always exactly this
 // shape: sanitize-html re-serialises the tree and drops every attribute that
@@ -42,8 +53,51 @@ const LANGUAGE_CLASS = /(?:^|[\s"'])language-([\w+#.-]+)/i;
 
 // Below this, highlight.js is guessing. An auto-detected block that scores low
 // is usually prose or config in a fenced block, where speculative colouring
-// looks like a bug — leave those plain.
-const MIN_AUTO_RELEVANCE = 5;
+// looks like a bug — leave those plain. The floor sits at six because English
+// prose measurably reaches five: "If it shows enabled we can do our next
+// step" scores five as VB.NET ("do", "next", "step", "to", "in" are all its
+// keywords), so five cannot tell sentence from snippet. Shell command
+// transcripts, which score far lower still, are handled separately below —
+// see SHELL_GRAMMARS.
+const MIN_AUTO_RELEVANCE = 6;
+
+// The languages the editor's picker offers that `highlight.js/lib/common`
+// leaves unregistered (toml, tsx and jsx already resolve — they are aliases of
+// ini and javascript). Registering them is what makes a declared ```dockerfile
+// or ```elixir fence highlight instead of silently rendering plain.
+const PICKER_LANGUAGES: ReadonlyArray<[string, LanguageFn]> = [
+  ["dart", dart],
+  ["dockerfile", dockerfile],
+  ["elixir", elixir],
+  ["haskell", haskell],
+  ["powershell", powershell],
+  ["scala", scala],
+];
+for (const [name, grammar] of PICKER_LANGUAGES) hljs.registerLanguage(name, grammar);
+
+// The one gap a relevance floor can never close: the shell command transcript.
+// A tutorial's `sudo dnf install -y openssh-server` scores 1–3 — bash has few
+// keywords to reward — while an English sentence routinely scores higher still
+// ("and", "in", "is" are SQL and VB.NET keywords to the highlighter), so no
+// threshold colours the commands without colouring the prose. What actually
+// separates them is not relevance but function words: prose cannot be written
+// without them, and a command transcript contains none (measured: prose ≥ 0.5,
+// commands 0.0). So an undeclared block whose best guess is a shell grammar,
+// scoring at least something, and reading as no prose, is a command transcript
+// — colour it. The stopword guard is what keeps an English sentence that
+// happens to score bash from being painted; the ratio sits far below prose's
+// floor, and a declared language is never overridden by the rescue.
+const SHELL_GRAMMARS = new Set(["bash", "shell"]);
+const PROSE_WORDS =
+  /\b(?:the|a|an|and|or|but|if|then|else|when|we|you|they|it|is|are|was|were|be|been|being|to|of|in|on|at|for|with|from|by|that|this|these|those|there|here|as|so|not|no|can|could|should|would|will|shall|may|might|must|do|does|did|have|has|had|our|your|their|its|his|her|my|me|us|them|he|she)\b/gi;
+const MAX_PROSE_STOPWORD_RATIO = 0.25;
+
+function readsAsProse(source: string): boolean {
+  const words = source.match(/[a-zA-Z']+/g) ?? [];
+  if (words.length < 3) return false;
+  const matches = source.match(PROSE_WORDS) ?? [];
+  return matches.length / words.length > MAX_PROSE_STOPWORD_RATIO;
+}
 
 // The five entities sanitize-html emits, back to their characters. `&amp;` is
 // undone last: doing it first would turn a literal `&lt;` written by the author
@@ -63,7 +117,9 @@ function decodeEntities(html: string): string {
  *
  * The language comes from the `language-*` class a Markdown fence produces
  * (```ts). Without one — an editor code block, which carries no language — the
- * language is detected, and left alone when detection is not confident.
+ * language is detected, and left alone when detection is not confident. The
+ * exception is a shell command transcript, which relevance alone cannot vouch
+ * for (see SHELL_GRAMMARS).
  *
  * Returns the HTML unchanged when it holds no code, so an ordinary post costs
  * one `includes` and nothing else.
@@ -91,7 +147,13 @@ export function highlightCodeBlocks(html: string): string {
         language = declared;
       } else {
         const auto = hljs.highlightAuto(source);
-        if (!auto.language || auto.relevance < MIN_AUTO_RELEVANCE) {
+        // Confident guess, or an undeclared shell transcript (see
+        // SHELL_GRAMMARS above — never over a declared language: the author
+        // said what the block is, and a guess must not paint over that).
+        const confident =
+          auto.relevance >= MIN_AUTO_RELEVANCE ||
+          (!declared && SHELL_GRAMMARS.has(auto.language ?? "") && auto.relevance > 0 && !readsAsProse(source));
+        if (!auto.language || !confident) {
           return withTitle(block, title, declared);
         }
         value = auto.value;


### PR DESCRIPTION
## Symptom

In a tutorial post, only code blocks whose language the author explicitly declared (e.g. ```shell) got a label and syntax colors; bare ``` fences full of shell commands rendered as plain gray text, even though they are obviously commands.

## Root cause (measured, not guessed)

Two gaps in the read-time highlighter (`apps/frontend/src/lib/highlight.ts`):

1. **The editor's language picker promises languages the reader cannot highlight.** The picker offers Dockerfile, PowerShell, Elixir, Haskell, Dart and Scala, but `highlight.js/lib/common` does not register them (`toml`, `tsx`, `jsx` already resolve as aliases of `ini`/`javascript`). A declared ```dockerfile fence silently fell into the auto-detect branch and rendered plain.

2. **No relevance threshold can detect command transcripts.** `hljs.highlightAuto` scores the tutorial's blocks at 1–3 (`sudo dnf install -y openssh-server` → bash, 1) because bash has few keywords to reward — while English prose scores *higher* ("If it shows enabled we can do our next step…" → 5 as VB.NET, since "do/next/step/to/in" are its keywords; SQL feeds on "and/in/is"). So lowering the floor to catch commands necessarily mis-colors prose. An earlier suggestion to simply lower `MIN_AUTO_RELEVANCE` to 2 was tested against real snippets and rejected on this evidence.

## Fix

- Register the six missing picker languages on top of the common bundle.
- Rescue shell transcripts specifically: an **undeclared** block whose top guess is a shell grammar (`bash`/`shell`) with any positive relevance, and whose text carries almost no English function words (stopword ratio ≤ 0.25; measured: prose ≥ 0.50, commands 0.00 — the only clean separator found), is highlighted as shell. The rescue never overrides a declared language.
- Raise the global floor 5 → 6, since prose measurably reaches 5. Non-shell guesses keep the conservative gate.

## What this changes for readers

- The reported post's command blocks (`sudo dnf install…`, `firewall-cmd…`, `systemctl…`) now highlight as bash. `hostname -I` / `ssh user@IP` stay plain — nothing in them matches any grammar, so coloring would add nothing.
- Prose in bare fences stays plain (including sentences that were mis-colored as VB.NET at the old threshold).
- Declared ```dockerfile/```powershell/etc. blocks now actually highlight.
- Captions still only ever show author-declared languages, never guesses.

Retroactive by design: highlighting runs at read time, so existing posts pick all of this up on the next render — no migration.

## Verified

- New `highlight.test.ts` (8 cases): declared+caption, newly registered language, unregistered declaration captioned plain, transcript rescued without caption, single command line, prose left byte-identical, no-signal block untouched, empty titled block caption.
- Full suite: 34/34 pass; `svelte-check`, `oxlint`, `oxfmt --check` clean (warnings pre-existing in untouched files).
- Score distributions measured against the installed highlight.js 11.12 with the exact snippets from the reported post.

## Deploy notes

None — normal frontend rebuild/redeploy.
