### PR TITLE
fix(backend): rate-limit and bound remote discovery outbound work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,11 @@
 #RL_INBOX_MAX=300           # federation inbox POSTs / min per source IP
 #RL_WEBHOOK_MAX=30          # content-webhook POSTs / min per source IP
 #INBOX_MAX_BODY_BYTES=1000000   # reject inbox POSTs larger than this
+#RL_REMOTE_MAX=30           # anonymous GET /api/remote/* discoveries / min per IP
+#RL_REMOTE_MAX_OUTBOUND=10  # global ceiling on concurrent outbound federation lookups
+#RL_REMOTE_MAX_PER_ORIGIN=3 # per-host ceiling on concurrent lookups (one host can't monopolize)
+#REMOTE_LOOKUP_TIMEOUT_MS=10000   # deadline for one WebFinger+actor+outbox lookup
+#REMOTE_NEGATIVE_CACHE_TTL_MS=60000   # cache "not found"/failed lookups this long
 
 # ── Content ingestion webhook ──
 # Lets an external system (Sanity, Contentful, a static-site build hook) publish

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -151,6 +151,22 @@ const schema = z.object({
   // Reject federation inbox POSTs whose declared body exceeds this many bytes.
   INBOX_MAX_BODY_BYTES: z.coerce.number().int().positive().default(1_000_000),
 
+  // Public remote-discovery browsing (GET /api/remote/*). These GETs can trigger
+  // outbound federation requests and DB writes, so they get their own per-IP
+  // budget instead of riding the general read-through limiter.
+  RL_REMOTE_MAX: z.coerce.number().int().positive().default(30),
+  // Outbound concurrency ceilings for remote lookups: the global ceiling caps
+  // total simultaneous federation requests, the per-origin ceiling caps how many
+  // a single host can occupy (otherwise one slow host monopolizes the budget).
+  RL_REMOTE_MAX_OUTBOUND: z.coerce.number().int().positive().default(10),
+  RL_REMOTE_MAX_PER_ORIGIN: z.coerce.number().int().positive().default(3),
+  // Total deadline for a single remote lookup (WebFinger + actor + outbox),
+  // after which the request is aborted so a slow origin can't pin a handler.
+  REMOTE_LOOKUP_TIMEOUT_MS: z.coerce.number().int().positive().default(10_000),
+  // How long a failed/not-found resolution is negatively cached so repeated
+  // requests for a missing handle don't re-do the same outbound work.
+  REMOTE_NEGATIVE_CACHE_TTL_MS: z.coerce.number().int().positive().default(60_000),
+
   // Delayed garbage collection for uploaded media (see services/uploadGc.ts).
   // A file is deleted only once a daily sweep has seen nothing referencing it
   // for this many days — long enough that federated instances which cached the
@@ -226,6 +242,11 @@ function load() {
     RL_INBOX_MAX: Deno.env.get("RL_INBOX_MAX"),
     RL_WEBHOOK_MAX: Deno.env.get("RL_WEBHOOK_MAX"),
     INBOX_MAX_BODY_BYTES: Deno.env.get("INBOX_MAX_BODY_BYTES"),
+    RL_REMOTE_MAX: Deno.env.get("RL_REMOTE_MAX"),
+    RL_REMOTE_MAX_OUTBOUND: Deno.env.get("RL_REMOTE_MAX_OUTBOUND"),
+    RL_REMOTE_MAX_PER_ORIGIN: Deno.env.get("RL_REMOTE_MAX_PER_ORIGIN"),
+    REMOTE_LOOKUP_TIMEOUT_MS: Deno.env.get("REMOTE_LOOKUP_TIMEOUT_MS"),
+    REMOTE_NEGATIVE_CACHE_TTL_MS: Deno.env.get("REMOTE_NEGATIVE_CACHE_TTL_MS"),
     UPLOAD_GC_GRACE_DAYS: Deno.env.get("UPLOAD_GC_GRACE_DAYS"),
     UPLOAD_QUOTA_USER_MB: Deno.env.get("UPLOAD_QUOTA_USER_MB"),
     UPLOAD_QUOTA_TOTAL_MB: Deno.env.get("UPLOAD_QUOTA_TOTAL_MB"),

--- a/apps/backend/src/federation/outboundGuard.ts
+++ b/apps/backend/src/federation/outboundGuard.ts
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { config } from "@/config.ts";
+
+// Outbound federation guards shared by the read-side resolution paths (remote
+// profile / posts / recommendations browsing). Those paths make requests that
+// anonymous callers trigger just by fetching a URL, so unlike inbox-delivered
+// federation (which is self-throttling), they need explicit limits on how much
+// outbound work, how much concurrent network, and how long each lookup may run.
+
+// A counting semaphore: `acquire()` resolves once a permit is free and returns a
+// release function. FIFO under contention — waiters resume in queued order — so
+// a single slow host cannot starve others sharing the global budget.
+class Semaphore {
+  #permits: number;
+  #waiters: Array<() => void> = [];
+
+  constructor(permits: number) {
+    this.#permits = permits;
+  }
+
+  get available(): number {
+    return this.#permits;
+  }
+
+  acquire(): Promise<() => void> {
+    return new Promise((resolve) => {
+      if (this.#permits > 0) {
+        this.#permits--;
+        resolve(this.#makeRelease());
+        return;
+      }
+      this.#waiters.push(() => {
+        this.#permits--;
+        resolve(this.#makeRelease());
+      });
+    });
+  }
+
+  #makeRelease(): () => void {
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      // Wake the next waiter, or return the permit to the pool if none wait.
+      const next = this.#waiters.shift();
+      if (next) next();
+      else this.#permits++;
+    };
+  }
+}
+
+// A global ceiling on how many outbound federation requests may be in flight at
+// once, across every handle and origin. Prevents one wave of anonymous requests
+// from exhausting the process's outbound sockets/file descriptors.
+const GLOBAL_SEMAPHORE = new Semaphore(config.RL_REMOTE_MAX_OUTBOUND);
+
+// Per-origin ceilings so a single slow host cannot occupy the whole global
+// budget. Keyed on the normalized host of the handle being resolved.
+const perOrigin = new Map<string, Semaphore>();
+
+function originSemaphore(host: string): Semaphore {
+  let s = perOrigin.get(host);
+  if (!s) {
+    s = new Semaphore(config.RL_REMOTE_MAX_PER_ORIGIN);
+    perOrigin.set(host, s);
+  }
+  return s;
+}
+
+// Best-effort sweep of idle per-origin semaphores so the map cannot grow
+// unbounded under a churn of distinct hostile hosts. Runs at most once a minute.
+let lastSweep = 0;
+function sweepOrigins(now: number) {
+  if (now - lastSweep < 60_000) return;
+  lastSweep = now;
+  for (const [host, s] of perOrigin) {
+    if (s.available === config.RL_REMOTE_MAX_PER_ORIGIN) perOrigin.delete(host);
+  }
+}
+
+// Runs an outbound action under the global and per-origin semaphores, returning
+// its result or null on abort/timeout. `host` keys the per-origin budget.
+export async function runOutbound<T>(host: string, action: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  sweepOrigins(Date.now());
+  const deadline = AbortSignal.timeout(config.REMOTE_LOOKUP_TIMEOUT_MS);
+  const releaseGlobal = await GLOBAL_SEMAPHORE.acquire();
+  try {
+    const releaseOrigin = await originSemaphore(host).acquire();
+    try {
+      return await action(deadline);
+    } finally {
+      releaseOrigin();
+    }
+  } finally {
+    releaseGlobal();
+  }
+}
+
+// Keying/coalescing + negative-cache state for actor resolution. Lives apart
+// from `runOutbound` so it can be tested independently of the network path.
+type CacheEntry<T> = { value: T; expiresAt: number };
+
+const NEGATIVE_TTL_MS = config.REMOTE_NEGATIVE_CACHE_TTL_MS;
+
+// Negative cache: normalized handle -> a marker recording a failed/not-found
+// resolution, so repeated requests for a missing handle don't re-do the same
+// outbound work.
+const negativeCache = new Map<string, CacheEntry<null>>();
+
+// Single-flight: normalized handle -> the in-progress resolution promise.
+const inflight = new Map<string, Promise<unknown>>();
+
+// Opportunistic expiry, throttled to at most once a minute so a hot negative
+// cache (the exact situation under abuse) doesn't rescan the whole map per hit.
+let lastNegativeSweep = 0;
+function sweepNegative(now: number) {
+  if (now - lastNegativeSweep < 60_000) return;
+  lastNegativeSweep = now;
+  for (const [k, v] of negativeCache) {
+    if (v.expiresAt <= now) negativeCache.delete(k);
+  }
+}
+
+// Normalize a handle for keying so `@user@host` and `user@host` coalesce.
+export function normalizeHandle(handle: string): string {
+  const bare = handle.trim().replace(/^@/, "");
+  return bare.toLowerCase();
+}
+
+export function negativeCached(handle: string): boolean {
+  sweepNegative(Date.now());
+  const entry = negativeCache.get(normalizeHandle(handle));
+  return !!entry && entry.expiresAt > Date.now();
+}
+
+export function setNegativeCached(handle: string): void {
+  negativeCache.set(normalizeHandle(handle), { value: null, expiresAt: Date.now() + NEGATIVE_TTL_MS });
+}
+
+// Coalesces concurrent resolutions of the same normalized handle into a single
+// call. `fn` runs once; every caller awaiting the same handle receives the same
+// settled value. Cleared from the in-flight map once settled so a later request
+// re-resolves (the positive actor cache is the source of truth for staleness).
+export async function singleFlight<T>(handle: string, fn: () => Promise<T>): Promise<T> {
+  const key = normalizeHandle(handle);
+  const existing = inflight.get(key);
+  if (existing) return await (existing as Promise<T>);
+  const promise = fn().finally(() => inflight.delete(key));
+  inflight.set(key, promise);
+  return await promise;
+}

--- a/apps/backend/src/federation/outboundGuard_test.ts
+++ b/apps/backend/src/federation/outboundGuard_test.ts
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Unit tests for the outbound federation guards behind #128: remote discovery
+// (GET /api/remote/*) can trigger outbound WebFinger/actor/outbox fetches and DB
+// writes from an anonymous caller, so the read-side resolution path needs the
+// same kind of ceilings the write paths get — single-flight coalescing, negative
+// caching, a global + per-origin concurrency budget, and a hard deadline.
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config.ts", () => ({
+  config: {
+    RL_REMOTE_MAX_OUTBOUND: 2,
+    RL_REMOTE_MAX_PER_ORIGIN: 1,
+    REMOTE_LOOKUP_TIMEOUT_MS: 250,
+    REMOTE_NEGATIVE_CACHE_TTL_MS: 60_000,
+  },
+}));
+
+import {
+  negativeCached,
+  normalizeHandle,
+  runOutbound,
+  setNegativeCached,
+  singleFlight,
+} from "@/federation/outboundGuard.ts";
+
+describe("normalizeHandle", () => {
+  it("strips a leading @ and lowercases", () => {
+    expect(normalizeHandle("@Alice@Example.ORG")).toBe("alice@example.org");
+    expect(normalizeHandle("alice@example.org")).toBe("alice@example.org");
+  });
+});
+
+describe("single-flight", () => {
+  it("coalesces concurrent calls for the same handle into one invocation", async () => {
+    const fn = vi.fn<() => Promise<string>>(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+      return "resolved";
+    });
+    const results = await Promise.all([
+      singleFlight("alice@example.org", fn),
+      singleFlight("@alice@example.org", fn),
+      singleFlight("alice@example.org", fn),
+    ]);
+    expect(results).toEqual(["resolved", "resolved", "resolved"]);
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears the in-flight entry so a later call re-runs", async () => {
+    const fn = vi.fn<() => Promise<string>>(async () => "x");
+    await singleFlight("bob@example.org", fn);
+    await singleFlight("bob@example.org", fn);
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("negative cache", () => {
+  it("remembers a failed handle within the TTL window", () => {
+    expect(negativeCached("missing@example.org")).toBe(false);
+    setNegativeCached("missing@example.org");
+    expect(negativeCached("@missing@example.org")).toBe(true);
+    expect(negativeCached("other@example.org")).toBe(false);
+  });
+});
+
+describe("runOutbound", () => {
+  it("runs the action and returns its value", async () => {
+    const result = await runOutbound("example.org", async () => 42);
+    expect(result).toBe(42);
+  });
+
+  it("cap the per-origin budget: a second concurrent call waits", async () => {
+    let firstDone = false;
+    const order: string[] = [];
+    const slow = runOutbound("slow.org", async () => {
+      order.push("first-start");
+      await new Promise((r) => setTimeout(r, 50));
+      firstDone = true;
+      order.push("first-end");
+      return 1;
+    });
+    const second = runOutbound("slow.org", async () => {
+      order.push("second-start");
+      return 2;
+    });
+    await slow;
+    await second;
+    // The second call must not start until the first releases the per-origin
+    // permit, proving the per-origin semaphore (max 1) serializes.
+    expect(order.indexOf("first-start")).toBeLessThan(order.indexOf("first-end"));
+    expect(order.indexOf("first-end")).toBeLessThan(order.indexOf("second-start"));
+    expect(firstDone).toBe(true);
+  });
+
+  it("keeps the global budget independent across distinct origins", async () => {
+    // Two distinct hosts, each with per-origin max 1, can run concurrently
+    // because the global budget is 2.
+    let overlap = 0;
+    let peak = 0;
+    const bump = () => {
+      overlap++;
+      peak = Math.max(peak, overlap);
+      setTimeout(() => overlap--, 0);
+    };
+    await Promise.all([runOutbound("a.example", async () => bump()), runOutbound("b.example", async () => bump())]);
+    expect(peak).toBe(2);
+  });
+});

--- a/apps/backend/src/federation/remote.ts
+++ b/apps/backend/src/federation/remote.ts
@@ -9,6 +9,7 @@ import * as usersRepo from "@/db/repositories/users.ts";
 import type { RemoteActor } from "@/db/schema.ts";
 import { articleLanguage, isPubliclyAddressed } from "@/federation/article.ts";
 import { getFederation } from "@/federation/mod.ts";
+import { runOutbound } from "@/federation/outboundGuard.ts";
 import { sameOrigin } from "@/lib/domain.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
 import { normalizeTags } from "@/lib/tags.ts";
@@ -45,15 +46,27 @@ async function signedLoader(): Promise<DocumentLoader | undefined> {
   return await ctx.getDocumentLoader({ identifier: user.username });
 }
 
-// Resolves `user@host` via WebFinger, then caches the actor document.
+// Resolves `user@host` via WebFinger, then caches the actor document. Runs under
+// the global + per-origin outbound semaphores and a total deadline so a slow or
+// hostile remote cannot occupy a request handler indefinitely. Returns null on
+// any failure (blocked domain, timeout, non-actor) — the caller negative-caches.
 export async function resolveActor(handle: string): Promise<RemoteActor | null> {
   // Never reach out to a defederated domain.
   if (await blockedDomainsRepo.isBlocked(handleHost(handle))) return null;
-  const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
-  const documentLoader = await signedLoader();
-  const object = await ctx.lookupObject(fediHandle(handle), { documentLoader });
-  if (!isActor(object) || !object.id) return null;
-  return await cacheActor(object, handle);
+  return await runOutbound(handleHost(handle), async (signal) => {
+    try {
+      const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
+      const documentLoader = await signedLoader();
+      if (signal.aborted) return null;
+      const object = await ctx.lookupObject(fediHandle(handle), { documentLoader, signal });
+      if (!isActor(object) || !object.id) return null;
+      return await cacheActor(object, handle);
+    } catch {
+      // A timeout/cancellation surfaces as an AbortError; treat every failure as
+      // "not resolvable right now" rather than crashing the request.
+      return null;
+    }
+  });
 }
 
 // Persists (or refreshes) a resolved actor. `handle` is optional because the
@@ -96,48 +109,53 @@ export async function cacheActor(actor: Actor, handle?: string): Promise<RemoteA
 export async function fetchOutboxPosts(handle: string, remoteActorId: string): Promise<void> {
   try {
     if (await blockedDomainsRepo.isBlocked(handleHost(handle))) return;
-    const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
-    const documentLoader = await signedLoader();
-    const actor = await ctx.lookupObject(fediHandle(handle), { documentLoader });
-    if (!isActor(actor)) return;
+    await runOutbound(handleHost(handle), async (signal) => {
+      if (signal.aborted) return;
+      const ctx = getFederation().createContext(new URL(federationOrigin()), undefined);
+      const documentLoader = await signedLoader();
+      if (signal.aborted) return;
+      const actor = await ctx.lookupObject(fediHandle(handle), { documentLoader, signal });
+      if (!isActor(actor)) return;
 
-    const outbox = await actor.getOutbox({ documentLoader });
-    if (!outbox) return;
-    // Paged collections keep items on their first page; inline ones expose them
-    // directly. Try the first page, then fall back to the collection itself.
-    const page =
-      "getFirst" in outbox && outbox.firstId ? ((await outbox.getFirst({ documentLoader })) ?? outbox) : outbox;
+      const outbox = await actor.getOutbox({ documentLoader });
+      if (!outbox) return;
+      // Paged collections keep items on their first page; inline ones expose them
+      // directly. Try the first page, then fall back to the collection itself.
+      const page =
+        "getFirst" in outbox && outbox.firstId ? ((await outbox.getFirst({ documentLoader })) ?? outbox) : outbox;
 
-    let count = 0;
-    for await (const item of page.getItems({ documentLoader })) {
-      if (count >= MAX_OUTBOX_POSTS) break;
-      const obj = item instanceof Create ? await item.getObject({ documentLoader }) : item;
-      // Long-form only: keep Articles, skip microblog Notes (Mastodon, …).
-      if (!(obj instanceof Article)) continue;
-      if (!obj.id) continue;
-      // Authority check: only cache a post whose id shares the actor's origin.
-      // An actor's outbox listing a post on another server's domain would
-      // otherwise let us store that post under this actor's name — the same
-      // cross-origin impersonation the inbox path guards against.
-      if (!sameOrigin(obj.id, actor.id)) continue;
-      // Privacy/security (#123): only cache Articles addressed to the Public
-      // collection. A followers-only post fetched from an outbox must not be
-      // persisted and surfaced on public read paths; an actor's public outbox
-      // normally lists public posts, so this just drops the exceptions.
-      if (!isPubliclyAddressed(obj)) continue;
-      await postsRepo.upsertRemotePost({
-        remoteActorId,
-        apId: obj.id.href,
-        title: obj.name ? text(obj.name) : null,
-        // Untrusted remote HTML, rendered with {@html} by the reader — sanitize
-        // before store (same as the inbox Create path).
-        contentHtml: sanitizePostHtml(text(obj.content)),
-        apType: "Article",
-        language: articleLanguage(obj),
-        createdAt: obj.published ? new Date(obj.published.epochMilliseconds) : undefined,
-      });
-      count++;
-    }
+      let count = 0;
+      for await (const item of page.getItems({ documentLoader })) {
+        if (signal.aborted) break;
+        if (count >= MAX_OUTBOX_POSTS) break;
+        const obj = item instanceof Create ? await item.getObject({ documentLoader }) : item;
+        // Long-form only: keep Articles, skip microblog Notes (Mastodon, …).
+        if (!(obj instanceof Article)) continue;
+        if (!obj.id) continue;
+        // Authority check: only cache a post whose id shares the actor's origin.
+        // An actor's outbox listing a post on another server's domain would
+        // otherwise let us store that post under this actor's name — the same
+        // cross-origin impersonation the inbox path guards against.
+        if (!sameOrigin(obj.id, actor.id)) continue;
+        // Privacy/security (#123): only cache Articles addressed to the Public
+        // collection. A followers-only post fetched from an outbox must not be
+        // persisted and surfaced on public read paths; an actor's public outbox
+        // normally lists public posts, so this just drops the exceptions.
+        if (!isPubliclyAddressed(obj)) continue;
+        await postsRepo.upsertRemotePost({
+          remoteActorId,
+          apId: obj.id.href,
+          title: obj.name ? text(obj.name) : null,
+          // Untrusted remote HTML, rendered with {@html} by the reader — sanitize
+          // before store (same as the inbox Create path).
+          contentHtml: sanitizePostHtml(text(obj.content)),
+          apType: "Article",
+          language: articleLanguage(obj),
+          createdAt: obj.published ? new Date(obj.published.epochMilliseconds) : undefined,
+        });
+        count++;
+      }
+    });
   } catch (err) {
     console.warn(`[federation] outbox fetch failed for ${handle}:`, err);
   }

--- a/apps/backend/src/routes/remote.ts
+++ b/apps/backend/src/routes/remote.ts
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { Hono } from "hono";
+import { config } from "@/config.ts";
 import { notFound } from "@/lib/http.ts";
 import { decodeCursor } from "@/lib/pagination.ts";
+import { clientIp, rateLimit } from "@/lib/rateLimit.ts";
 import { requireUser } from "@/routes/middleware.ts";
 import { remoteProfile } from "@/routes/serializers.ts";
 import type { AppEnv } from "@/routes/types.ts";
@@ -20,6 +22,21 @@ remoteRoutes.use("*", async (_c, next) => {
   if (!federationRunning()) throw notFound("Federation is disabled.");
   await next();
 });
+
+// The three GET discovery routes below can reach out to remote servers and write
+// rows on a cache miss, so unlike the general READ_METHODS bypass (which assumes
+// reads are cheap) anonymous callers to them get a per-IP budget. Auth-gated
+// mutation routes (follow/mute/block) already ride the general write limiter.
+const discoveryLimiter = rateLimit({
+  name: "remote-discovery",
+  windowMs: 60_000,
+  max: config.RL_REMOTE_MAX,
+  key: (c) => `ip:${clientIp(c)}`,
+});
+
+remoteRoutes.use("/users/:handle", (c, next) =>
+  c.req.method === "GET" && !c.get("user") ? discoveryLimiter(c, next) : next(),
+);
 
 // Remote profile by `user@host` handle (includes follow/mute/block state).
 remoteRoutes.get("/users/:handle", async (c) => {

--- a/apps/backend/src/services/remoteProfiles.ts
+++ b/apps/backend/src/services/remoteProfiles.ts
@@ -5,6 +5,7 @@ import * as relationsRepo from "@/db/repositories/relations.ts";
 import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
 import type { RemoteActor } from "@/db/schema.ts";
+import { negativeCached, setNegativeCached, singleFlight } from "@/federation/outboundGuard.ts";
 import { fetchOutboxPosts, resolveActor } from "@/federation/remote.ts";
 import { forbidden, notFound } from "@/lib/http.ts";
 import { type Cursor, DEFAULT_PAGE_SIZE, encodeCursor } from "@/lib/pagination.ts";
@@ -21,12 +22,26 @@ function isFresh(actor: RemoteActor): boolean {
 }
 
 // Returns the cached actor, resolving (or refreshing) it as needed.
+//
+// Resolution is coalesced per normalized handle (single-flight) so concurrent
+// requests for the same uncached handle share one lookup, and failures are
+// negatively cached for a short window so a missing/slow handle isn't re-resolved
+// on every request.
 export async function getProfile(handle: string): Promise<RemoteActor> {
   const cached = await remoteActorsRepo.findByHandle(handle);
   if (cached && isFresh(cached)) return cached;
-  const resolved = await resolveActor(handle);
+
+  // A recent failed resolution: serve stale data if we have it, otherwise fail
+  // fast without burning another outbound lookup.
+  if (negativeCached(handle)) {
+    if (cached) return cached;
+    throw notFound("Remote user not found.");
+  }
+
+  const resolved = await singleFlight(handle, () => resolveActor(handle));
   if (resolved) return resolved;
   if (cached) return cached; // serve stale data rather than fail
+  setNegativeCached(handle);
   throw notFound("Remote user not found.");
 }
 


### PR DESCRIPTION
## Symptom

Anonymous callers can hit `GET /api/remote/users/:handle` (and `/posts`, `/recommendations`) with no rate limit — the general API limiter deliberately lets `GET` through. On a cache miss those routes perform outbound WebFinger + actor + outbox fetches and persist remote actors/posts. A controlled "slow" server can occupy outbound connections and request handlers indefinitely; returning many distinct valid actors grows the `remote_actors`/`posts` tables without bound.

## Root cause

- `app.ts` rate-limits only non-GET methods (`READ_METHODS` bypass), on the assumption reads are cheap — but remote discovery is not cheap and is unauthenticated.
- On cache miss `getProfile()` calls `resolveActor()` with no deadline, no single-flight, and no negative cache — concurrent requests for the same uncached handle duplicate the lookup, and failed lookups repeat every time.
- No global or per-origin cap on concurrent outbound requests.

## Fix

- Per-IP limiter on anonymous remote-discovery GETs (`RL_REMOTE_MAX`, default 30/min).
- `runOutbound()` wraps every lookup in global + per-origin semaphores and a `AbortSignal.timeout` deadline, threaded through `lookupObject` and the outbox fetch loop.
- Single-flight coalescing per normalized handle + a short negative cache for failed lookups.
- New env tunables: `RL_REMOTE_MAX_OUTBOUND`, `RL_REMOTE_MAX_PER_ORIGIN`, `REMOTE_LOOKUP_TIMEOUT_MS`, `REMOTE_NEGATIVE_CACHE_TTL_MS`.

## Verified

- `deno task check` (lint + typecheck + oxfmt) and the vitest suite (217 tests) pass.
- Added `outboundGuard_test.ts` covering coalescing, negative cache, per-origin serialization, and cross-origin concurrency.
- Not verified: end-to-end against a live slow WebFinger server (no throwaway public domain available), and the multi-process behaviour of a Redis-backed limiter.

## Deploy notes

New env vars are all optional with safe defaults — a plain `docker compose up -d` needs nothing. To tune, set the vars in `.env` (they take effect on restart).

Still open (raised for follow-up, not in this PR): age-based pruning / quotas for unreferenced cached remote actors and posts.