### PR TITLE
fix(federation): build ActivityPub identities from the setup-wizard domain

### DIFF
--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -258,6 +258,3 @@ function load() {
 }
 
 export const config = load();
-
-// The instance origin (scheme + domain). https unless a localhost dev domain.
-export const origin = `${config.APP_DOMAIN.startsWith("localhost") ? "http" : "https"}://${config.APP_DOMAIN}`;

--- a/apps/backend/src/federation/actor.ts
+++ b/apps/backend/src/federation/actor.ts
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { ActorKeyPair as FedifyActorKeyPair, Context } from "@fedify/fedify";
 import { Endpoints, Hashtag, Image, OrderedCollection, Person, PropertyValue } from "@fedify/fedify/vocab";
-import { origin } from "@/config.ts";
 import * as linksRepo from "@/db/repositories/profileLinks.ts";
 import * as listsRepo from "@/db/repositories/readingLists.ts";
 import type { TagSummary } from "@/db/repositories/tags.ts";
 import type { User } from "@/db/schema.ts";
 import { escapeHtml } from "@/lib/html.ts";
 import { linkDisplayText, linkLabel } from "@/lib/profileLinks.ts";
+import { federationOrigin } from "@/services/federationState.ts";
 
 // Builds the ActivityPub Person for a local user. Shared by the actor
 // dispatcher (mod.ts, serving GET /users/{id}) and the outbound Update sender
@@ -66,12 +66,12 @@ export async function buildPerson(
     // answer, and it negotiates back to this actor for anything that asks for
     // JSON-LD (see the frontend's hooks.server.ts). Same split Mastodon draws
     // between /users/<name> and /@<name>.
-    url: new URL(`/@${identifier}`, origin),
-    icon: user.avatarUrl ? new Image({ url: new URL(user.avatarUrl, origin) }) : undefined,
+    url: new URL(`/@${identifier}`, federationOrigin()),
+    icon: user.avatarUrl ? new Image({ url: new URL(user.avatarUrl, federationOrigin()) }) : undefined,
     publicKey: keys[0]?.cryptographicKey,
     assertionMethods: keys.map((k) => k.multikey),
     // Profile tags, federated as Hashtags (like Mastodon's featured tags).
-    tags: tags.map((t) => new Hashtag({ name: `#${t.name}`, href: new URL(`/tags/${t.slug}`, origin) })),
+    tags: tags.map((t) => new Hashtag({ name: `#${t.name}`, href: new URL(`/tags/${t.slug}`, federationOrigin()) })),
     streams: publicLists.map((l) => ctx.getObjectUri(OrderedCollection, { identifier, listId: l.id })),
     attachments,
   });

--- a/apps/backend/src/federation/article.ts
+++ b/apps/backend/src/federation/article.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Context } from "@fedify/fedify";
 import { Article, Hashtag, Image, LanguageString, PUBLIC_COLLECTION } from "@fedify/fedify/vocab";
-import { origin } from "@/config.ts";
 import type { TagSummary } from "@/db/repositories/tags.ts";
 import type { Post } from "@/db/schema.ts";
 import { absoluteBanner, bannerOf } from "@/lib/cover.ts";
 import { normalizeLanguage } from "@/lib/languages.ts";
+import { federationOrigin } from "@/services/federationState.ts";
 
 // The post's banner as an ActivityPub Image.
 //
@@ -14,7 +14,7 @@ import { normalizeLanguage } from "@/lib/languages.ts";
 // against ours first. Anything still unparseable is dropped rather than
 // federated as a broken attachment.
 function coverImage(url: string | null): Image | undefined {
-  const absolute = absoluteBanner(url, origin);
+  const absolute = absoluteBanner(url, federationOrigin());
   if (!absolute) return undefined;
   try {
     return new Image({ url: new URL(absolute) });
@@ -94,7 +94,7 @@ export function buildArticle(
     to,
     cc,
     url: new URL(`/posts/${post.id}`, ctx.getActorUri(identifier)),
-    tags: tags.map((t) => new Hashtag({ name: `#${t.name}`, href: new URL(`/tags/${t.slug}`, origin) })),
+    tags: tags.map((t) => new Hashtag({ name: `#${t.name}`, href: new URL(`/tags/${t.slug}`, federationOrigin()) })),
   });
 }
 

