### PR TITLE
fix(uploads): attribute uploads, throttle them, GC unreferenced media, and quota storage (#76)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,8 @@
 #RL_API_WRITE_MAX=120       # writes / min per signed-in user (or per IP)
 #RL_UPLOAD_MAX=10           # media uploads / min per signed-in user (or per IP)
 #UPLOAD_GC_GRACE_DAYS=30    # days an unreferenced upload survives before daily GC deletes it
+#UPLOAD_QUOTA_USER_MB=200   # upload storage cap per account; 0 disables
+#UPLOAD_QUOTA_TOTAL_MB=2048 # upload storage cap for the whole instance; 0 disables
 #RL_INBOX_MAX=300           # federation inbox POSTs / min per source IP
 #RL_WEBHOOK_MAX=30          # content-webhook POSTs / min per source IP
 #INBOX_MAX_BODY_BYTES=1000000   # reject inbox POSTs larger than this

--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,7 @@
 #RL_LOGIN_MAX=15            # per-IP login attempts / 15 min
 #RL_REGISTER_MAX=5          # per-IP registrations / hour
 #RL_API_WRITE_MAX=120       # writes / min per signed-in user (or per IP)
+#RL_UPLOAD_MAX=10           # media uploads / min per signed-in user (or per IP)
 #RL_INBOX_MAX=300           # federation inbox POSTs / min per source IP
 #RL_WEBHOOK_MAX=30          # content-webhook POSTs / min per source IP
 #INBOX_MAX_BODY_BYTES=1000000   # reject inbox POSTs larger than this

--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,7 @@
 #RL_REGISTER_MAX=5          # per-IP registrations / hour
 #RL_API_WRITE_MAX=120       # writes / min per signed-in user (or per IP)
 #RL_UPLOAD_MAX=10           # media uploads / min per signed-in user (or per IP)
+#UPLOAD_GC_GRACE_DAYS=30    # days an unreferenced upload survives before daily GC deletes it
 #RL_INBOX_MAX=300           # federation inbox POSTs / min per source IP
 #RL_WEBHOOK_MAX=30          # content-webhook POSTs / min per source IP
 #INBOX_MAX_BODY_BYTES=1000000   # reject inbox POSTs larger than this

--- a/apps/backend/drizzle/0032_uploads.sql
+++ b/apps/backend/drizzle/0032_uploads.sql
@@ -1,0 +1,26 @@
+-- Upload records: who owns each persisted media file, and how big it is.
+-- Additive and idempotent.
+--
+-- Every accepted upload (post images, avatars, the instance banner) writes a
+-- UUID-named file to UPLOADS_DIR. Before this table nothing recorded its owner
+-- or size, so storage use was unattributable and nothing could later decide
+-- which files are unreferenced and safe to delete. Each row mirrors one file
+-- (`filename` is the name on disk, uniquely indexed as the lookup key); row
+-- deletion never deletes the file, and a deleted user's rows cascade while
+-- their files stay behind for delayed garbage collection, since federated
+-- copies may still reference the URLs.
+CREATE TABLE IF NOT EXISTS "uploads" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"owner_id" uuid NOT NULL,
+	"filename" text NOT NULL,
+	"bytes" integer NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "uploads" ADD CONSTRAINT "uploads_owner_id_users_id_fk" FOREIGN KEY ("owner_id") REFERENCES "users"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "uploads_filename_idx" ON "uploads" ("filename");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "uploads_owner_created_idx" ON "uploads" ("owner_id","created_at" DESC);

--- a/apps/backend/drizzle/0033_upload_last_referenced.sql
+++ b/apps/backend/drizzle/0033_upload_last_referenced.sql
@@ -1,0 +1,9 @@
+-- Upload GC bookkeeping: when a file was last seen referenced. Additive and
+-- idempotent.
+--
+-- The GC sweep (services/uploadGc.ts) refreshes this for every file still
+-- referenced by a profile, post, or the instance banner, then reaps only rows
+-- that have lagged behind by the full grace period. Keying the grace period on
+-- "last seen referenced" rather than "created" is what makes replacement safe:
+-- an avatar replaced after 5 years still gets its full grace period.
+ALTER TABLE "uploads" ADD COLUMN IF NOT EXISTS "last_referenced_at" timestamp with time zone DEFAULT now() NOT NULL;

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -225,6 +225,13 @@
       "when": 1786209507624,
       "tag": "0031_tag_aliases",
       "breakpoints": true
+    },
+    {
+      "idx": 32,
+      "version": "7",
+      "when": 1787000000000,
+      "tag": "0032_uploads",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -232,6 +232,13 @@
       "when": 1787000000000,
       "tag": "0032_uploads",
       "breakpoints": true
+    },
+    {
+      "idx": 33,
+      "version": "7",
+      "when": 1787900000000,
+      "tag": "0033_upload_last_referenced",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -28,6 +28,21 @@ const apiWriteLimiter = rateLimit({
   },
 });
 
+// Uploads persist image bytes to durable storage (see db/schema.ts `uploads`),
+// so they layer a much tighter budget on top of the general write limiter —
+// without it, one account could spend its whole write budget on 5 MB images
+// every minute. Keyed per signed-in user; both upload endpoints are auth-only,
+// but the IP fallback keeps the key well-formed if session resolution changes.
+const uploadLimiter = rateLimit({
+  name: "upload",
+  windowMs: 60_000,
+  max: config.RL_UPLOAD_MAX,
+  key: (c) => {
+    const user = c.get("user");
+    return user ? `u:${user.id}` : `ip:${clientIp(c)}`;
+  },
+});
+
 // The federation inbox accepts unauthenticated POSTs from arbitrary instances;
 // cap per source IP so a hostile peer can't flood it. Generous, since a busy
 // instance legitimately delivers many activities.
