### PR TITLE
feat(backend): prune stale unreferenced remote actors and posts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,6 +58,7 @@
 #RL_REMOTE_MAX_PER_ORIGIN=3 # per-host ceiling on concurrent lookups (one host can't monopolize)
 #REMOTE_LOOKUP_TIMEOUT_MS=10000   # deadline for one WebFinger+actor+outbox lookup
 #REMOTE_NEGATIVE_CACHE_TTL_MS=60000   # cache "not found"/failed lookups this long
+#REMOTE_CACHE_RETENTION_DAYS=30   # prune stale, unreferenced remote actors/posts after this long (0 disables)
 
 # ── Content ingestion webhook ──
 # Lets an external system (Sanity, Contentful, a static-site build hook) publish

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -166,6 +166,10 @@ const schema = z.object({
   // How long a failed/not-found resolution is negatively cached so repeated
   // requests for a missing handle don't re-do the same outbound work.
   REMOTE_NEGATIVE_CACHE_TTL_MS: z.coerce.number().int().positive().default(60_000),
+  // How long a cached remote actor (and its posts) survives once nothing
+  // re-fetches it and no local user has an active edge against it. The
+  // remote-cache GC sweeper prunes actors older than this. 0 disables pruning.
+  REMOTE_CACHE_RETENTION_DAYS: z.coerce.number().int().min(0).default(30),
 
   // Delayed garbage collection for uploaded media (see services/uploadGc.ts).
   // A file is deleted only once a daily sweep has seen nothing referencing it
@@ -247,6 +251,7 @@ function load() {
     RL_REMOTE_MAX_PER_ORIGIN: Deno.env.get("RL_REMOTE_MAX_PER_ORIGIN"),
     REMOTE_LOOKUP_TIMEOUT_MS: Deno.env.get("REMOTE_LOOKUP_TIMEOUT_MS"),
     REMOTE_NEGATIVE_CACHE_TTL_MS: Deno.env.get("REMOTE_NEGATIVE_CACHE_TTL_MS"),
+    REMOTE_CACHE_RETENTION_DAYS: Deno.env.get("REMOTE_CACHE_RETENTION_DAYS"),
     UPLOAD_GC_GRACE_DAYS: Deno.env.get("UPLOAD_GC_GRACE_DAYS"),
     UPLOAD_QUOTA_USER_MB: Deno.env.get("UPLOAD_QUOTA_USER_MB"),
     UPLOAD_QUOTA_TOTAL_MB: Deno.env.get("UPLOAD_QUOTA_TOTAL_MB"),

--- a/apps/backend/src/db/repositories/remoteActors.ts
+++ b/apps/backend/src/db/repositories/remoteActors.ts
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { eq, ilike, or, sql } from "drizzle-orm";
+import { and, eq, ilike, lt, or, sql } from "drizzle-orm";
 import { db } from "@/db/client.ts";
-import { type NewRemoteActor, remoteActors } from "@/db/schema.ts";
+import {
+  blocks,
+  follows,
+  mutes,
+  notifications,
+  recommendations,
+  type NewRemoteActor,
+  remoteActors,
+} from "@/db/schema.ts";
 
 // Cached fediverse actors. Services/routes never touch `db` directly.
 
@@ -38,6 +46,13 @@ export async function removeByApId(apId: string): Promise<boolean> {
   return rows.length > 0;
 }
 
+// Removes a cached actor by its primary key. Used by the remote-cache GC, which
+// has ids from `listPrunable` and so can delete straight by id without an extra
+// apId round-trip.
+export async function removeById(id: string): Promise<void> {
+  await db.delete(remoteActors).where(eq(remoteActors.id, id));
+}
+
 // Purges every cached actor on a domain and its subdomains (their posts, follow
 // edges, etc. cascade via FKs). Used when defederating a domain so its content
 // stops surfacing here. Returns the number of actors removed.
@@ -47,6 +62,29 @@ export async function removeByDomain(domain: string): Promise<number> {
     .where(or(eq(remoteActors.host, domain), sql`${remoteActors.host} like ${"%." + domain}`))
     .returning({ id: remoteActors.id });
   return rows.length;
+}
+
+// ── age-based pruning (remote-cache GC) ──────────────────────────────────
+// Remote actors cache forever, but only the ones a local user still has an
+// active edge against (a follow, mute, block, recommendation, or a pending
+// notification) need to stay. Anything else that has not been re-fetched since
+// `cutoff` is prunable: deleting it cascades its posts, tags, and all the join
+// rows that hung off it — see services/remoteCacheGc.ts for the sweep.
+export function listPrunable(cutoff: Date, limit: number): Promise<{ id: string }[]> {
+  return db
+    .select({ id: remoteActors.id })
+    .from(remoteActors)
+    .where(
+      and(
+        lt(remoteActors.fetchedAt, cutoff),
+        sql`not exists (select 1 from ${follows} where ${follows.remoteFolloweeId} = ${remoteActors.id})`,
+        sql`not exists (select 1 from ${mutes} where ${mutes.targetRemoteActorId} = ${remoteActors.id})`,
+        sql`not exists (select 1 from ${blocks} where ${blocks.targetRemoteActorId} = ${remoteActors.id})`,
+        sql`not exists (select 1 from ${recommendations} where ${recommendations.remoteActorId} = ${remoteActors.id})`,
+        sql`not exists (select 1 from ${notifications} where ${notifications.remoteActorId} = ${remoteActors.id})`,
+      ),
+    )
+    .limit(limit);
 }
 
 // Inserts or refreshes a cached actor keyed by its ActivityPub id. Bumps

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -7,6 +7,7 @@ import { reconcileAnubisInBackground } from "@/services/anubisProtection.ts";
 import { seedFederationOrigin, seedFederationRunning } from "@/services/federationState.ts";
 import { getFederationEnabled, getOrigin } from "@/services/instanceSetup.ts";
 import { backfillSlugs } from "@/services/postSlugs.ts";
+import { startRemoteCacheGcSweeper } from "@/services/remoteCacheGc.ts";
 import { startScheduleSweeper } from "@/services/scheduledPosts.ts";
 import { startUploadGcSweeper } from "@/services/uploadGc.ts";
 import { APP_VERSION } from "@/version.ts";
@@ -43,6 +44,12 @@ async function main() {
   // that cached the URL to move on). Same database-backed pattern as the
   // schedule sweeper — see services/uploadGc.ts.
   startUploadGcSweeper();
+
+  // Prune cached remote actors (and their posts) that are stale and no longer
+  // referenced by any local follow/mute/block/recommendation/notification edge,
+  // so a hostile instance can't grow the remote tables without bound by serving
+  // many distinct actors. Safe to run on every node — see services/remoteCacheGc.ts.
+  startRemoteCacheGcSweeper();
 
   // `onListen` overrides Deno's own "Listening on http://0.0.0.0:8000/" banner,
   // which otherwise prints alongside ours and announces the same thing twice —

--- a/apps/backend/src/services/remoteCacheGc.ts
+++ b/apps/backend/src/services/remoteCacheGc.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { config } from "@/config.ts";
+import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
+
+// Age-based pruning of the remote actor/post cache.
+//
+// Browsing /@user@host resolves and caches the remote actor, and fetching their
+// posts persists up to 20 Articles per outbox. Nothing ever evicts those rows:
+// every handle someone once looked at stays in `remote_actors`/`posts` forever.
+// A hostile instance can exploit that — serve many distinct, valid actors and
+// outboxes, and the anonymous browsing path (rate-limited but still allowed)
+// grows those tables without bound. This sweeper is the counterweight: it
+// forgets cached actors that are no longer referenced by any of a local user's
+// durable edges and have not been re-fetched within a retention window.
+//
+// Deleting an actor cascades its posts, tags, and every join row that hung off
+// that actor (follows, mutes, blocks, recommendations, notifications — all
+// FK-cascade), so pruning an actor also reclaims its posts. "Referenced" means
+// the actor is still meaningful to some local user: they follow it, have it
+// muted or blocked, received a recommendation or notification from it — see
+// remoteActorsRepo.listPrunable for the exact predicate.
+//
+// Database-backed and timer-driven like the upload GC and scheduled-post
+// sweepers: it must simply happen every day forever, and the job queue is
+// one-shot. Safe to run on every backend process — deleting an already-deleted
+// row is a no-op.
+
+// Daily, matching the upload GC. The retention window absorbs sweep latency.
+const SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+// Most a single sweep will forget. Like the upload reaper, this cap only matters
+// the first time GC lands on an instance with a large stale cache; the rest
+// follow on later sweeps.
+const PRUNE_BATCH = 200;
+
+let started = false;
+
+/** Start the remote-cache GC sweeper. Call once at boot. */
+export function startRemoteCacheGcSweeper(): void {
+  if (started) return;
+  started = true;
+  void sweep();
+  setInterval(() => void sweep(), SWEEP_INTERVAL_MS);
+  console.log("✔ Remote-cache GC sweeper started.");
+}
+
+/**
+ * One pass: forget cached remote actors that have not been re-fetched within
+ * the retention window and are no longer referenced by any local edge. Returns
+ * the number of actors removed. Failures are logged and dropped — the next
+ * sweep retries wholesale, so there is no retry ladder to maintain.
+ */
+export async function sweep(): Promise<number> {
+  // 0 disables pruning entirely.
+  if (config.REMOTE_CACHE_RETENTION_DAYS <= 0) return 0;
+  const cutoff = new Date(Date.now() - config.REMOTE_CACHE_RETENTION_DAYS * 86_400_000);
+
+  let victims: { id: string }[];
+  try {
+    victims = await remoteActorsRepo.listPrunable(cutoff, PRUNE_BATCH);
+  } catch (err) {
+    console.error("remote-cache-gc: failed to list prunable actors:", err);
+    return 0;
+  }
+
+  let pruned = 0;
+  for (const victim of victims) {
+    try {
+      await remoteActorsRepo.removeById(victim.id);
+    } catch (err) {
+      console.warn("remote-cache-gc: could not forget actor:", err);
+      continue;
+    }
+    pruned++;
+  }
+  if (pruned > 0) console.log(`remote-cache-gc: pruned ${pruned} unreferenced remote actor(s).`);
+  return pruned;
+}

--- a/apps/backend/tests/integration/remote_cache_gc_test.ts
+++ b/apps/backend/tests/integration/remote_cache_gc_test.ts
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Age-based pruning of the remote actor/post cache, against a real database.
+//
+// A hostile instance can grow the remote_actors/posts tables without bound by
+// serving many distinct, valid actors and outboxes to the anonymous browsing
+// path. The remote-cache GC is the counterweight: it forgets cached actors
+// that are stale (past the retention window) and no longer referenced by any
+// of a local user's durable edges. The "referenced" predicate lives in SQL
+// (remoteActorsRepo.listPrunable) and can only be asserted against a database.
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { sql } from "@/db/client.ts";
+import { db } from "@/db/client.ts";
+import { blocks, follows, mutes, notifications, posts, recommendations, remoteActors } from "@/db/schema.ts";
+import { sweep } from "@/services/remoteCacheGc.ts";
+import { closeDb, mkPost, mkUser, resetDb } from "./harness.ts";
+
+const DAY = 24 * 3_600_000;
+
+// The retention window the sweep uses; test rows are aged well past it.
+const CUTOFF_DAYS = 30;
+
+// Inserts a cached remote actor with an explicitly backdated `fetchedAt` so its
+// staleness is under our control, unlike the default now().
+async function mkRemoteActor(handle: string, ageDays: number) {
+  const [row] = await db
+    .insert(remoteActors)
+    .values({
+      apId: `https://${handle.split("@")[1]}/users/${handle.split("@")[0]}`,
+      handle,
+      username: handle.split("@")[0],
+      host: handle.split("@")[1],
+      displayName: handle,
+      fetchedAt: new Date(Date.now() - ageDays * DAY),
+    })
+    .returning();
+  return row;
+}
+
+// A remote post owned by an actor (persisted the way fetchOutboxPosts writes).
+async function mkRemotePost(actorId: string, apId: string) {
+  return await db.insert(posts).values({
+    remoteActorId: actorId,
+    apId,
+    title: apId,
+    contentHtml: `<p>${apId}</p>`,
+    apType: "Article",
+    remote: true,
+  });
+}
+
+async function resetRemoteTables() {
+  // resetDb truncates users/posts/follows/... but not the remote-actor half of
+  // the graph, so clear it explicitly for this suite.
+  await sql`truncate remote_actors, blocks, mutes, notifications, recommendations restart identity cascade`;
+}
+
+async function countActors(handle: string) {
+  const rows = await db.select({ id: remoteActors.id }).from(remoteActors).where(eq(remoteActors.handle, handle));
+  return rows.length;
+}
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe("remote-cache GC", () => {
+  beforeAll(async () => {
+    await resetDb();
+    await resetRemoteTables();
+  });
+
+  test("prunes a stale actor that nothing references", async () => {
+    await mkRemoteActor("orphan@stale.example", CUTOFF_DAYS + 10);
+    expect(await sweep()).toBeGreaterThanOrEqual(1);
+    expect(await countActors("orphan@stale.example")).toBe(0);
+  });
+
+  test("keeps a recently-fetched actor even with no references", async () => {
+    await mkRemoteActor("fresh@recent.example", 1);
+    await sweep();
+    expect(await countActors("fresh@recent.example")).toBe(1);
+  });
+
+  test("pruning an actor cascades its cached posts", async () => {
+    const actor = await mkRemoteActor("posts@stale.example", CUTOFF_DAYS + 5);
+    await mkRemotePost(actor.id, "https://stale.example/posts/1");
+    await sweep();
+    const remaining = await db
+      .select({ id: posts.id })
+      .from(posts)
+      .where(eq(posts.apId, "https://stale.example/posts/1"));
+    expect(remaining.length).toBe(0);
+  });
+
+  test("keeps a stale actor that a local user follows", async () => {
+    const user = await mkUser("gc-follower");
+    const actor = await mkRemoteActor("followed@stale.example", CUTOFF_DAYS + 5);
+    await db.insert(follows).values({ followerId: user.id, remoteFolloweeId: actor.id, approved: true });
+    await sweep();
+    expect(await countActors("followed@stale.example")).toBe(1);
+  });
+
+  test("keeps a stale actor that a local user has muted", async () => {
+    const user = await mkUser("gc-muter");
+    const actor = await mkRemoteActor("muted@stale.example", CUTOFF_DAYS + 5);
+    await db.insert(mutes).values({ userId: user.id, targetRemoteActorId: actor.id });
+    await sweep();
+    expect(await countActors("muted@stale.example")).toBe(1);
+  });
+
+  test("keeps a stale actor that a local user has blocked", async () => {
+    const user = await mkUser("gc-blocker");
+    const actor = await mkRemoteActor("blocked@stale.example", CUTOFF_DAYS + 5);
+    await db.insert(blocks).values({ userId: user.id, targetRemoteActorId: actor.id });
+    await sweep();
+    expect(await countActors("blocked@stale.example")).toBe(1);
+  });
+
+  test("keeps a stale actor referenced by a recommendation", async () => {
+    const user = await mkUser("gc-rec");
+    const actor = await mkRemoteActor("recommended@stale.example", CUTOFF_DAYS + 5);
+    const post = await mkPost(user.id, "rec-target");
+    await db.insert(recommendations).values({ postId: post.id, remoteActorId: actor.id });
+    await sweep();
+    expect(await countActors("recommended@stale.example")).toBe(1);
+  });
+
+  test("keeps a stale actor referenced by a notification", async () => {
+    const user = await mkUser("gc-notif");
+    const actor = await mkRemoteActor("notifying@stale.example", CUTOFF_DAYS + 5);
+    await db.insert(notifications).values({
+      recipientId: user.id,
+      type: "follow",
+      remoteActorId: actor.id,
+    });
+    await sweep();
+    expect(await countActors("notifying@stale.example")).toBe(1);
+  });
+});


### PR DESCRIPTION
## What was missing

#128 flagged that a hostile instance could grow the `remote_actors` and `posts`
tables without bound: serve many distinct, valid actors and outboxes, and the
anonymous browsing path (now rate-limited, but still allowed) caches each one
forever. The earlier PR added the rate limit, single-flight, negative cache,
concurrency ceilings, and deadline — but nothing ever *evicted* a row once it
was cached. This closes that last gap.

## What changed

- `services/remoteCacheGc.ts` — a daily, database-backed sweep (same timer
  pattern as the upload GC and scheduled-post sweepers).
- `remoteActorsRepo.listPrunable(cutoff, limit)` — actors older than the cutoff
  and referenced by no follow / mute / block / recommendation / notification
  edge. `removeById(id)` deletes them; posts, tags, and join rows cascade.
- `REMOTE_CACHE_RETENTION_DAYS` (default 30, `0` disables) in config + `.env`.
- `main.ts` starts the sweeper at boot.

## Why this shape

"Referenced" means a local user has expressed durable intent against the actor
(follow/mute/block) or has an outstanding recommendation/notification pointing
at it. Everything else — an actor someone browsed once and never engaged with —
is safe to forget once it's stale, and its posts go with it (a post can't exist
without its actor; the FK cascades).

## What was verified

- `deno task check` (typecheck, oxlint, oxfmt, 217 unit tests) clean.
- Integration suite (62 tests) green against a throwaway Postgres 16, including
  8 new cases: prune stale-unreferenced, keep fresh, cascade posts, and keep
  actors referenced by follow / mute / block / recommendation / notification.

## Deploy notes

Optional, safe-default config (`REMOTE_CACHE_RETENTION_DAYS=30`). A plain
`docker compose up -d` enables it; set to `0` to disable. Takes effect on the
next restart and runs its first sweep at boot.