--- a/apps/backend/src/federation/article_test.ts
+++ b/apps/backend/src/federation/article_test.ts
@@ -4,10 +4,13 @@ import { PUBLIC_COLLECTION } from "@fedify/fedify/vocab";
 // addressed to the ActivityStreams Public collection may be cached, so a
 // followers-only or direct-message post is never persisted and surfaced on
 // anonymous read paths. The module under test imports config (which needs a
-// Deno runtime for env access), so it is mocked; the logic tested is real.
+// Deno runtime for env access), so it is mocked; the logic tested is real. No
+// origin is provided: article.ts reads the federation origin from
+// federationState, which falls back to its own config-derived default — and
+// isPubliclyAddressed never consults it.
 import { describe, expect, it, vi } from "vitest";
 
-vi.mock("@/config.ts", () => ({ config: {}, origin: "https://omicron.example" }));
+vi.mock("@/config.ts", () => ({ config: {} }));
 
 import { isPubliclyAddressed } from "@/federation/article.ts";
 

--- a/apps/backend/src/federation/deliver.ts
+++ b/apps/backend/src/federation/deliver.ts
@@ -2,7 +2,6 @@
 import type { Context } from "@fedify/fedify";
 import type { Actor } from "@fedify/fedify/vocab";
 import { Create, Delete, isActor, PUBLIC_COLLECTION, Tombstone, Update } from "@fedify/fedify/vocab";
-import { origin } from "@/config.ts";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
@@ -11,6 +10,7 @@ import * as usersRepo from "@/db/repositories/users.ts";
 import { buildPerson } from "@/federation/actor.ts";
 import { buildArticle, type ArticleAudience } from "@/federation/article.ts";
 import { getFederation } from "@/federation/mod.ts";
+import { federationOrigin } from "@/services/federationState.ts";
 
 // Resolves a local author's remote followers into deliverable actor objects,
 // skipping any on a defederated domain (exact host or subdomain). Shared by
