### PR TITLE
fix(ui): align post byline meta rows on mobile

### DIFF
--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -274,7 +274,15 @@
         {post.author.displayName}
       </Button>
       <div class="flex flex-col gap-1 text-muted-foreground sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
-        <Time iso={post.createdAt} />
+        <!-- Every row shares one structure — icon, gap, text — so the stacked
+             mobile layout lines up in two clean columns instead of the date's
+             text sitting flush while the icon rows' text hangs indented. The
+             calendar icon is mobile-only: on sm+ the meta is a single wrapped
+             line where the bare date reads fine. -->
+        <span class="flex items-center gap-1">
+          <Icon name="calendar" size={13} class="sm:hidden" />
+          <Time iso={post.createdAt} />
+        </span>
         <Separator.Root orientation="vertical" class="hidden shrink-0 bg-border sm:block sm:h-3 sm:w-px" />
         <span class="flex items-center gap-1"><Icon name="clock" size={13} /> {minutes} min read</span>
         {#if post.remote && originInstance}


### PR DESCRIPTION
## Symptom

On mobile, the post page byline looks misaligned under the author name: the date ("Aug 25, 2026, 09:22") starts flush at the text column edge, while "3 min read" and "English" start ~17px further right, because their leading 13px icons plus the 4px gap push the text over. The text edge alternates down the stacked rows.

## Root cause

The meta container (`apps/frontend/src/routes/[handle]/[slug]/+page.svelte`) stacks its rows vertically on mobile (`flex-col`), but its children mix two structures: the `<Time>` element is bare text (flush left), while the read-time/language rows are `flex items-center gap-1` rows whose icon consumes the first 17px. Nothing sets a shared text column, so the rows don't line up.

## Fix

Give every meta row the same icon-gap-text structure: the date is wrapped in the same kind of row and gets a 13px calendar icon, scoped `sm:hidden` so the desktop byline (a single wrapped line with separators, where the bare date already reads fine) is pixel-identical to before.

Result on mobile: icons form one aligned column at the edge (under the author name), all meta text aligns in a second column.

## Verified

- `svelte-check`, `oxfmt --check`, `vitest` (34/34) pass; `oxlint` warnings are pre-existing in untouched files.
- Not verified in a real mobile browser (no reproduction env here) — the change is pure flex geometry with standard utilities.

## Deploy notes

None — normal frontend rebuild/redeploy.
