### PR TITLE
fix(dashboard): link posts directly to their canonical URL

### DIFF
--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -765,12 +765,14 @@ export function claimDue(limit = 50, now = new Date()) {
     .returning({ id: posts.id, authorId: posts.authorId });
 }
 
-// An author's published posts as lightweight (id, title, createdAt) rows — the
-// spine of the writer dashboard, which then attaches per-post engagement and
-// view stats. No pagination: an author's own catalogue, newest first.
+// An author's published posts as lightweight (id, title, slug, createdAt) rows —
+// the spine of the writer dashboard, which then attaches per-post engagement and
+// view stats. The slug is included so the dashboard can link each post straight
+// to its canonical /@author/<slug> URL instead of round-tripping through the
+// legacy id permalink. No pagination: an author's own catalogue, newest first.
 export function publishedBriefByAuthor(authorId: string) {
   return db
-    .select({ id: posts.id, title: posts.title, createdAt: posts.createdAt })
+    .select({ id: posts.id, title: posts.title, slug: posts.slug, createdAt: posts.createdAt })
     .from(posts)
     .where(and(eq(posts.authorId, authorId), eq(posts.status, "published")))
     .orderBy(desc(posts.createdAt), desc(posts.id));

--- a/apps/backend/src/services/analytics.ts
+++ b/apps/backend/src/services/analytics.ts
@@ -46,6 +46,10 @@ export async function recordPostView(
 export type PostStat = {
   postId: string;
   title: string | null;
+  // The post's slug (null for an untitled post), so the dashboard can link each
+  // row straight to its canonical /@author/<slug> URL rather than resolving it
+  // through the legacy id permalink on every navigation.
+  slug: string | null;
   createdAt: Date;
   views: number;
   likes: number;
@@ -87,6 +91,7 @@ export async function dashboardFor(authorId: string, sinceDays = 30): Promise<Da
   const stats: PostStat[] = posts.map((p) => ({
     postId: p.id,
     title: p.title,
+    slug: p.slug,
     createdAt: p.createdAt,
     views: viewTotals.get(p.id) ?? 0,
     likes: likeStats.get(p.id)?.count ?? 0,

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -292,6 +292,10 @@ export type SearchResults = {
 export type PostStat = {
   postId: string;
   title: string | null;
+  // The post's slug (null for an untitled post), so the dashboard can link each
+  // row straight to its canonical /@author/<slug> URL instead of resolving it
+  // through the legacy id permalink on every navigation.
+  slug: string | null;
   createdAt: string;
   views: number;
   likes: number;

--- a/apps/frontend/src/routes/dashboard/+page.server.ts
+++ b/apps/frontend/src/routes/dashboard/+page.server.ts
@@ -5,9 +5,11 @@ import type { PageServerLoad } from "./$types";
 
 // A writer's analytics for their own posts — auth required. The backend scopes
 // everything to the signed-in author; no reader identities are ever returned.
+// `username` is threaded through so the component can link each post row straight
+// to its canonical /@author/<slug> URL.
 export const load: PageServerLoad = async ({ fetch, parent }) => {
   const { user } = await parent();
   if (!user) redirect(302, "/login");
   const summary = await endpoints(fetch).dashboard();
-  return { summary };
+  return { summary, username: user.username };
 };

--- a/apps/frontend/src/routes/dashboard/+page.svelte
+++ b/apps/frontend/src/routes/dashboard/+page.svelte
@@ -3,6 +3,7 @@
   import Icon, { type IconName } from "$lib/components/Icon.svelte";
   import PageTitle from "$lib/components/PageTitle.svelte";
   import Time from "$lib/components/Time.svelte";
+  import { postPath } from "$lib/links";
   import { locale } from "$lib/locale";
   import { timeZone } from "$lib/timezone";
   import type { DashboardSummary, PostStat } from "$lib/types";
@@ -318,7 +319,14 @@
                       >Top</span
                     >
                   {/if}
-                  <a href="/posts/{p.postId}" class="font-medium text-foreground hover:underline">
+                  <!-- Link straight to the post's canonical /@author/<slug> URL.
+                       Going through the legacy id permalink would add a server
+                       round-trip + redirect on every navigation, which is what
+                       made the blog page feel intermittently slow to open. -->
+                  <a
+                    href={postPath({ id: p.postId, slug: p.slug, author: { username: data.username } })}
+                    class="font-medium text-foreground hover:underline"
+                  >
                     {p.title || "Untitled"}
                   </a>
                 </div>


### PR DESCRIPTION
Fixes #117

## Problem

On the writer dashboard, clicking a post title to open the blog page intermittently takes much longer than expected. Every such click navigated through the **legacy id permalink** (`/posts/<id>`), a SvelteKit route that resolves the post via the backend and then `308`-redirects to the real `/@author/<slug>` page. That added a whole extra **server round-trip + browser redirect hop** on every click, before the actual page (which itself loads the post, comments, and related posts) even started. The intermittent nature matches the extra hop: when that redirect request is slow, the navigation appears frozen with no loading feedback.

## Fix

Make the dashboard link each post **directly to its canonical URL**, skipping the id-permalink detour entirely.

- **Backend** — `publishedBriefByAuthor` now also selects the post `slug`, and `analytics.dashboardFor` threads it into each `PostStat` row.
- **Frontend** — the dashboard's `+page.server` returns the signed-in author's `username`; the posts table builds each link with `postPath(...)`, the same helper the rest of the app uses, producing `/@author/<slug>` (with the short-id fallback for an untitled post).

No routing or caching changes — the canonical route resolves and loads exactly as it always did; it's just reached in one hop now.

## Validation

- Backend: `deno check` clean, `pnpm lint` 0 errors, `pnpm fmt:check` clean, 214 unit tests pass.
- Frontend: `svelte-check` 0 errors/0 warnings, `pnpm lint` 0 errors, `pnpm fmt:check` clean, 34 unit tests pass, production `vite build` succeeds.