@@ -42,7 +42,7 @@ export async function deliverPost(postId: string, action: "create" | "update" = 
   const author = await usersRepo.findById(row.post.authorId);
   if (!author) return;
 
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const recipients = await remoteRecipients(ctx, author.id);
   if (recipients.length === 0) return;
 
@@ -89,7 +89,7 @@ export async function deliverActorUpdate(userId: string): Promise<void> {
   const user = await usersRepo.findById(userId);
   if (!user) return;
 
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const recipients = await remoteRecipients(ctx, user.id);
   if (recipients.length === 0) return;
 
@@ -119,7 +119,7 @@ export async function deliverPostDelete(postId: string, authorId: string): Promi
   const author = await usersRepo.findById(authorId);
   if (!author) return;
 
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const recipients = await remoteRecipients(ctx, author.id);
   if (recipients.length === 0) return;
 

--- a/apps/backend/src/federation/lists.ts
+++ b/apps/backend/src/federation/lists.ts
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { Add, isActor, OrderedCollection, PUBLIC_COLLECTION, Remove } from "@fedify/fedify/vocab";
-import { origin } from "@/config.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as listsRepo from "@/db/repositories/readingLists.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import { getFederation } from "@/federation/mod.ts";
+import { federationOrigin } from "@/services/federationState.ts";
 
 // Announces that a post was added to / removed from a *public* reading list, via
 // a standard Add / Remove activity whose `target` is the list's OrderedCollection
@@ -27,9 +27,10 @@ export async function deliverListItem(listId: string, postId: string, action: "a
   if (!row) return;
   // The post's canonical ActivityPub URI: local posts live under this instance's
   // /posts/{id}; remote posts keep their origin apId.
-  const postUri = row.post.remote && row.post.apId ? new URL(row.post.apId) : new URL(`/posts/${row.post.id}`, origin);
+  const postUri =
+    row.post.remote && row.post.apId ? new URL(row.post.apId) : new URL(`/posts/${row.post.id}`, federationOrigin());
 
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const recipients = [];
   for (const uri of followerUris) {
     const actor = await ctx.lookupObject(uri);

--- a/apps/backend/src/federation/mod.ts
+++ b/apps/backend/src/federation/mod.ts
@@ -27,7 +27,6 @@ import {
   Update,
 } from "@fedify/fedify/vocab";
 import { RedisKvStore, RedisMessageQueue } from "@fedify/redis";
-import { origin } from "@/config.ts";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
@@ -46,6 +45,7 @@ import { sameOrigin } from "@/lib/domain.ts";
 import { getRedis, redisEnabled, redisFactory } from "@/lib/redis.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
 import { normalizeTags } from "@/lib/tags.ts";
+import { federationOrigin } from "@/services/federationState.ts";
 import * as notifications from "@/services/notifications.ts";
 
 // ── ActivityPub wiring (isolated) ────────────────────────────────────────
@@ -192,7 +192,9 @@ function setupLists(f: Federation<ContextData>) {
       if (!list || list.userId !== user.id || list.visibility !== "public") return null;
 
       const refs = await listsRepo.itemRefs(list.id);
-      const items = refs.map((r) => (r.remote && r.apId ? new URL(r.apId) : new URL(`/posts/${r.id}`, origin)));
+      const items = refs.map((r) =>
+        r.remote && r.apId ? new URL(r.apId) : new URL(`/posts/${r.id}`, federationOrigin()),
+      );
       return new OrderedCollection({
         id: ctx.getObjectUri(OrderedCollection, { identifier, listId }),
         name: list.title,

--- a/apps/backend/src/federation/outbound.ts
+++ b/apps/backend/src/federation/outbound.ts
@@ -12,11 +12,11 @@ import {
   Reject,
   Undo,
 } from "@fedify/fedify/vocab";
-import { origin } from "@/config.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import { getFederation } from "@/federation/mod.ts";
+import { federationOrigin } from "@/services/federationState.ts";
 
 // Outbound Follow / Undo(Follow) to a remote actor URI. Wired for future use
 // when the UI lets users follow remote handles; the call site already enqueues
@@ -25,7 +25,7 @@ import { getFederation } from "@/federation/mod.ts";
 export async function sendFollow(followerId: string, targetActor: string): Promise<void> {
   const user = await usersRepo.findById(followerId);
   if (!user) return;
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const actor = await ctx.lookupObject(targetActor);
   if (!isActor(actor)) return;
   await ctx.sendActivity(
@@ -42,7 +42,7 @@ export async function sendFollow(followerId: string, targetActor: string): Promi
 export async function sendUnfollow(followerId: string, targetActor: string): Promise<void> {
   const user = await usersRepo.findById(followerId);
   if (!user) return;
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const actor = await ctx.lookupObject(targetActor);
   if (!isActor(actor)) return;
   await ctx.sendActivity(
@@ -63,7 +63,7 @@ export async function sendUnfollow(followerId: string, targetActor: string): Pro
 export async function sendBlock(blockerId: string, targetActor: string): Promise<void> {
   const user = await usersRepo.findById(blockerId);
   if (!user) return;
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const actor = await ctx.lookupObject(targetActor);
   if (!isActor(actor)) return;
   await ctx.sendActivity(
@@ -80,7 +80,7 @@ export async function sendBlock(blockerId: string, targetActor: string): Promise
 export async function sendUndoBlock(blockerId: string, targetActor: string): Promise<void> {
   const user = await usersRepo.findById(blockerId);
   if (!user) return;
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const actor = await ctx.lookupObject(targetActor);
   if (!isActor(actor)) return;
   await ctx.sendActivity(
@@ -101,7 +101,7 @@ export async function sendUndoBlock(blockerId: string, targetActor: string): Pro
 export async function sendRejectFollow(userId: string, targetActor: string): Promise<void> {
   const user = await usersRepo.findById(userId);
   if (!user) return;
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const actor = await ctx.lookupObject(targetActor);
   if (!isActor(actor) || !actor.id) return;
   const actorUri = ctx.getActorUri(user.username);
@@ -128,7 +128,7 @@ export async function sendAcceptFollow(
 ): Promise<void> {
   const user = await usersRepo.findById(userId);
   if (!user) return;
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const actor = await ctx.lookupObject(targetActor);
   if (!isActor(actor) || !actor.id) return;
   const actorUri = ctx.getActorUri(user.username);
@@ -173,12 +173,12 @@ export async function sendRecommend(userId: string, postId: string): Promise<voi
   const row = await postsRepo.findById(postId);
   if (!row) return;
 
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const recipients = await followerRecipients(ctx, user.id);
   if (recipients.length === 0) return;
 
   const objectUri =
-    row.post.remote && row.post.apId ? new URL(row.post.apId) : new URL(`/posts/${row.post.id}`, origin);
+    row.post.remote && row.post.apId ? new URL(row.post.apId) : new URL(`/posts/${row.post.id}`, federationOrigin());
   const actorUri = ctx.getActorUri(user.username);
 
   await ctx.sendActivity(
@@ -201,7 +201,7 @@ export async function sendUnrecommend(userId: string, postId: string): Promise<v
   const user = await usersRepo.findById(userId);
   if (!user) return;
 
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const recipients = await followerRecipients(ctx, user.id);
   if (recipients.length === 0) return;
 
@@ -228,7 +228,7 @@ export async function sendActorDelete(userId: string): Promise<void> {
   const followerUris = await followsRepo.remoteFollowerActors(user.id);
   if (followerUris.length === 0) return;
 
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const recipients = [];
   for (const uri of followerUris) {
     const actor = await ctx.lookupObject(uri);

--- a/apps/backend/src/federation/remote.ts
+++ b/apps/backend/src/federation/remote.ts
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { DocumentLoader } from "@fedify/fedify";
 import { type Actor, Article, Create, Hashtag, isActor } from "@fedify/fedify/vocab";
-import { origin } from "@/config.ts";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
@@ -13,6 +12,7 @@ import { getFederation } from "@/federation/mod.ts";
 import { sameOrigin } from "@/lib/domain.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
 import { normalizeTags } from "@/lib/tags.ts";
+import { federationOrigin } from "@/services/federationState.ts";
 
 // Resolving and caching remote fediverse actors + their posts. This is the
 // read-side counterpart to outbound.ts: we fetch foreign actor documents and
@@ -39,7 +39,7 @@ function handleHost(handle: string): string {
 // require authorized fetch / secure mode still serve us their documents. Falls
 // back to the default loader when there is no local user yet.
 async function signedLoader(): Promise<DocumentLoader | undefined> {
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const user = await usersRepo.firstUser();
   if (!user) return undefined;
   return await ctx.getDocumentLoader({ identifier: user.username });
@@ -49,7 +49,7 @@ async function signedLoader(): Promise<DocumentLoader | undefined> {
 export async function resolveActor(handle: string): Promise<RemoteActor | null> {
   // Never reach out to a defederated domain.
   if (await blockedDomainsRepo.isBlocked(handleHost(handle))) return null;
-  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
   const documentLoader = await signedLoader();
   const object = await ctx.lookupObject(fediHandle(handle), { documentLoader });
   if (!isActor(object) || !object.id) return null;
@@ -96,7 +96,7 @@ export async function cacheActor(actor: Actor, handle?: string): Promise<RemoteA
 export async function fetchOutboxPosts(handle: string, remoteActorId: string): Promise<void> {
   try {
     if (await blockedDomainsRepo.isBlocked(handleHost(handle))) return;
-    const ctx = getFederation().createContext(new URL(origin), undefined);
+    const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
     const documentLoader = await signedLoader();
     const actor = await ctx.lookupObject(fediHandle(handle), { documentLoader });
     if (!isActor(actor)) return;

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -4,8 +4,8 @@ import { config } from "@/config.ts";
 import { runMigrations } from "@/db/migrate.ts";
 import { startJobWorker } from "@/queue/queue.ts";
 import { reconcileAnubisInBackground } from "@/services/anubisProtection.ts";
-import { seedFederationRunning } from "@/services/federationState.ts";
-import { getFederationEnabled } from "@/services/instanceSetup.ts";
+import { seedFederationOrigin, seedFederationRunning } from "@/services/federationState.ts";
+import { getFederationEnabled, getOrigin } from "@/services/instanceSetup.ts";
 import { backfillSlugs } from "@/services/postSlugs.ts";
 import { startScheduleSweeper } from "@/services/scheduledPosts.ts";
 import { startUploadGcSweeper } from "@/services/uploadGc.ts";
@@ -21,6 +21,11 @@ async function main() {
   // Resolve the effective federation state (admin toggle → env → default) before
   // the app binds its ActivityPub routes; the value is fixed for this process.
   seedFederationRunning(await getFederationEnabled());
+  // Resolve the effective federation origin (wizard-persisted domain → env →
+  // default) the same way before the app binds, so ActivityPub actor/activity
+  // identities and outbound deliveries use the domain configured by the setup
+  // wizard instead of the boot-time APP_DOMAIN default (#122).
+  seedFederationOrigin(await getOrigin());
   const app = await buildApp();
 
   // Drain durable jobs when Redis is configured; no-op in-process otherwise.

--- a/apps/backend/src/services/federationState.ts
+++ b/apps/backend/src/services/federationState.ts
@@ -20,3 +20,31 @@ export function federationRunning(): boolean {
 export function seedFederationRunning(value: boolean): void {
   running = value;
 }
+
+// The ActivityPub origin this process constructs identities against (scheme +
+// domain). Like the `running` flag above, it is seeded once at boot and fixed
+// for the process — Fedify contexts and actor/activity URIs are built from it
+// throughout. But unlike the boot-time env domain, it honours the domain the
+// setup wizard persisted to the DB (see instanceSetup.getOrigin), so a
+// wizard-configured HTTPS domain is what federation actually uses even when
+// APP_DOMAIN was left at the default `localhost:5173`. Falls back to the same
+// config-derived value as before when nothing has been seeded (e.g. bare unit
+// tests that don't run main()). Defensive about a missing APP_DOMAIN so a unit
+// test that mocks config as `{}` still loads.
+const configOrigin = (): string => {
+  const domain = config.APP_DOMAIN?.trim() || "localhost:5173";
+  return `${domain.startsWith("localhost") ? "http" : "https"}://${domain}`;
+};
+let origin = configOrigin();
+
+// The effective federation origin in force for this process.
+export function federationOrigin(): string {
+  return origin;
+}
+
+// Seed the federation origin with the effective value during boot, before the
+// app binds its ActivityPub routes. Not for request-time use — the value is
+// fixed for the process's lifetime.
+export function seedFederationOrigin(value: string): void {
+  origin = value;
+}

--- a/apps/backend/src/services/federationState_test.ts
+++ b/apps/backend/src/services/federationState_test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Unit tests for the federation origin holder behind #122: the origin used to
+// build ActivityPub identities is seeded at boot from the *persisted* instance
+// domain (wizard → env → default), not pinned to the boot-time APP_DOMAIN. The
+// default must also survive a config mocked without the field (as other unit
+// tests do), so the derivation is defensive.
+vi.mock("@/config.ts", () => ({ config: { APP_DOMAIN: "localhost:5173" } }));
+
+import { federationOrigin, seedFederationOrigin } from "@/services/federationState.ts";
+
+describe("federation origin (#122)", () => {
+  it("defaults to the config-derived origin when nothing has been seeded", () => {
+    expect(federationOrigin()).toBe("http://localhost:5173");
+  });
+
+  it("returns the wizard-persisted origin after seeding", () => {
+    seedFederationOrigin("https://blog.example.com");
+    expect(federationOrigin()).toBe("https://blog.example.com");
+  });
+});

--- a/apps/backend/src/services/instanceSetup.ts
+++ b/apps/backend/src/services/instanceSetup.ts
@@ -36,9 +36,10 @@ export async function getAppName(): Promise<string> {
 }
 
 // Effective public domain: wizard → APP_DOMAIN env/default (config.APP_DOMAIN).
-// Note: federation actor identity is bound to config.APP_DOMAIN at boot, so a
-// domain change here applies to app-level URLs immediately but only reaches
-// ActivityPub after a restart (which enabling federation requires anyway).
+// Note: the federation origin is seeded once at boot from this same effective
+// domain (see main.ts / federationState.ts), so a domain change here applies to
+// app-level URLs immediately but only reaches ActivityPub after a restart
+// (which enabling federation requires anyway).
 export async function getAppDomain(): Promise<string> {
   const fromDb = await settingsRepo.get<string>(SETUP_KEYS.appDomain);
   return fromDb?.trim() || config.APP_DOMAIN;


### PR DESCRIPTION
Fixes #122

## Problem

The setup wizard persists the operator's chosen domain to `instance_settings`, and `instanceSetup.getOrigin()` already derives the effective public origin from it (DB → `APP_DOMAIN` env → default). But federation never used that helper. Every federation module imported a module-level `origin` baked straight from the boot-time `config.APP_DOMAIN`:

- `config.ts` → `export const origin = "http://localhost:5173"` (the Docker default)
- `deliver.ts` → `getFederation().createContext(new URL(origin), undefined)`
- `outbound.ts` / `remote.ts` → the same static origin for follow/block/recommend/delivery
- `actor.ts` / `article.ts` / `lists.ts` / `mod.ts` → `new URL(base, origin)` for actor/activity/hashtag/list URIs

So on the advertised zero-config path (no `APP_DOMAIN` set), an instance configured through the wizard with `blog.example.com` still built its ActivityPub actor and activity identities relative to `http://localhost:5173`.

## Fix

Resolve **one** effective federation origin from the persisted instance domain at startup and seed it into process-level state, mirroring the existing `seedFederationRunning` pattern.

- **`services/federationState.ts`** now holds the federation origin (seeded once, fixed for the process), defaulting defensively to the config-derived value so bare unit tests still load.
- **`main.ts`** seeds `seedFederationOrigin(await getOrigin())` right next to the federation-running seed, before `buildApp`, so the wizard-set domain (or env fallback) is what ActivityPub actually uses.
- **`actor.ts` / `article.ts` / `deliver.ts` / `lists.ts` / `mod.ts` / `outbound.ts` / `remote.ts`** now call `federationOrigin()` for both `new URL(base, ...)` URI building and Fedify `createContext` calls.

No behavior change for an env-configured instance: substituting the resolved domain for the env value yields the same origin. But a wizard-configured instance now federates under its real HTTPS domain instead of `http://localhost:5173`.

## Tests

- New `federationState_test.ts`: verifies the unseeded default and the seeded origin.
- Backend: `deno check` clean, `pnpm lint` 0 errors, `pnpm fmt:check` clean, **216 unit tests pass** (214 existing + 2 new).