### PR TITLE
fix(federation): respect remote post visibility (#123)

### DIFF
--- a/apps/backend/src/federation/article.ts
+++ b/apps/backend/src/federation/article.ts
@@ -23,6 +23,34 @@ function coverImage(url: string | null): Image | undefined {
   }
 }
 
+// The recipients a built Article addresses, matching the wrapping activity that
+// carries it. A private author's Article passes `{ to: <Followers> }` and omits
+// the Public collection entirely; a public author passes the followers as `cc`.
+export type ArticleAudience = {
+  to: URL;
+  cc?: URL;
+};
+
+// A remote object's audience, as exposed by Fedify's `Object` (the synchronous
+// `*Ids` accessors — avoids the async getters that would force a refetch).
+type AddressedLike = {
+  toIds: URL[];
+  ccIds: URL[];
+  audienceIds: URL[];
+};
+
+// True when an ActivityPub object is addressed to the ActivityStreams Public
+// collection, which ActivityPub defines as making it accessible without
+// authentication. Public appears in `to` or `cc` in every mainstream
+// implementation (`audience` is the rare third place some put it); `bcc` is
+// deliberately excluded — it is a hidden copy that must never be read as
+// publicity. Gates whether we cache a remote Article (#123): a followers-only
+// or direct message must not be persisted and then surfaced on every anonymous
+// read path.
+export function isPubliclyAddressed(obj: AddressedLike): boolean {
+  return [obj.toIds, obj.ccIds, obj.audienceIds].some((ids) => ids.some((u) => u.href === PUBLIC_COLLECTION.href));
+}
+
 // Builds the ActivityPub Article for a local post. Omicron is a long-form
 // blogging platform, so posts federate as Articles (not microblog Notes) and
 // carry their title as the object `name`. The id is stable so the same post
