### PR TITLE
fix(ui): flush mobile byline meta, icons inline only on sm+

### DIFF
--- a/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
+++ b/apps/frontend/src/routes/[handle]/[slug]/+page.svelte
@@ -274,25 +274,29 @@
         {post.author.displayName}
       </Button>
       <div class="flex flex-col gap-1 text-muted-foreground sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
-        <!-- Every row shares one structure — icon, gap, text — so the stacked
-             mobile layout lines up in two clean columns instead of the date's
-             text sitting flush while the icon rows' text hangs indented. The
-             calendar icon is mobile-only: on sm+ the meta is a single wrapped
-             line where the bare date reads fine. -->
-        <span class="flex items-center gap-1">
-          <Icon name="calendar" size={13} class="sm:hidden" />
-          <Time iso={post.createdAt} />
-        </span>
+        <!-- Mobile stacks the meta under the name as plain text: icons are
+             hidden there because anything in front of the text pushes that
+             row out of the shared left edge. On sm+ the meta is a single
+             wrapped line, where the icons read as inline decoration. -->
+        <Time iso={post.createdAt} />
         <Separator.Root orientation="vertical" class="hidden shrink-0 bg-border sm:block sm:h-3 sm:w-px" />
-        <span class="flex items-center gap-1"><Icon name="clock" size={13} /> {minutes} min read</span>
+        <span class="flex items-center gap-1">
+          <Icon name="clock" size={13} class="hidden sm:inline" />
+          {minutes} min read
+        </span>
         {#if post.remote && originInstance}
           <Separator.Root orientation="vertical" class="hidden shrink-0 bg-border sm:block sm:h-3 sm:w-px" />
-          <span class="flex items-center gap-1"><Icon name="globe" size={13} /> {originInstance}</span>
+          <span class="flex items-center gap-1">
+            <Icon name="globe" size={13} class="hidden sm:inline" />
+            {originInstance}
+          </span>
         {/if}
         {#if post.language}
           <Separator.Root orientation="vertical" class="hidden shrink-0 bg-border sm:block sm:h-3 sm:w-px" />
-          <span class="flex items-center gap-1"><Icon name="languages" size={13} /> {languageLabel(post.language)}</span
-          >
+          <span class="flex items-center gap-1">
+            <Icon name="languages" size={13} class="hidden sm:inline" />
+            {languageLabel(post.language)}
+          </span>
         {/if}
       </div>
     </div>


### PR DESCRIPTION
## Symptom

After #114, the mobile byline showed each meta row as icon + indented text (icons in a column at the edge, text starting ~17px in). Feedback: it does not look good — every parameter should sit on one shared vertical line with the author name.

## Cause

Any icon placed in front of a stacked row's text pushes that text off the shared left edge; with icons in the rows, either the text indents (two columns) or the icons must leave the rows.

## Fix

On mobile the meta rows are plain text — date, read time, (instance,) language — all flush at the same left edge as the author name. The icons are hidden below `sm` (`hidden sm:inline`) and stay inline in the desktop single-line meta, where they sit between separators and break no column. The calendar icon added in #114 is dropped entirely; the desktop byline is back to its pre-#114 rendering.

Mobile result:

```
Subhan Gadirli
Aug 25, 2026, 09:22
3 min read
English
```

## Verified

- `svelte-check` clean, `oxfmt --check` clean, `vitest` 34/34.
- Pure display-utility change; not visually verified in a real mobile browser (no repro env here).

## Deploy notes

None — normal frontend rebuild/redeploy.