@@ -155,6 +170,13 @@ export async function buildApp() {
   app.use("/api/*", sessionMiddleware);
   // General write throttle, after session resolution so it can key by user.
   app.use("/api/*", (c, next) => (READ_METHODS.has(c.req.method) ? next() : apiWriteLimiter(c, next)));
+  // Upload-specific throttle on the three endpoints that persist media bytes
+  // (post images, avatars, and the instance banner). Each file is capped (2 MB
+  // avatars, 5 MB the rest), but without this limiter one account could spend
+  // its whole write budget on new files every minute.
+  app.use("/api/uploads", (c, next) => (c.req.method === "POST" ? uploadLimiter(c, next) : next()));
+  app.use("/api/users/me/avatar", (c, next) => (c.req.method === "POST" ? uploadLimiter(c, next) : next()));
+  app.use("/api/admin/instance/banner", (c, next) => (c.req.method === "POST" ? uploadLimiter(c, next) : next()));
   app.route("/api", apiRoutes);
 
   return app;

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -157,6 +157,13 @@ const schema = z.object({
   // URL have had a fair chance to move on.
   UPLOAD_GC_GRACE_DAYS: z.coerce.number().int().min(1).default(30),
 
+  // Upload storage quotas, enforced transactionally at upload time (see
+  // repositories/uploads.ts createWithinQuota): the quota check and the upload
+  // record commit together under locks, so concurrent uploads cannot race past
+  // a cap. Per account / per instance, in megabytes; 0 disables a cap.
+  UPLOAD_QUOTA_USER_MB: z.coerce.number().int().min(0).default(200),
+  UPLOAD_QUOTA_TOTAL_MB: z.coerce.number().int().min(0).default(2048),
+
   // Content ingestion webhook (POST /api/webhooks/content). Unset — the default
   // — means the endpoint is disabled entirely and answers 503; there is no
   // "empty secret" state in which it would accept anything. Set it to a long
@@ -220,6 +227,8 @@ function load() {
     RL_WEBHOOK_MAX: Deno.env.get("RL_WEBHOOK_MAX"),
     INBOX_MAX_BODY_BYTES: Deno.env.get("INBOX_MAX_BODY_BYTES"),
     UPLOAD_GC_GRACE_DAYS: Deno.env.get("UPLOAD_GC_GRACE_DAYS"),
+    UPLOAD_QUOTA_USER_MB: Deno.env.get("UPLOAD_QUOTA_USER_MB"),
+    UPLOAD_QUOTA_TOTAL_MB: Deno.env.get("UPLOAD_QUOTA_TOTAL_MB"),
     WEBHOOK_SECRET: Deno.env.get("WEBHOOK_SECRET")?.trim() || undefined,
     WEBHOOK_AUTHOR: Deno.env.get("WEBHOOK_AUTHOR")?.trim() || undefined,
     WEBHOOK_MAX_BODY_BYTES: Deno.env.get("WEBHOOK_MAX_BODY_BYTES"),

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -142,6 +142,10 @@ const schema = z.object({
   RL_LOGIN_MAX: z.coerce.number().int().positive().default(15),
   RL_REGISTER_MAX: z.coerce.number().int().positive().default(5),
   RL_API_WRITE_MAX: z.coerce.number().int().positive().default(120),
+  // Uploads write image bytes to durable disk storage, so they get their own,
+  // much tighter budget than the general write limiter above — otherwise one
+  // account could persist its full write budget in 5 MB images every minute.
+  RL_UPLOAD_MAX: z.coerce.number().int().positive().default(10),
   RL_INBOX_MAX: z.coerce.number().int().positive().default(300),
   RL_WEBHOOK_MAX: z.coerce.number().int().positive().default(30),
   // Reject federation inbox POSTs whose declared body exceeds this many bytes.
@@ -205,6 +209,7 @@ function load() {
     RL_LOGIN_MAX: Deno.env.get("RL_LOGIN_MAX"),
     RL_REGISTER_MAX: Deno.env.get("RL_REGISTER_MAX"),
     RL_API_WRITE_MAX: Deno.env.get("RL_API_WRITE_MAX"),
+    RL_UPLOAD_MAX: Deno.env.get("RL_UPLOAD_MAX"),
     RL_INBOX_MAX: Deno.env.get("RL_INBOX_MAX"),
     RL_WEBHOOK_MAX: Deno.env.get("RL_WEBHOOK_MAX"),
     INBOX_MAX_BODY_BYTES: Deno.env.get("INBOX_MAX_BODY_BYTES"),

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -151,6 +151,12 @@ const schema = z.object({
   // Reject federation inbox POSTs whose declared body exceeds this many bytes.
   INBOX_MAX_BODY_BYTES: z.coerce.number().int().positive().default(1_000_000),
 
+  // Delayed garbage collection for uploaded media (see services/uploadGc.ts).
+  // A file is deleted only once a daily sweep has seen nothing referencing it
+  // for this many days — long enough that federated instances which cached the
+  // URL have had a fair chance to move on.
+  UPLOAD_GC_GRACE_DAYS: z.coerce.number().int().min(1).default(30),
+
   // Content ingestion webhook (POST /api/webhooks/content). Unset — the default
   // — means the endpoint is disabled entirely and answers 503; there is no
   // "empty secret" state in which it would accept anything. Set it to a long
@@ -213,6 +219,7 @@ function load() {
     RL_INBOX_MAX: Deno.env.get("RL_INBOX_MAX"),
     RL_WEBHOOK_MAX: Deno.env.get("RL_WEBHOOK_MAX"),
     INBOX_MAX_BODY_BYTES: Deno.env.get("INBOX_MAX_BODY_BYTES"),
+    UPLOAD_GC_GRACE_DAYS: Deno.env.get("UPLOAD_GC_GRACE_DAYS"),
     WEBHOOK_SECRET: Deno.env.get("WEBHOOK_SECRET")?.trim() || undefined,
     WEBHOOK_AUTHOR: Deno.env.get("WEBHOOK_AUTHOR")?.trim() || undefined,
     WEBHOOK_MAX_BODY_BYTES: Deno.env.get("WEBHOOK_MAX_BODY_BYTES"),

--- a/apps/backend/src/db/repositories/uploads.ts
+++ b/apps/backend/src/db/repositories/uploads.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { eq, sql } from "drizzle-orm";
+import { db } from "@/db/client.ts";
+import { uploads } from "@/db/schema.ts";
+
+// Upload-record DB access. Services never touch `db` directly. One row per
+// accepted media upload, mirroring the file on disk (see db/schema.ts for why
+// the row and the file are deliberately decoupled).
+
+export async function create(ownerId: string, filename: string, bytes: number) {
+  await db.insert(uploads).values({ ownerId, filename, bytes });
+}
+
+// Total bytes a user has uploaded. Read-only today (abuse inspection), and the
+// natural hook for per-user quotas if those land later.
+export async function sumBytesForUser(userId: string): Promise<number> {
+  const [row] = await db
+    .select({ total: sql<number>`coalesce(sum(${uploads.bytes}), 0)::bigint` })
+    .from(uploads)
+    .where(eq(uploads.ownerId, userId));
+  return row?.total ?? 0;
+}

--- a/apps/backend/src/db/repositories/uploads.ts
+++ b/apps/backend/src/db/repositories/uploads.ts
@@ -2,23 +2,72 @@
 import { eq, inArray, like, lt, sql } from "drizzle-orm";
 import { db } from "@/db/client.ts";
 import { posts, uploads, users } from "@/db/schema.ts";
+import { quotaVerdict } from "@/lib/uploads.ts";
 
 // Upload-record DB access. Services never touch `db` directly. One row per
 // accepted media upload, mirroring the file on disk (see db/schema.ts for why
 // the row and the file are deliberately decoupled).
 
-export async function create(ownerId: string, filename: string, bytes: number) {
+export type QuotaResult = { ok: true } | { ok: false; reason: "user" | "total" };
+
+async function create(ownerId: string, filename: string, bytes: number) {
   await db.insert(uploads).values({ ownerId, filename, bytes });
+}
+
+// Records an upload and enforces the storage quotas in one transaction, so a
+// cap cannot be raced past by two uploads landing together. The sums are
+// computed rather than kept as counters: slower on huge tables, but immune to
+// drift when rows leave outside this path (GC reaps, account deletion
+// cascades) — a quota that silently over-counts locks users out forever, and
+// that failure mode is far worse than the scan. Locking (advisory lock for the
+// global sum, the owner row for the per-user sum) is what makes check + insert
+// atomic; uploads are rare relative to reads, so the coarse global lock costs
+// nothing. A cap of 0 disables its check entirely.
+export async function createWithinQuota(
+  ownerId: string,
+  filename: string,
+  bytes: number,
+  maxUserBytes: number,
+  maxTotalBytes: number,
+): Promise<QuotaResult> {
+  if (maxUserBytes <= 0 && maxTotalBytes <= 0) {
+    await create(ownerId, filename, bytes);
+    return { ok: true };
+  }
+  return await db.transaction(async (tx) => {
+    await tx.execute(sql`select pg_advisory_xact_lock(745220011)`);
+    // Locking the owner's row serializes that user's uploads and tells us
+    // whether they still exist — a vanished owner must not reserve storage.
+    const owner = await tx.select({ id: users.id }).from(users).where(eq(users.id, ownerId)).for("update");
+    if (owner.length === 0) return { ok: false, reason: "user" };
+    const [userSum, totalSum] = await Promise.all([
+      tx
+        .select({ total: sql<number>`coalesce(sum(${uploads.bytes}), 0)::double precision` })
+        .from(uploads)
+        .where(eq(uploads.ownerId, ownerId)),
+      tx.select({ total: sql<number>`coalesce(sum(${uploads.bytes}), 0)::double precision` }).from(uploads),
+    ]);
+    const verdict = quotaVerdict(userSum[0]?.total ?? 0, bytes, totalSum[0]?.total ?? 0, maxUserBytes, maxTotalBytes);
+    if (verdict !== "ok") return { ok: false, reason: verdict };
+    await tx.insert(uploads).values({ ownerId, filename, bytes });
+    return { ok: true };
+  });
 }
 
 // Total bytes a user has uploaded. Read-only today (abuse inspection), and the
 // natural hook for per-user quotas if those land later.
 export async function sumBytesForUser(userId: string): Promise<number> {
   const [row] = await db
-    .select({ total: sql<number>`coalesce(sum(${uploads.bytes}), 0)::bigint` })
+    .select({ total: sql<number>`coalesce(sum(${uploads.bytes}), 0)::double precision` })
     .from(uploads)
     .where(eq(uploads.ownerId, userId));
   return row?.total ?? 0;
+}
+
+// Forgets a reserved upload whose file never made it to disk (see
+// services/media.ts, which compensates when the disk write fails).
+export async function removeByFilename(filename: string) {
+  await db.delete(uploads).where(eq(uploads.filename, filename));
 }
 
 // ── reference scan + garbage collection ───────────────────────────────

--- a/apps/backend/src/db/repositories/uploads.ts
+++ b/apps/backend/src/db/repositories/uploads.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { eq, sql } from "drizzle-orm";
+import { eq, inArray, like, lt, sql } from "drizzle-orm";
 import { db } from "@/db/client.ts";
-import { uploads } from "@/db/schema.ts";
+import { posts, uploads, users } from "@/db/schema.ts";
 
 // Upload-record DB access. Services never touch `db` directly. One row per
 // accepted media upload, mirroring the file on disk (see db/schema.ts for why
@@ -19,4 +19,66 @@ export async function sumBytesForUser(userId: string): Promise<number> {
     .from(uploads)
     .where(eq(uploads.ownerId, userId));
   return row?.total ?? 0;
+}
+
+// ── reference scan + garbage collection ───────────────────────────────
+
+// The SQL twin of lib/uploads.ts's filename grammar — keep the two in sync.
+// Emitted via sql.raw because the special `substring(x from '…')` syntax wants
+// its pattern as static query text, not a bind parameter. Constant we control,
+// so raw interpolation is safe.
+const UPLOAD_RE_SQL = sql.raw(`'/api/uploads/([a-zA-Z0-9-]+\\.(?:png|jpe?g|webp|gif))'`);
+
+// Every upload filename currently referenced anywhere persistent. This is the
+// single source of truth for what the GC must never reap: a new column or
+// table that stores an /api/uploads/… URL MUST be added here, or the sweep
+// will eventually delete a file still in use. Comment bodies are deliberately
+// not scanned — they render escaped, never as HTML, so they cannot embed
+// images. Body images are extracted SQL-side (`regexp_matches … 'g'` finds
+// every occurrence, not just the first) so post HTML never ships to the app.
+export async function referencedFilenames(): Promise<string[]> {
+  const [avatarRows, coverRows, bodyRows] = await Promise.all([
+    db
+      .selectDistinct({ filename: sql<string | null>`substring(${users.avatarUrl} from ${UPLOAD_RE_SQL})` })
+      .from(users)
+      .where(like(users.avatarUrl, "/api/uploads/%")),
+    db
+      .selectDistinct({ filename: sql<string | null>`substring(${posts.coverUrl} from ${UPLOAD_RE_SQL})` })
+      .from(posts)
+      .where(like(posts.coverUrl, "/api/uploads/%")),
+    db
+      .selectDistinct({
+        filename: sql<string | null>`(regexp_matches(${posts.contentHtml}, ${UPLOAD_RE_SQL}, 'g'))[1]`,
+      })
+      .from(posts)
+      .where(like(posts.contentHtml, "%/api/uploads/%")),
+  ]);
+  const filenames = new Set<string>();
+  for (const row of [...avatarRows, ...coverRows, ...bodyRows]) {
+    if (row.filename) filenames.add(row.filename);
+  }
+  return [...filenames];
+}
+
+// Stamps every referenced file as referenced-now. The reap step keys its grace
+// period on this column, so a file referenced at any recent sweep is safe even
+// if its last local reference is removed moments later.
+export async function refreshReferenced(filenames: string[]) {
+  if (filenames.length === 0) return;
+  await db.update(uploads).set({ lastReferencedAt: new Date() }).where(inArray(uploads.filename, filenames));
+}
+
+// Rows unreferenced for longer than `cutoff` — safe to reap.
+export function listReapable(cutoff: Date, limit: number): Promise<{ id: string; filename: string }[]> {
+  return db
+    .select({ id: uploads.id, filename: uploads.filename })
+    .from(uploads)
+    .where(lt(uploads.lastReferencedAt, cutoff))
+    .limit(limit);
+}
+
+// Forgets a reaped upload. The caller has already unlinked the file (or found
+// it already gone).
+export async function remove(id: string) {
+  await db.delete(uploads).where(eq(uploads.id, id));
 }

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -846,6 +846,33 @@ export const notifications = pgTable(
   ],
 );
 
+// ── uploads ────────────────────────────────────────────────────────────
+// One row per accepted media upload (post images via POST /api/uploads,
+// avatars, and the instance banner). The file itself lives on disk under
+// UPLOADS_DIR; this table records who owns it and how large it is, so storage
+// use is attributable and unreferenced files can one day be garbage-collected
+// (the file's name on disk is `filename`, uniquely indexed here as the lookup
+// key). Deleting a row never deletes the file — and deleting a user cascades
+// these rows while their files stay behind for delayed GC, which is
+// deliberate: federated copies may still reference the URLs.
+export const uploads = pgTable(
+  "uploads",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    ownerId: uuid("owner_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    filename: text("filename").notNull(),
+    bytes: integer("bytes").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("uploads_filename_idx").on(t.filename),
+    // Owner storage totals / future per-user quotas scan newest-first.
+    index("uploads_owner_created_idx").on(t.ownerId, t.createdAt.desc()),
+  ],
+);
+
 export type User = typeof users.$inferSelect;
 export type NewUser = typeof users.$inferInsert;
 export type Post = typeof posts.$inferSelect;
@@ -864,6 +891,8 @@ export type Session = typeof sessions.$inferSelect;
 export type AuthToken = typeof authTokens.$inferSelect;
 export type NewAuthToken = typeof authTokens.$inferInsert;
 export type WebhookToken = typeof webhookTokens.$inferSelect;
+export type Upload = typeof uploads.$inferSelect;
+export type NewUpload = typeof uploads.$inferInsert;
 export type Tag = typeof tags.$inferSelect;
 export type NewTag = typeof tags.$inferInsert;
 export type TagAlias = typeof tagAliases.$inferSelect;

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -850,10 +850,11 @@ export const notifications = pgTable(
 // One row per accepted media upload (post images via POST /api/uploads,
 // avatars, and the instance banner). The file itself lives on disk under
 // UPLOADS_DIR; this table records who owns it and how large it is, so storage
-// use is attributable and unreferenced files can one day be garbage-collected
-// (the file's name on disk is `filename`, uniquely indexed here as the lookup
-// key). Deleting a row never deletes the file — and deleting a user cascades
-// these rows while their files stay behind for delayed GC, which is
+// use is attributable and unreferenced files are garbage-collected once they
+// have been unreferenced for a full grace period (see services/uploadGc.ts).
+// The file's name on disk is `filename`, uniquely indexed here as the lookup
+// key. Deleting a row never deletes the file directly — and deleting a user
+// cascades these rows while their files stay behind for the GC, which is
 // deliberate: federated copies may still reference the URLs.
 export const uploads = pgTable(
   "uploads",
@@ -865,6 +866,11 @@ export const uploads = pgTable(
     filename: text("filename").notNull(),
     bytes: integer("bytes").notNull(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    // Refreshed by every GC sweep for as long as the file is referenced by
+    // anything (see services/uploadGc.ts). The reap step only takes rows this
+    // has lagged behind by the full grace period, which is what makes
+    // replacement safe: an avatar replaced after years still gets its grace.
+    lastReferencedAt: timestamp("last_referenced_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     uniqueIndex("uploads_filename_idx").on(t.filename),

--- a/apps/backend/src/lib/http.ts
+++ b/apps/backend/src/lib/http.ts
@@ -18,6 +18,7 @@ export const unauthorized = (msg = "Unauthorized") => new HttpError(401, msg);
 export const forbidden = (msg = "Forbidden") => new HttpError(403, msg);
 export const notFound = (msg = "Not found") => new HttpError(404, msg);
 export const conflict = (msg: string) => new HttpError(409, msg);
+export const payloadTooLarge = (msg: string) => new HttpError(413, msg);
 export const tooManyRequests = (msg = "Too many requests.") => new HttpError(429, msg);
 
 // Centralized error → JSON response mapping (wired in app.ts via onError).

--- a/apps/backend/src/lib/uploads.ts
+++ b/apps/backend/src/lib/uploads.ts
@@ -26,3 +26,24 @@ export function uploadFilenamesInText(text: string | null | undefined): string[]
   if (!text) return [];
   return [...new Set([...text.matchAll(new RegExp(`/api/uploads/(${FILENAME})`, "g"))].map((m) => m[1]))];
 }
+
+/**
+ * Whether one more upload of `newBytes` fits the storage quotas, given what
+ * the account (`userBytes`) and the instance (`totalBytes`) already store.
+ * Returns "ok", or which cap a new upload would breach — "user" wins when
+ * both are breached, since that is the message the uploader can act on.
+ * A cap of 0 (or less) is disabled, matching the env-var convention.
+ */
+export function quotaVerdict(
+  userBytes: number,
+  newBytes: number,
+  totalBytes: number,
+  maxUserBytes: number,
+  maxTotalBytes: number,
+): "ok" | "user" | "total" {
+  const userBreached = maxUserBytes > 0 && userBytes + newBytes > maxUserBytes;
+  const totalBreached = maxTotalBytes > 0 && totalBytes + newBytes > maxTotalBytes;
+  if (userBreached) return "user";
+  if (totalBreached) return "total";
+  return "ok";
+}

--- a/apps/backend/src/lib/uploads.ts
+++ b/apps/backend/src/lib/uploads.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Pure helpers for reasoning about upload URLs. The SQL reference scan in
+// db/repositories/uploads.ts mirrors the filename grammar here — keep the two
+// in sync, or the GC will disagree with the app about what is a reference.
+
+// The filename grammar every stored upload follows: `<uuid>.<raster ext>`.
+// The serving route (`/api/uploads/:file`) accepts the same set, as does the
+// media service's persisted naming.
+const FILENAME = "[a-zA-Z0-9-]+\\.(?:png|jpe?g|webp|gif)";
+
+/**
+ * The upload filename a root-relative URL points at, or null when `url` is not
+ * one. Absolute http(s) URLs are someone else's host, `/api/uploads/og/…` is a
+ * derived share image (not the stored file), and anything else is not an
+ * upload — all must return null so the GC never treats them as references.
+ */
+export function uploadFilenameFromUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  const match = new RegExp(`^/api/uploads/(${FILENAME})$`).exec(url.trim());
+  return match?.[1] ?? null;
+}
+
+/** Every upload filename appearing anywhere in `text`, deduplicated. */
+export function uploadFilenamesInText(text: string | null | undefined): string[] {
+  if (!text) return [];
+  return [...new Set([...text.matchAll(new RegExp(`/api/uploads/(${FILENAME})`, "g"))].map((m) => m[1]))];
+}

--- a/apps/backend/src/lib/uploads_test.ts
+++ b/apps/backend/src/lib/uploads_test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { expect, test } from "vitest";
+import { uploadFilenameFromUrl, uploadFilenamesInText } from "@/lib/uploads.ts";
+
+// The GC decides what to delete from what these helpers accept as a
+// reference. A false positive reaps a file still in use; a false negative
+// only delays a deletion. Both directions are pinned here.
+
+test("uploadFilenameFromUrl: accepts every stored raster extension", () => {
+  for (const [url, expected] of [
+    ["/api/uploads/9f2b81ce-4a5d-4c1e-9f3a-2b7d8e6c1a01.png", "9f2b81ce-4a5d-4c1e-9f3a-2b7d8e6c1a01.png"],
+    ["/api/uploads/abc.jpg", "abc.jpg"],
+    ["/api/uploads/abc.jpeg", "abc.jpeg"],
+    ["/api/uploads/abc.webp", "abc.webp"],
+    ["/api/uploads/abc.gif", "abc.gif"],
+  ] as const) {
+    expect(uploadFilenameFromUrl(url)).toBe(expected);
+  }
+  // Padded by whitespace the way a stored setting might be hand-edited.
+  expect(uploadFilenameFromUrl("  /api/uploads/abc.png  ")).toBe("abc.png");
+});
+
+test("uploadFilenameFromUrl: rejects everything that is not a stored upload", () => {
+  // Someone else's host, or an absolute form of ours — references to uploads
+  // are always stored root-relative.
+  expect(uploadFilenameFromUrl("https://images.test/x.jpg")).toBeNull();
+  expect(uploadFilenameFromUrl("https://blog.test/api/uploads/abc.png")).toBeNull();
+  // The derived share image is not the stored file.
+  expect(uploadFilenameFromUrl("/api/uploads/og/abc.jpg")).toBeNull();
+  // Path traversal and stray text must never read as a filename.
+  expect(uploadFilenameFromUrl("/api/uploads/../../etc/passwd")).toBeNull();
+  expect(uploadFilenameFromUrl("/api/uploads/abc.png?w=100")).toBeNull();
+  expect(uploadFilenameFromUrl("/api/uploads/abc.svg")).toBeNull();
+  expect(uploadFilenameFromUrl("")).toBeNull();
+  expect(uploadFilenameFromUrl(null)).toBeNull();
+});
+
+test("uploadFilenamesInText: finds every upload in rendered body HTML", () => {
+  const html =
+    '<p>Hi</p><img src="/api/uploads/a.webp" alt="" /><img src="/api/uploads/b.jpg" />' +
+    '<img src="/api/uploads/og/a.jpg"><img src="https://elsewhere.test/c.png">';
+  expect(uploadFilenamesInText(html)).toEqual(["a.webp", "b.jpg"]);
+});
+
+test("uploadFilenamesInText: deduplicates and tolerates empty input", () => {
+  expect(uploadFilenamesInText('<img src="/api/uploads/a.png"><img src="/api/uploads/a.png">')).toEqual(["a.png"]);
+  expect(uploadFilenamesInText("<p>no images here</p>")).toEqual([]);
+  expect(uploadFilenamesInText("")).toEqual([]);
+  expect(uploadFilenamesInText(null)).toEqual([]);
+});

--- a/apps/backend/src/lib/uploads_test.ts
+++ b/apps/backend/src/lib/uploads_test.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { expect, test } from "vitest";
-import { uploadFilenameFromUrl, uploadFilenamesInText } from "@/lib/uploads.ts";
+import { quotaVerdict, uploadFilenameFromUrl, uploadFilenamesInText } from "@/lib/uploads.ts";
 
 // The GC decides what to delete from what these helpers accept as a
 // reference. A false positive reaps a file still in use; a false negative
@@ -47,4 +47,30 @@ test("uploadFilenamesInText: deduplicates and tolerates empty input", () => {
   expect(uploadFilenamesInText("<p>no images here</p>")).toEqual([]);
   expect(uploadFilenamesInText("")).toEqual([]);
   expect(uploadFilenamesInText(null)).toEqual([]);
+});
+
+// The quota decision gates every upload, so its boundaries are pinned exactly:
+// a cap that rejects at equality would break the last upload that fits, and
+// one that accepts past the cap would quietly un-do the storage bound.
+test("quotaVerdict: allows uploads that fit exactly", () => {
+  expect(quotaVerdict(90, 10, 1000, 100, 2000)).toBe("ok");
+  expect(quotaVerdict(199, 1, 1000, 200, 2000)).toBe("ok");
+});
+
+test("quotaVerdict: names the per-user cap when it breaches", () => {
+  expect(quotaVerdict(200, 1, 1000, 200, 2000)).toBe("user");
+  expect(quotaVerdict(150, 51, 1000, 200, 2000)).toBe("user");
+});
+
+test("quotaVerdict: names the global cap when only it breaches", () => {
+  expect(quotaVerdict(10, 1, 2000, 200, 2000)).toBe("total");
+  expect(quotaVerdict(10, 100, 1901, 200, 2000)).toBe("total");
+  // Both breached: the per-user message is the one the uploader can act on.
+  expect(quotaVerdict(200, 1, 2000, 200, 2000)).toBe("user");
+});
+
+test("quotaVerdict: a cap of 0 is disabled", () => {
+  expect(quotaVerdict(10_000_000, 1, 10_000_000, 0, 0)).toBe("ok");
+  expect(quotaVerdict(0, 1, 5000, 100, 0)).toBe("ok");
+  expect(quotaVerdict(0, 1, 5000, 0, 100)).toBe("total");
 });

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -8,6 +8,7 @@ import { seedFederationRunning } from "@/services/federationState.ts";
 import { getFederationEnabled } from "@/services/instanceSetup.ts";
 import { backfillSlugs } from "@/services/postSlugs.ts";
 import { startScheduleSweeper } from "@/services/scheduledPosts.ts";
+import { startUploadGcSweeper } from "@/services/uploadGc.ts";
 import { APP_VERSION } from "@/version.ts";
 
 // Entry point: migrate → build app → serve. Stateless; all data in Postgres.
@@ -31,6 +32,12 @@ async function main() {
   // run on every node — see services/scheduledPosts.ts. Started after the
   // worker so its first sweep has somewhere to enqueue federation.
   startScheduleSweeper();
+
+  // Reap uploaded files nothing references anymore, once they have been
+  // unreferenced for a full grace period (long enough for federated copies
+  // that cached the URL to move on). Same database-backed pattern as the
+  // schedule sweeper — see services/uploadGc.ts.
+  startUploadGcSweeper();
 
   // `onListen` overrides Deno's own "Listening on http://0.0.0.0:8000/" banner,
   // which otherwise prints alongside ours and announces the same thing twice —

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -172,10 +172,10 @@ adminRoutes.put("/instance", jsonBody(instanceSchema), async (c) => {
 // re-encoded the image before it reaches here (see lib/editor/image.ts), so
 // this layer only validates and persists.
 adminRoutes.post("/instance/banner", async (c) => {
-  requireAdmin(c);
+  const viewer = requireAdmin(c);
   const contentType = (c.req.header("content-type") ?? "").split(";")[0].trim();
   const bytes = new Uint8Array(await c.req.arrayBuffer());
-  const url = await mediaService.saveImage(bytes, contentType);
+  const url = await mediaService.saveImage(viewer.id, bytes, contentType);
   await setup.setBannerImageUrl(url);
   return c.json(await instanceSnapshot(), 201);
 });

--- a/apps/backend/src/routes/media.ts
+++ b/apps/backend/src/routes/media.ts
@@ -15,10 +15,10 @@ export const mediaRoutes = new Hono<AppEnv>();
 // Upload a post image (raw image body; content-type identifies the format).
 // Auth-only; returns the public URL the editor inserts into the document.
 mediaRoutes.post("/", async (c) => {
-  requireUser(c);
+  const viewer = requireUser(c);
   const contentType = (c.req.header("content-type") ?? "").split(";")[0].trim();
   const bytes = new Uint8Array(await c.req.arrayBuffer());
-  const url = await mediaService.saveImage(bytes, contentType);
+  const url = await mediaService.saveImage(viewer.id, bytes, contentType);
   return c.json({ url }, 201);
 });
 

--- a/apps/backend/src/services/instanceSetup.ts
+++ b/apps/backend/src/services/instanceSetup.ts
@@ -141,8 +141,9 @@ export async function getBannerImageUrl(): Promise<string | null> {
 }
 
 // Persist (or, with `null`, clear) the banner image URL. Clearing only drops
-// the setting — the uploaded file itself is left on disk, same as removing an
-// avatar, since nothing else references it for cleanup.
+// the setting — the uploaded file itself stays on disk until the upload GC
+// reaps it after the grace period (see services/uploadGc.ts), since federated
+// copies may still reference the URL.
 export async function setBannerImageUrl(url: string | null): Promise<void> {
   await settingsRepo.set(SETUP_KEYS.bannerImageUrl, url ?? "");
 }

--- a/apps/backend/src/services/media.ts
+++ b/apps/backend/src/services/media.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { config } from "@/config.ts";
+import * as uploadsRepo from "@/db/repositories/uploads.ts";
 import { badRequest } from "@/lib/http.ts";
 
 // Business logic for user-uploaded post media. Images are downscaled and
@@ -69,8 +70,10 @@ export function sniffMatches(bytes: Uint8Array, ext: string): boolean {
 }
 
 // Persists an uploaded image to local disk and returns its public URL, served
-// back through `mediaRoutes` (mounted at /api/uploads).
-export async function saveImage(bytes: Uint8Array, contentType: string): Promise<string> {
+// back through `mediaRoutes` (mounted at /api/uploads). `ownerId` records who
+// made the upload (see db/schema.ts `uploads`) so storage use is attributable —
+// a DB failure here leaves an orphaned file behind, which delayed GC will reap.
+export async function saveImage(ownerId: string, bytes: Uint8Array, contentType: string): Promise<string> {
   const ext = IMAGE_TYPES[contentType];
   if (!ext) throw badRequest("Unsupported image type. Use PNG, JPEG, WebP, or GIF.");
   if (bytes.byteLength === 0) throw badRequest("The uploaded file is empty.");
@@ -82,5 +85,6 @@ export async function saveImage(bytes: Uint8Array, contentType: string): Promise
   await Deno.mkdir(config.UPLOADS_DIR, { recursive: true });
   const filename = `${crypto.randomUUID()}.${ext}`;
   await Deno.writeFile(`${config.UPLOADS_DIR}/${filename}`, bytes);
+  await uploadsRepo.create(ownerId, filename, bytes.byteLength);
   return `/api/uploads/${filename}`;
 }

--- a/apps/backend/src/services/media.ts
+++ b/apps/backend/src/services/media.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { config } from "@/config.ts";
 import * as uploadsRepo from "@/db/repositories/uploads.ts";
-import { badRequest } from "@/lib/http.ts";
+import { badRequest, payloadTooLarge, type HttpError } from "@/lib/http.ts";
 
 // Business logic for user-uploaded post media. Images are downscaled and
 // re-encoded in the browser before upload (see the editor), so this layer only
@@ -17,6 +17,25 @@ export const IMAGE_TYPES: Record<string, string> = {
 };
 
 export const MAX_IMAGE_BYTES = 5 * 1024 * 1024; // 5 MB
+
+// Storage quotas as bytes, straight from the MB-valued env knobs (see
+// services/media.ts saveImage for how they are enforced). Exported so every
+// upload path — post images here, avatars in services/users.ts — checks the
+// same caps.
+export const UPLOAD_USER_QUOTA_BYTES = config.UPLOAD_QUOTA_USER_MB * 1024 * 1024;
+export const UPLOAD_TOTAL_QUOTA_BYTES = config.UPLOAD_QUOTA_TOTAL_MB * 1024 * 1024;
+
+// Maps a quota verdict to the error the upload endpoint surfaces. 413 rather
+// than 403: the request itself was fine, the payload simply does not fit.
+export function quotaError(reason: "user" | "total"): HttpError {
+  return reason === "user"
+    ? payloadTooLarge(
+        `Upload storage limit reached (${config.UPLOAD_QUOTA_USER_MB} MB per account). Remove old images — edit older posts or clear your avatar — and try again.`,
+      )
+    : payloadTooLarge(
+        `This instance's upload storage is full (${config.UPLOAD_QUOTA_TOTAL_MB} MB). Please contact the operator.`,
+      );
+}
 
 // Confirms the leading bytes actually match the claimed image format. The
 // declared content-type is attacker-controlled, so without this a caller could
@@ -71,8 +90,12 @@ export function sniffMatches(bytes: Uint8Array, ext: string): boolean {
 
 // Persists an uploaded image to local disk and returns its public URL, served
 // back through `mediaRoutes` (mounted at /api/uploads). `ownerId` records who
-// made the upload (see db/schema.ts `uploads`) so storage use is attributable —
-// a DB failure here leaves an orphaned file behind, which delayed GC will reap.
+// made the upload (see db/schema.ts `uploads`) so storage use is attributable.
+// The quota is reserved before a byte is written, so storage can never fill
+// with files the database has already refused; a failed disk write releases
+// the reservation immediately (the GC would clear the orphaned row eventually
+// anyway, but a quota that heals on the next upload is kinder than one that
+// waits a month).
 export async function saveImage(ownerId: string, bytes: Uint8Array, contentType: string): Promise<string> {
   const ext = IMAGE_TYPES[contentType];
   if (!ext) throw badRequest("Unsupported image type. Use PNG, JPEG, WebP, or GIF.");
@@ -82,9 +105,22 @@ export async function saveImage(ownerId: string, bytes: Uint8Array, contentType:
     throw badRequest("The file contents don't match a PNG, JPEG, WebP, or GIF image.");
   }
 
-  await Deno.mkdir(config.UPLOADS_DIR, { recursive: true });
   const filename = `${crypto.randomUUID()}.${ext}`;
-  await Deno.writeFile(`${config.UPLOADS_DIR}/${filename}`, bytes);
-  await uploadsRepo.create(ownerId, filename, bytes.byteLength);
+  const verdict = await uploadsRepo.createWithinQuota(
+    ownerId,
+    filename,
+    bytes.byteLength,
+    UPLOAD_USER_QUOTA_BYTES,
+    UPLOAD_TOTAL_QUOTA_BYTES,
+  );
+  if (!verdict.ok) throw quotaError(verdict.reason);
+
+  await Deno.mkdir(config.UPLOADS_DIR, { recursive: true });
+  try {
+    await Deno.writeFile(`${config.UPLOADS_DIR}/${filename}`, bytes);
+  } catch (err) {
+    await uploadsRepo.removeByFilename(filename).catch(() => {});
+    throw err;
+  }
   return `/api/uploads/${filename}`;
 }

--- a/apps/backend/src/services/uploadGc.ts
+++ b/apps/backend/src/services/uploadGc.ts
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { config } from "@/config.ts";
+import * as instanceSettingsRepo from "@/db/repositories/instanceSettings.ts";
+import * as uploadsRepo from "@/db/repositories/uploads.ts";
+import { uploadFilenameFromUrl } from "@/lib/uploads.ts";
+import { SETUP_KEYS } from "@/services/instanceSetup.ts";
+import { cachePath } from "@/services/shareImage.ts";
+
+// Delayed garbage collection for uploaded media.
+//
+// Files on disk outlive every reference that ever pointed at them: replacing
+// an avatar orphans the old file, deleting a post orphans its body images, and
+// deleting a user cascades their upload rows while the files stay behind (see
+// db/schema.ts `uploads` for why that decoupling is deliberate). This sweeper
+// reaps the orphans — but only after a full grace period, because federated
+// instances cache these URLs and keep fetching them long after the local
+// reference is gone. A file is deleted only once a sweep has seen nothing
+// referencing it for UPLOAD_GC_GRACE_DAYS straight.
+//
+// Database-backed and timer-driven like the scheduled-post sweeper
+// (services/scheduledPosts.ts): the job queue is one-shot and, without Redis,
+// not durable, while GC must simply happen every day forever. The sweep is
+// idempotent — deleting an already-deleted file is a no-op — so it is safe to
+// run on every backend process without coordination.
+
+// Daily. The grace period absorbs sweep latency, so a tighter loop would buy
+// nothing for a scan that touches every post's HTML.
+const SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+// Most a single sweep will delete. A cap only matters after the GC first
+// lands on an instance with years of orphans; the rest follow on later sweeps
+// rather than one pass unlinking thousands of files.
+const REAP_BATCH = 200;
+
+let started = false;
+
+/** Start the GC sweeper. Call once at boot. */
+export function startUploadGcSweeper(): void {
+  if (started) return;
+  started = true;
+  void sweep();
+  setInterval(() => void sweep(), SWEEP_INTERVAL_MS);
+  console.log("✔ Upload GC sweeper started.");
+}
+
+/**
+ * One pass: refresh what is referenced, then reap what has been unreferenced
+ * past the grace period. Returns the number of files deleted. Failures are
+ * logged and dropped — every step is retried wholesale by the next sweep, so
+ * there is no retry ladder to maintain.
+ */
+export async function sweep(): Promise<number> {
+  let referenced: string[];
+  try {
+    referenced = await collectReferenced();
+  } catch (err) {
+    console.error("upload-gc: reference scan failed:", err);
+    return 0;
+  }
+  try {
+    await uploadsRepo.refreshReferenced(referenced);
+  } catch (err) {
+    console.error("upload-gc: failed to refresh references:", err);
+    return 0;
+  }
+
+  const cutoff = new Date(Date.now() - config.UPLOAD_GC_GRACE_DAYS * 86_400_000);
+  let victims: { id: string; filename: string }[];
+  try {
+    victims = await uploadsRepo.listReapable(cutoff, REAP_BATCH);
+  } catch (err) {
+    console.error("upload-gc: failed to list reapable uploads:", err);
+    return 0;
+  }
+
+  let reaped = 0;
+  for (const victim of victims) {
+    try {
+      await Deno.remove(`${config.UPLOADS_DIR}/${victim.filename}`);
+    } catch (err) {
+      // Already gone — another node won the race, or an earlier sweep unlinked
+      // the file but failed before forgetting the row: the row can still go.
+      // Anything else leaves the row so a later sweep retries.
+      if (!(err instanceof Deno.errors.NotFound)) {
+        console.warn(`upload-gc: could not delete ${victim.filename}:`, err);
+        continue;
+      }
+    }
+    // Drop the derived share image too (id = filename without extension);
+    // stale otherwise, and it would never be rebuilt once the source is gone.
+    const id = victim.filename.replace(/\.[a-z0-9]+$/i, "");
+    await Deno.remove(cachePath(id)).catch(() => {});
+    try {
+      await uploadsRepo.remove(victim.id);
+    } catch (err) {
+      console.warn(`upload-gc: could not forget ${victim.filename}:`, err);
+      continue;
+    }
+    reaped++;
+  }
+  if (reaped > 0) console.log(`upload-gc: reaped ${reaped} unreferenced upload(s).`);
+  return reaped;
+}
+
+// Everything that currently points at an upload: the persistent reference scan
+// (profile avatars, post covers and body images) plus the instance banner,
+// which lives in the settings key/value store rather than a column.
+async function collectReferenced(): Promise<string[]> {
+  const [fromContent, bannerUrl] = await Promise.all([
+    uploadsRepo.referencedFilenames(),
+    instanceSettingsRepo.get<string>(SETUP_KEYS.bannerImageUrl),
+  ]);
+  const filenames = new Set(fromContent);
+  const banner = uploadFilenameFromUrl(bannerUrl);
+  if (banner) filenames.add(banner);
+  return [...filenames];
+}

--- a/apps/backend/src/services/users.ts
+++ b/apps/backend/src/services/users.ts
@@ -2,6 +2,7 @@ import { config } from "@/config.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as linksRepo from "@/db/repositories/profileLinks.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
+import * as uploadsRepo from "@/db/repositories/uploads.ts";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import * as usersRepo from "@/db/repositories/users.ts";
 import type { ProfileLink, User } from "@/db/schema.ts";
@@ -206,6 +207,7 @@ export async function setAvatar(userId: string, bytes: Uint8Array, contentType: 
   await Deno.mkdir(config.UPLOADS_DIR, { recursive: true });
   const filename = `${crypto.randomUUID()}.${ext}`;
   await Deno.writeFile(`${config.UPLOADS_DIR}/${filename}`, bytes);
+  await uploadsRepo.create(userId, filename, bytes.byteLength);
 
   const user = await usersRepo.update(userId, { avatarUrl: `/api/uploads/${filename}` });
   queue.add("federate_actor_update", { userId });

--- a/apps/backend/src/services/users.ts
+++ b/apps/backend/src/services/users.ts
@@ -214,9 +214,10 @@ export async function setAvatar(userId: string, bytes: Uint8Array, contentType: 
   return user;
 }
 
-// Clears the avatar so the profile falls back to initials. The previous file is
-// left on disk (it may still be referenced by federated copies), matching how
-// `setAvatar` doesn't prune the prior image.
+// Clears the avatar so the profile falls back to initials. The previous file
+// is left on disk for the upload GC to reap once it has been unreferenced past
+// the grace period (see services/uploadGc.ts); federated copies may still
+// reference it in the meantime.
 export async function removeAvatar(userId: string): Promise<User> {
   const user = await usersRepo.update(userId, { avatarUrl: null });
   queue.add("federate_actor_update", { userId });

--- a/apps/backend/src/services/users.ts
+++ b/apps/backend/src/services/users.ts
@@ -13,7 +13,7 @@ import { MAX_PROFILE_TAGS, normalizeTags } from "@/lib/tags.ts";
 import { queue } from "@/queue/queue.ts";
 import { relationActorLocal } from "@/routes/serializers.ts";
 import * as followRequests from "@/services/followRequests.ts";
-import { sniffMatches } from "@/services/media.ts";
+import { quotaError, sniffMatches, UPLOAD_TOTAL_QUOTA_BYTES, UPLOAD_USER_QUOTA_BYTES } from "@/services/media.ts";
 
 // Business logic for editing one's own profile. Routes stay HTTP-only and call
 // into here; all disk + DB access is funnelled through the repository / services.
@@ -204,10 +204,26 @@ export async function setAvatar(userId: string, bytes: Uint8Array, contentType: 
     throw badRequest("The file contents don't match a PNG, JPEG, WebP, or GIF image.");
   }
 
-  await Deno.mkdir(config.UPLOADS_DIR, { recursive: true });
+  // Same reserve-then-write flow as saveImage: the quota (shared with post
+  // images — an avatar is storage too) is committed before the file lands, and
+  // a failed disk write releases the reservation.
   const filename = `${crypto.randomUUID()}.${ext}`;
-  await Deno.writeFile(`${config.UPLOADS_DIR}/${filename}`, bytes);
-  await uploadsRepo.create(userId, filename, bytes.byteLength);
+  const verdict = await uploadsRepo.createWithinQuota(
+    userId,
+    filename,
+    bytes.byteLength,
+    UPLOAD_USER_QUOTA_BYTES,
+    UPLOAD_TOTAL_QUOTA_BYTES,
+  );
+  if (!verdict.ok) throw quotaError(verdict.reason);
+
+  await Deno.mkdir(config.UPLOADS_DIR, { recursive: true });
+  try {
+    await Deno.writeFile(`${config.UPLOADS_DIR}/${filename}`, bytes);
+  } catch (err) {
+    await uploadsRepo.removeByFilename(filename).catch(() => {});
+    throw err;
+  }
 
   const user = await usersRepo.update(userId, { avatarUrl: `/api/uploads/${filename}` });
   queue.add("federate_actor_update", { userId });

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,10 +160,15 @@ services:
       HOST_HEADER: x-forwarded-host
       ADDRESS_HEADER: x-forwarded-for
       # Exactly one trusted proxy (Caddy) sits in front, so getClientAddress()
-      # reads the client IP that Caddy appended — not a value the client may have
-      # spoofed. Required whenever ADDRESS_HEADER is x-forwarded-for; without it
+      # reads the client IP that Caddy appended — not a value the client may
+      # have spoofed. Required whenever ADDRESS_HEADER is x-forwarded-for; without it
       # per-IP rate limiting keys on the wrong hop.
       XFF_DEPTH: "1"
+      # Align the proxy's request-body cap with the backend's advertised upload
+      # limit (MAX_IMAGE_BYTES = 5 MB). Left at adapter-node's 512 KB default,
+      # any upload over 512 KB is rejected here before the backend ever sees it.
+      # The backend enforces per-file caps and an upload rate limiter of its own.
+      BODY_SIZE_LIMIT: "5m"
     ports:
       # Loopback only: production traffic goes through Caddy. Exposed on the host
       # just for local debugging, not on the public interface.


### PR DESCRIPTION
## The symptom

Every accepted `POST /api/uploads` wrote a permanent UUID-named file with no record of its owner, size, or references. Nothing ever deleted an upload: replaced avatars explicitly kept the old file on disk, deleting a post orphaned its body images, and deleting a user cascaded nothing onto disk. The only throttle was the general 120 writes/min limiter, so one signed-in account could persist ~60 MB/min — ~600 MB/min at the backend's advertised 5 MB cap. Meanwhile `BODY_SIZE_LIMIT` was never set in the compose stack, so SvelteKit's adapter-node default (512 KB) silently rejected uploads the backend advertises as fine.

Found in #76. Reproduction there is accurate: uploading the same valid image twice yields two different, both-retained, publicly retrievable URLs, repeatable until the write limiter bites.

## Root cause

`services/media.ts`'s `saveImage` and `services/users.ts`'s `setAvatar` wrote bytes to disk and returned a URL, and nothing else ever recorded or removed them. Storage growth was unbounded, unattributable, and unrecoverable.

## The fix (three revertable commits)

**1. `fix(uploads): attribute uploads, throttle them, and align the proxy body cap`** — a new `uploads` table records owner, filename (the future GC lookup key), and byte size for every accepted upload; a dedicated upload limiter (`RL_UPLOAD_MAX`, default 10/min) layers on the three endpoints that persist media bytes; compose sets `BODY_SIZE_LIMIT: "5m"` so the proxy matches the backend — deliberately only after the controls landed, per the ordering #76 insisted on.

**2. `feat(uploads): delayed garbage collection for unreferenced media`** — a daily sweeper (same database-backed pattern as the scheduled-post sweeper: no Redis needed, idempotent, safe on every node) scans everything that persistently references an `/api/uploads/…` URL (profile avatars, post covers, post bodies — extracted SQL-side; comment bodies render escaped text and cannot embed images, so they are deliberately not scanned), stamps `last_referenced_at`, and reaps rows unreferenced past `UPLOAD_GC_GRACE_DAYS` (default 30). Keying the grace on *last seen referenced* rather than *created* is what makes replacement safe, and the period is what makes deletion safe: federated instances cache these URLs long after the local reference is gone. Stale `og/` share derivatives are dropped with their source; the `og/` directory itself is untouchable by design since GC only deletes filenames that exist as rows.

**3. `feat(uploads): transactional per-user and global storage quotas`** — `UPLOAD_QUOTA_USER_MB` (default 200) and `UPLOAD_QUOTA_TOTAL_MB` (default 2048; `0` disables either) are enforced inside one Postgres transaction (global advisory lock + the owner's row lock) that checks the sums and commits the upload record atomically, so concurrent uploads cannot race past a cap. The quota is reserved before a byte is written; a failed disk write releases it immediately. Breaches return 413 naming which cap was hit.

Sums are computed rather than kept as counters: GC reaps and account-deletion cascades remove rows outside the upload path, and a drifted counter locks users out forever, while a self-healing sum only costs a scan uploads are rare enough to afford.

## What was verified

- `deno check`, `oxlint` (0 warnings), `oxfmt --check`, `vitest` — 204/204, including new unit tests pinning the upload URL grammar (both directions: a false positive would reap a live file, a false negative only delays a deletion) and the quota verdict boundaries (exact fit allowed, equality rejects, `0` disables, per-user wins when both caps breach).
- All three migrations follow the repo's proven idempotent `CREATE TABLE IF NOT EXISTS` / `ADD COLUMN IF NOT EXISTS` template.

**Not verified (no live database in development):** the migrations applied end-to-end, the transactional quota path under concurrent load, and a real GC sweep. The reference scan and reap path have no integration test — they need a live Postgres + disk. A smoke test on a staging instance before or right after deploy is worthwhile.

## Deploy notes

Migrations apply automatically on backend startup. The frontend picks up `BODY_SIZE_LIMIT` from `docker compose up -d --build` — no `--force-recreate` needed. Five new optional env vars (`RL_UPLOAD_MAX`, `UPLOAD_GC_GRACE_DAYS`, `UPLOAD_QUOTA_USER_MB`, `UPLOAD_QUOTA_TOTAL_MB`) are documented in `.env.example`; defaults are sane for a small instance, and omicron-docs will need a matching update as a separate change.

Closes #76.