@@ -36,12 +64,24 @@ function coverImage(url: string | null): Image | undefined {
 // so a post that never had a cover set still federates with a picture. Accepts
 // a post without the internal `search_vector` column, which timeline selects
 // omit.
+//
+// The Article's recipients always mirror the wrapping activity so a receiving
+// instance never sees mismatched addressing (ActivityPub warns that mismatched
+// addressing "is likely to cause confusion"). By default a public author's
+// Article declares `to: Public, cc: followers`; pass `audience` to override,
+// as the outbound delivery path does for a private author (whose Article is
+// addressed only to the followers collection, with Public omitted entirely).
 export function buildArticle(
   ctx: Context<unknown>,
   identifier: string,
   post: Omit<Post, "searchVector">,
   tags: TagSummary[] = [],
+  audience?: ArticleAudience,
 ): Article {
+  const { to, cc } = audience ?? {
+    to: PUBLIC_COLLECTION,
+    cc: ctx.getFollowersUri(identifier),
+  };
   return new Article({
     id: new URL(`/posts/${post.id}`, ctx.getActorUri(identifier)),
     attribution: ctx.getActorUri(identifier),
@@ -51,8 +91,8 @@ export function buildArticle(
     // When the author declared a language, tag the content with it (rdf:langString)
     // so remote instances can language-filter it; otherwise send a plain string.
     content: post.language ? new LanguageString(post.contentHtml, post.language) : post.contentHtml,
-    to: PUBLIC_COLLECTION,
-    cc: ctx.getFollowersUri(identifier),
+    to,
+    cc,
     url: new URL(`/posts/${post.id}`, ctx.getActorUri(identifier)),
     tags: tags.map((t) => new Hashtag({ name: `#${t.name}`, href: new URL(`/tags/${t.slug}`, origin) })),
   });

--- a/apps/backend/src/federation/article_test.ts
+++ b/apps/backend/src/federation/article_test.ts
@@ -1,0 +1,62 @@
+import { PUBLIC_COLLECTION } from "@fedify/fedify/vocab";
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Unit tests for the inbound visibility gate behind #123: only remote Articles
+// addressed to the ActivityStreams Public collection may be cached, so a
+// followers-only or direct-message post is never persisted and surfaced on
+// anonymous read paths. The module under test imports config (which needs a
+// Deno runtime for env access), so it is mocked; the logic tested is real.
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config.ts", () => ({ config: {}, origin: "https://omicron.example" }));
+
+import { isPubliclyAddressed } from "@/federation/article.ts";
+
+// The minimal shape isPubliclyAddressed reads (Fedify's synchronous `*Ids`
+// accessors on an ActivityPub Object).
+type Addressed = {
+  toIds: URL[];
+  ccIds: URL[];
+  audienceIds: URL[];
+};
+
+const followers = () => new URL("https://remote.example/users/alice/followers");
+const bob = () => new URL("https://omicron.example/users/bob");
+
+function obj(o: Partial<Addressed>): Addressed {
+  return { toIds: [], ccIds: [], audienceIds: [], ...o };
+}
+
+describe("isPubliclyAddressed", () => {
+  it("accepts an Article addressed to the Public collection in to", () => {
+    expect(isPubliclyAddressed(obj({ toIds: [PUBLIC_COLLECTION] }))).toBe(true);
+  });
+
+  it("accepts an Article addressed to Public in cc", () => {
+    expect(isPubliclyAddressed(obj({ ccIds: [PUBLIC_COLLECTION] }))).toBe(true);
+  });
+
+  it("accepts an Article addressed to Public in audience", () => {
+    expect(isPubliclyAddressed(obj({ audienceIds: [PUBLIC_COLLECTION] }))).toBe(true);
+  });
+
+  it("rejects a followers-only Article (the #123 reproduction)", () => {
+    expect(isPubliclyAddressed(obj({ toIds: [followers()] }))).toBe(false);
+  });
+
+  it("rejects an Article addressed only to a specific user", () => {
+    expect(isPubliclyAddressed(obj({ toIds: [bob()], ccIds: [followers()] }))).toBe(false);
+  });
+
+  it("never treats bcc as publicity", () => {
+    // A defensive check: Public in bcc alone must not make a post "public".
+    const withBcc = obj({ toIds: [], ccIds: [], audienceIds: [] }) as Addressed & {
+      bccIds: URL[];
+    };
+    withBcc.bccIds = [PUBLIC_COLLECTION];
+    expect(isPubliclyAddressed(withBcc)).toBe(false);
+  });
+
+  it("rejects an Article with no addressing at all", () => {
+    expect(isPubliclyAddressed(obj({}))).toBe(false);
+  });
+});

--- a/apps/backend/src/federation/deliver.ts
+++ b/apps/backend/src/federation/deliver.ts
@@ -9,7 +9,7 @@ import * as postsRepo from "@/db/repositories/posts.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import { buildPerson } from "@/federation/actor.ts";
-import { buildArticle } from "@/federation/article.ts";
+import { buildArticle, type ArticleAudience } from "@/federation/article.ts";
 import { getFederation } from "@/federation/mod.ts";
 
 // Resolves a local author's remote followers into deliverable actor objects,
@@ -48,12 +48,18 @@ export async function deliverPost(postId: string, action: "create" | "update" = 
 
   const tags = await tagsRepo.tagsForPost(row.post.id);
   const actorUri = ctx.getActorUri(author.username);
-  const article = buildArticle(ctx, author.username, row.post, tags);
+  const followersUri = ctx.getFollowersUri(author.username);
 
-  // A private author's posts are followers-only: address the followers
-  // collection, not the public one, so receiving instances keep them off public
-  // timelines. (Delivery already targets only approved remote followers.)
-  const audience = author.isPrivate ? ctx.getFollowersUri(author.username) : PUBLIC_COLLECTION;
+  // A private author's posts are followers-only: address the wrapping activity
+  // (and the Article inside it) to the followers collection, not the public one,
+  // so receiving instances keep them off public timelines. Public authors get
+  // the normal `to: Public, cc: followers`. (Delivery already targets only
+  // approved remote followers for either case.)
+  const activityAudience = author.isPrivate ? followersUri : PUBLIC_COLLECTION;
+  const articleAudience: ArticleAudience = author.isPrivate
+    ? { to: followersUri }
+    : { to: PUBLIC_COLLECTION, cc: followersUri };
+  const article = buildArticle(ctx, author.username, row.post, tags, articleAudience);
 
   const activity =
     action === "update"
@@ -62,13 +68,13 @@ export async function deliverPost(postId: string, action: "create" | "update" = 
           id: new URL(`/posts/${row.post.id}/updates/${crypto.randomUUID()}`, actorUri),
           actor: actorUri,
           object: article,
-          tos: [audience],
+          tos: [activityAudience],
         })
       : new Create({
           id: new URL(`/posts/${row.post.id}/activity`, actorUri),
           actor: actorUri,
           object: article,
-          tos: [audience],
+          tos: [activityAudience],
         });
 
   await ctx.sendActivity({ identifier: author.username }, recipients, activity);

--- a/apps/backend/src/federation/mod.ts
+++ b/apps/backend/src/federation/mod.ts
@@ -39,7 +39,7 @@ import * as tagsRepo from "@/db/repositories/tags.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import type { Post } from "@/db/schema.ts";
 import { buildPerson } from "@/federation/actor.ts";
-import { articleLanguage, buildArticle } from "@/federation/article.ts";
+import { articleLanguage, buildArticle, isPubliclyAddressed } from "@/federation/article.ts";
 import { setupNodeInfo } from "@/federation/nodeinfo.ts";
 import { cacheActor } from "@/federation/remote.ts";
 import { sameOrigin } from "@/lib/domain.ts";
@@ -225,6 +225,14 @@ async function ingestArticle(ctx: Context<ContextData>, article: Article): Promi
   if (!article.id) return undefined;
   const existing = await postsRepo.findByApId(article.id.href);
   if (existing) return existing;
+
+  // Privacy/security (#123): we only persist remote posts that were addressed to
+  // the ActivityStreams Public collection. A followers-only or direct-message
+  // Article has no local author (author_id null) and would otherwise be treated
+  // as visible to everyone on the global feed and other anonymous read paths.
+  // We don't persist remote recipient ACLs, so refusing to cache anything that
+  // wasn't plainly public is the safe choice.
+  if (!isPubliclyAddressed(article)) return undefined;
 
   if (!article.attributionId) return undefined;
   const author = await ctx.lookupObject(article.attributionId);

--- a/apps/backend/src/federation/remote.ts
+++ b/apps/backend/src/federation/remote.ts
@@ -8,7 +8,7 @@ import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import type { RemoteActor } from "@/db/schema.ts";
-import { articleLanguage } from "@/federation/article.ts";
+import { articleLanguage, isPubliclyAddressed } from "@/federation/article.ts";
 import { getFederation } from "@/federation/mod.ts";
 import { sameOrigin } from "@/lib/domain.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
@@ -120,6 +120,11 @@ export async function fetchOutboxPosts(handle: string, remoteActorId: string): P
       // otherwise let us store that post under this actor's name — the same
       // cross-origin impersonation the inbox path guards against.
       if (!sameOrigin(obj.id, actor.id)) continue;
+      // Privacy/security (#123): only cache Articles addressed to the Public
+      // collection. A followers-only post fetched from an outbox must not be
+      // persisted and surfaced on public read paths; an actor's public outbox
+      // normally lists public posts, so this just drops the exceptions.
+      if (!isPubliclyAddressed(obj)) continue;
       await postsRepo.upsertRemotePost({
         remoteActorId,
         apId: obj.id.href,


### PR DESCRIPTION
Fixes #123

## Problem

Inbound ActivityPub Articles lost their recipient/audience information when cached. A followers-only Article delivered to a local follower (a fan-out) has no local `author_id`, so the `visibleToViewer` predicate treated it as public and surfaced it in the global feed and other anonymous read paths.

## Fix

**Inbound** — refuse to cache remote Articles that are not addressed to the ActivityStreams Public collection (`to`/`cc`/`audience`, excluding hidden `bcc`). A non-public Article is now dropped at ingest (the Create and Announce handlers) and at outbox fetch, instead of being persisted and treated as public. This is the safe path the issue recommends, since we don't persist remote recipient ACLs.

**Outbound** — `buildArticle` now accepts the author's audience and `deliverPost` passes it through, so a private account's Article omits the Public collection entirely and is addressed only to the followers collection, matching its wrapping Create/Update. Public authors keep `to: Public, cc: followers`.

## Tests

Adds `src/federation/article_test.ts` (7 unit tests) covering the new `isPubliclyAddressed` gate.

Validated locally: `deno check` clean, `pnpm lint` clean (0 errors), `pnpm fmt:check` clean, 214 unit tests pass.