### PR TITLE
feat(backend): tighter per-caller budget for cache-miss remote lookups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,7 @@
 #RL_WEBHOOK_MAX=30          # content-webhook POSTs / min per source IP
 #INBOX_MAX_BODY_BYTES=1000000   # reject inbox POSTs larger than this
 #RL_REMOTE_MAX=30           # anonymous GET /api/remote/* discoveries / min per IP
+#RL_REMOTE_MISS_MAX=20      # cache-miss (outbound) lookups / min per caller
 #RL_REMOTE_MAX_OUTBOUND=10  # global ceiling on concurrent outbound federation lookups
 #RL_REMOTE_MAX_PER_ORIGIN=3 # per-host ceiling on concurrent lookups (one host can't monopolize)
 #REMOTE_LOOKUP_TIMEOUT_MS=10000   # deadline for one WebFinger+actor+outbox lookup

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -155,6 +155,12 @@ const schema = z.object({
   // outbound federation requests and DB writes, so they get their own per-IP
   // budget instead of riding the general read-through limiter.
   RL_REMOTE_MAX: z.coerce.number().int().positive().default(30),
+  // Stricter per-IP budget for the operations that actually miss the local
+  // cache and perform outbound work. A cached read is cheap and counts only
+  // against RL_REMOTE_MAX; an outbound lookup (WebFinger + actor + outbox)
+  // also consumes this tighter cap, so a caller can't burn the full discovery
+  // budget on expensive remote resolutions.
+  RL_REMOTE_MISS_MAX: z.coerce.number().int().positive().default(20),
   // Outbound concurrency ceilings for remote lookups: the global ceiling caps
   // total simultaneous federation requests, the per-origin ceiling caps how many
   // a single host can occupy (otherwise one slow host monopolizes the budget).
@@ -247,6 +253,7 @@ function load() {
     RL_WEBHOOK_MAX: Deno.env.get("RL_WEBHOOK_MAX"),
     INBOX_MAX_BODY_BYTES: Deno.env.get("INBOX_MAX_BODY_BYTES"),
     RL_REMOTE_MAX: Deno.env.get("RL_REMOTE_MAX"),
+    RL_REMOTE_MISS_MAX: Deno.env.get("RL_REMOTE_MISS_MAX"),
     RL_REMOTE_MAX_OUTBOUND: Deno.env.get("RL_REMOTE_MAX_OUTBOUND"),
     RL_REMOTE_MAX_PER_ORIGIN: Deno.env.get("RL_REMOTE_MAX_PER_ORIGIN"),
     REMOTE_LOOKUP_TIMEOUT_MS: Deno.env.get("REMOTE_LOOKUP_TIMEOUT_MS"),

--- a/apps/backend/src/lib/rateLimit.ts
+++ b/apps/backend/src/lib/rateLimit.ts
@@ -14,78 +14,8 @@ import type { Context } from "hono";
 import { getConnInfo } from "hono/deno";
 import { createMiddleware } from "hono/factory";
 import { config } from "@/config.ts";
-import { getRedis } from "@/lib/redis.ts";
+import { hit } from "@/lib/rateLimitCore.ts";
 import type { AppEnv } from "@/routes/types.ts";
-
-type HitResult = { allowed: boolean; remaining: number; resetAt: number };
-
-type Bucket = { count: number; resetAt: number };
-
-const buckets = new Map<string, Bucket>();
-
-// Opportunistic sweep of expired buckets so the Map can't grow unbounded under
-// a churn of unique keys. Runs at most once a minute, on request, so there is no
-// background timer to leak in tests or short-lived processes.
-let lastSweep = 0;
-function sweep(now: number) {
-  if (now - lastSweep < 60_000) return;
-  lastSweep = now;
-  for (const [k, b] of buckets) {
-    if (b.resetAt <= now) buckets.delete(k);
-  }
-}
-
-function hitInProcess(key: string, windowMs: number, max: number): HitResult {
-  const now = Date.now();
-  sweep(now);
-  let b = buckets.get(key);
-  if (!b || b.resetAt <= now) {
-    b = { count: 0, resetAt: now + windowMs };
-    buckets.set(key, b);
-  }
-  b.count++;
-  return {
-    allowed: b.count <= max,
-    remaining: Math.max(0, max - b.count),
-    resetAt: b.resetAt,
-  };
-}
-
-// Atomic fixed-window in Redis: INCR the counter, set the TTL on the first hit
-// of a window, then read the remaining TTL for resetAt. Runs as one server-side
-// EVAL so there's no check-then-set race between processes.
-const HIT_LUA = `
-local c = redis.call('INCR', KEYS[1])
-if c == 1 then
-  redis.call('PEXPIRE', KEYS[1], ARGV[1])
-end
-local ttl = redis.call('PTTL', KEYS[1])
-return {c, ttl}
-`;
-
-async function hitRedis(key: string, windowMs: number, max: number): Promise<HitResult> {
-  const redis = getRedis();
-  if (!redis) return hitInProcess(key, windowMs, max);
-  try {
-    const [count, ttl] = (await redis.eval(HIT_LUA, 1, `rl:${key}`, windowMs)) as [number, number];
-    // PTTL returns -1 (no expiry) or -2 (no key) in edge races; fall back to a
-    // full window so resetAt stays sane.
-    const resetAt = Date.now() + (ttl >= 0 ? ttl : windowMs);
-    return { allowed: count <= max, remaining: Math.max(0, max - count), resetAt };
-  } catch (err) {
-    // Never let a Redis hiccup take down request handling — fail over to the
-    // in-process limiter (still throttles this process) and log once.
-    console.error("rateLimit: Redis error, falling back to in-process:", err);
-    return hitInProcess(key, windowMs, max);
-  }
-}
-
-// Records one hit against `key` and reports whether it is allowed, plus the
-// metadata needed for RateLimit / Retry-After headers. Uses Redis when
-// configured, otherwise the in-process Map.
-function hit(key: string, windowMs: number, max: number): Promise<HitResult> {
-  return config.REDIS_URL ? hitRedis(key, windowMs, max) : Promise.resolve(hitInProcess(key, windowMs, max));
-}
 
 // Resolves the caller's IP from `x-forwarded-for`, trusting only the value added
 // by the immediate upstream proxy.

--- a/apps/backend/src/lib/rateLimitCore.ts
+++ b/apps/backend/src/lib/rateLimitCore.ts
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// The pure counter/store half of rate limiting, split from rateLimit.ts so that
+// non-HTTP layers (services metering outbound work) can record hits without
+// importing Hono's Deno adapter. A fixed-window counter keyed per caller; the
+// store is an in-process Map by default, or Redis when `REDIS_URL` is set —
+// hidden behind `hit()` — so limits are shared across processes and survive
+// restarts. The in-process path is unchanged.
+
+import { config } from "@/config.ts";
+import { getRedis } from "@/lib/redis.ts";
+
+export type HitResult = { allowed: boolean; remaining: number; resetAt: number };
+
+type Bucket = { count: number; resetAt: number };
+
+const buckets = new Map<string, Bucket>();
+
+// Opportunistic sweep of expired buckets so the Map can't grow unbounded under
+// a churn of unique keys. Runs at most once a minute, on request, so there is no
+// background timer to leak in tests or short-lived processes.
+let lastSweep = 0;
+function sweep(now: number) {
+  if (now - lastSweep < 60_000) return;
+  lastSweep = now;
+  for (const [k, b] of buckets) {
+    if (b.resetAt <= now) buckets.delete(k);
+  }
+}
+
+function hitInProcess(key: string, windowMs: number, max: number): HitResult {
+  const now = Date.now();
+  sweep(now);
+  let b = buckets.get(key);
+  if (!b || b.resetAt <= now) {
+    b = { count: 0, resetAt: now + windowMs };
+    buckets.set(key, b);
+  }
+  b.count++;
+  return {
+    allowed: b.count <= max,
+    remaining: Math.max(0, max - b.count),
+    resetAt: b.resetAt,
+  };
+}
+
+// Atomic fixed-window in Redis: INCR the counter, set the TTL on the first hit
+// of a window, then read the remaining TTL for resetAt. Runs as one server-side
+// EVAL so there's no check-then-set race between processes.
+const HIT_LUA = `
+local c = redis.call('INCR', KEYS[1])
+if c == 1 then
+  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+end
+local ttl = redis.call('PTTL', KEYS[1])
+return {c, ttl}
+`;
+
+async function hitRedis(key: string, windowMs: number, max: number): Promise<HitResult> {
+  const redis = getRedis();
+  if (!redis) return hitInProcess(key, windowMs, max);
+  try {
+    const [count, ttl] = (await redis.eval(HIT_LUA, 1, `rl:${key}`, windowMs)) as [number, number];
+    // PTTL returns -1 (no expiry) or -2 (no key) in edge races; fall back to a
+    // full window so resetAt stays sane.
+    const resetAt = Date.now() + (ttl >= 0 ? ttl : windowMs);
+    return { allowed: count <= max, remaining: Math.max(0, max - count), resetAt };
+  } catch (err) {
+    // Never let a Redis hiccup take down request handling — fail over to the
+    // in-process limiter (still throttles this process) and log once.
+    console.error("rateLimit: Redis error, falling back to in-process:", err);
+    return hitInProcess(key, windowMs, max);
+  }
+}
+
+// Records one hit against `key` and reports whether it is allowed, plus the
+// metadata needed for RateLimit / Retry-After headers. Uses Redis when
+// configured, otherwise the in-process Map.
+export function hit(key: string, windowMs: number, max: number): Promise<HitResult> {
+  return config.REDIS_URL ? hitRedis(key, windowMs, max) : Promise.resolve(hitInProcess(key, windowMs, max));
+}
+
+// Key-based rate-limit check for layers below HTTP that already hold a caller
+// key (e.g. a service metering outbound work against a per-IP budget passed in
+// by the route). Same counter/window semantics as `checkRateLimit`, but the
+// caller supplies the key directly instead of a Hono Context.
+export async function checkRateLimitKey(
+  key: string,
+  name: string,
+  windowMs: number,
+  max: number,
+): Promise<{ allowed: boolean; retryAfter: number }> {
+  if (!config.RATE_LIMIT_ENABLED) return { allowed: true, retryAfter: 0 };
+  const { allowed, resetAt } = await hit(`${name}:${key}`, windowMs, max);
+  return { allowed, retryAfter: Math.max(0, Math.ceil((resetAt - Date.now()) / 1000)) };
+}

--- a/apps/backend/src/routes/remote.ts
+++ b/apps/backend/src/routes/remote.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { Hono } from "hono";
+import { Hono, type Context } from "hono";
 import { config } from "@/config.ts";
 import { notFound } from "@/lib/http.ts";
 import { decodeCursor } from "@/lib/pagination.ts";
@@ -38,13 +38,22 @@ remoteRoutes.use("/users/:handle", (c, next) =>
   c.req.method === "GET" && !c.get("user") ? discoveryLimiter(c, next) : next(),
 );
 
-// Remote profile by `user@host` handle (includes follow/mute/block state).
+// A stable per-caller key for the stricter cache-miss budget: signed-in users
+// keyed by id, anonymous callers by IP — the same convention as the general
+// write limiter, so a signed-in user and an anonymous browser never share a
+// bucket.
+function callerKey(c: Context): string {
+  const user = c.get("user");
+  return user ? `u:${user.id}` : `ip:${clientIp(c)}`;
+}
+
 remoteRoutes.get("/users/:handle", async (c) => {
   const viewer = c.get("user");
   const handle = c.req.param("handle");
   const { actor, isFollowing, isMuted, isBlocked, tags } = await remoteProfilesService.getProfileView(
     handle,
     viewer?.id ?? null,
+    callerKey(c),
   );
   return c.json(remoteProfile(actor, isFollowing, { isMuted, isBlocked }, tags));
 });
@@ -93,7 +102,7 @@ remoteRoutes.get("/users/:handle/posts", async (c) => {
   const viewer = c.get("user");
   const handle = c.req.param("handle");
   const cursor = decodeCursor(c.req.query("cursor"));
-  const { items, nextCursor } = await remoteProfilesService.getPosts(handle, cursor, viewer?.id ?? null);
+  const { items, nextCursor } = await remoteProfilesService.getPosts(handle, cursor, viewer?.id ?? null, callerKey(c));
   return c.json({ items: await enrichPosts(items, viewer?.id ?? null), nextCursor });
 });
 
@@ -103,7 +112,7 @@ remoteRoutes.get("/users/:handle/recommendations", async (c) => {
   const viewer = c.get("user");
   const handle = c.req.param("handle");
   const cursor = decodeCursor(c.req.query("cursor"));
-  const actor = await remoteProfilesService.getProfile(handle);
+  const actor = await remoteProfilesService.getProfile(handle, callerKey(c));
   const { items, nextCursor } = await recommendationsService.listByRemoteActor(actor.id, viewer?.id ?? null, cursor);
   return c.json({ items: await enrichPosts(items, viewer?.id ?? null), nextCursor });
 });

--- a/apps/backend/src/services/remoteProfiles.ts
+++ b/apps/backend/src/services/remoteProfiles.ts
@@ -1,14 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { config } from "@/config.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as relationsRepo from "@/db/repositories/relations.ts";
-// SPDX-License-Identifier: AGPL-3.0-or-later
 import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
 import type { RemoteActor } from "@/db/schema.ts";
 import { negativeCached, setNegativeCached, singleFlight } from "@/federation/outboundGuard.ts";
 import { fetchOutboxPosts, resolveActor } from "@/federation/remote.ts";
-import { forbidden, notFound } from "@/lib/http.ts";
+import { forbidden, notFound, tooManyRequests } from "@/lib/http.ts";
 import { type Cursor, DEFAULT_PAGE_SIZE, encodeCursor } from "@/lib/pagination.ts";
+import { checkRateLimitKey } from "@/lib/rateLimitCore.ts";
 import { queue } from "@/queue/queue.ts";
 
 // Read-side federation: resolve `user@host`, cache the actor + their outbox,
@@ -21,13 +23,25 @@ function isFresh(actor: RemoteActor): boolean {
   return Date.now() - actor.fetchedAt.getTime() < STALE_AFTER_MS;
 }
 
+// Charges the stricter cache-miss budget against `callerKey` before any
+// outbound work. A fresh cache hit never reaches this; an outbound WebFinger +
+// actor + outbox fetch does, so repeated anonymous lookups burn through a
+// tighter cap than plain (cached) reads. `callerKey` is undefined for internal
+// callers that are already metered elsewhere (e.g. the signed-in follow path
+// rides the general write limiter).
+async function chargeMiss(callerKey: string | undefined): Promise<void> {
+  if (!callerKey) return;
+  const { allowed } = await checkRateLimitKey(callerKey, "remote-miss", 60_000, config.RL_REMOTE_MISS_MAX);
+  if (!allowed) throw tooManyRequests("Too many remote lookups; try again shortly.");
+}
+
 // Returns the cached actor, resolving (or refreshing) it as needed.
 //
 // Resolution is coalesced per normalized handle (single-flight) so concurrent
 // requests for the same uncached handle share one lookup, and failures are
 // negatively cached for a short window so a missing/slow handle isn't re-resolved
 // on every request.
-export async function getProfile(handle: string): Promise<RemoteActor> {
+export async function getProfile(handle: string, callerKey?: string): Promise<RemoteActor> {
   const cached = await remoteActorsRepo.findByHandle(handle);
   if (cached && isFresh(cached)) return cached;
 
@@ -38,6 +52,7 @@ export async function getProfile(handle: string): Promise<RemoteActor> {
     throw notFound("Remote user not found.");
   }
 
+  await chargeMiss(callerKey);
   const resolved = await singleFlight(handle, () => resolveActor(handle));
   if (resolved) return resolved;
   if (cached) return cached; // serve stale data rather than fail
@@ -46,8 +61,8 @@ export async function getProfile(handle: string): Promise<RemoteActor> {
 }
 
 // Profile plus whether `viewerId` follows this remote actor.
-export async function getProfileView(handle: string, viewerId: string | null) {
-  const actor = await getProfile(handle);
+export async function getProfileView(handle: string, viewerId: string | null, callerKey?: string) {
+  const actor = await getProfile(handle, callerKey);
   // A blocked remote actor is invisible to the viewer, same as a blocked local
   // user — the profile reads as not-found. Unblock from Connections settings.
   if (viewerId && (await relationsRepo.hasRemote("block", viewerId, actor.id))) {
@@ -80,17 +95,26 @@ export async function unfollow(viewerId: string, handle: string): Promise<void> 
   queue.add("send_unfollow", { followerId: viewerId, targetActor: actor.apId });
 }
 
-export async function getPosts(handle: string, cursor: Cursor | null, viewerId: string | null = null) {
-  const actor = await getProfile(handle);
+export async function getPosts(
+  handle: string,
+  cursor: Cursor | null,
+  viewerId: string | null = null,
+  callerKey?: string,
+) {
+  const actor = await getProfile(handle, callerKey);
   // Only re-crawl the outbox on the first page, and only when stale, so
   // pagination stays cheap and stable.
   if (!cursor && !isFresh(actor)) {
+    await chargeMiss(callerKey);
     await fetchOutboxPosts(handle, actor.id);
   } else if (!cursor) {
     // Fresh-but-empty (e.g. first ever view in the same TTL window): ensure we
     // have at least crawled once.
     const existing = await postsRepo.listByRemoteActor(actor.id, null, null, 1);
-    if (existing.length === 0) await fetchOutboxPosts(handle, actor.id);
+    if (existing.length === 0) {
+      await chargeMiss(callerKey);
+      await fetchOutboxPosts(handle, actor.id);
+    }
   }
 
   const rows = await postsRepo.listByRemoteActor(actor.id, viewerId, cursor, DEFAULT_PAGE_SIZE);

--- a/apps/backend/src/services/remoteProfiles_test.ts
+++ b/apps/backend/src/services/remoteProfiles_test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Unit tests for the stricter cache-miss budget behind #128: the general GET
+// pass-through lets remote discovery through, but a request that actually
+// misses the local cache performs outbound federation work, so it must count
+// against a tighter per-caller cap than a plain cached read. A fresh cache hit
+// never reaches the meter; a miss does, and once exhausted it is refused 429.
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config.ts", () => ({
+  config: { RATE_LIMIT_ENABLED: true, REDIS_URL: undefined, RL_REMOTE_MISS_MAX: 2 },
+}));
+
+vi.mock("@/db/repositories/remoteActors.ts", () => ({
+  findByHandle: vi.fn<() => Promise<unknown>>(),
+}));
+
+vi.mock("@/db/repositories/follows.ts", () => ({ isFollowingRemote: vi.fn<() => Promise<unknown>>() }));
+vi.mock("@/db/repositories/relations.ts", () => ({ hasRemote: vi.fn<() => Promise<unknown>>() }));
+vi.mock("@/db/repositories/tags.ts", () => ({ tagsForRemoteActor: vi.fn<() => Promise<unknown>>() }));
+vi.mock("@/db/repositories/posts.ts", () => ({ listByRemoteActor: vi.fn<() => Promise<unknown>>() }));
+
+vi.mock("@/federation/outboundGuard.ts", () => ({
+  negativeCached: () => false,
+  setNegativeCached: () => {},
+  singleFlight: (_h: string, fn: () => unknown) => fn(),
+}));
+
+vi.mock("@/federation/remote.ts", () => ({
+  resolveActor: () => Promise.resolve(null),
+  fetchOutboxPosts: () => Promise.resolve(),
+}));
+
+vi.mock("@/queue/queue.ts", () => ({ queue: { add: vi.fn() } }));
+
+import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
+import { getProfile } from "@/services/remoteProfiles.ts";
+
+const freshActor = (handle: string) => ({
+  id: "actor-id",
+  apId: `https://example.com/users/${handle}`,
+  handle,
+  username: handle,
+  host: "example.com",
+  displayName: handle,
+  fetchedAt: new Date(),
+});
+
+describe("cache-miss budget (#128)", () => {
+  it("serves repeated fresh cache hits without ever hitting the miss budget", async () => {
+    // A fresh cached actor short-circuits before the meter; even far more
+    // hits than the cap must all succeed.
+    vi.mocked(remoteActorsRepo.findByHandle).mockResolvedValue(freshActor("alice@example.com") as never);
+    const key = `no-miss-${Date.now()}`;
+    for (let i = 0; i < 10; i++) {
+      const actor = await getProfile("alice@example.com", key);
+      expect(actor.handle).toBe("alice@example.com");
+    }
+  });
+
+  it("rejects excessive cache-miss lookups with 429 once the budget is spent", async () => {
+    // Always a miss: no cached actor, not negatively cached, resolution fails.
+    vi.mocked(remoteActorsRepo.findByHandle).mockResolvedValue(null as never);
+    const key = `miss-${Date.now()}`;
+
+    // The first RL_REMOTE_MISS_MAX (=2) misses resolve (and fail as not-found).
+    for (let i = 0; i < 2; i++) {
+      await expect(getProfile(`missing${i}@example.com`, key)).rejects.toMatchObject({ status: 404 });
+    }
+    // The next miss is refused by the stricter budget before any outbound work.
+    await expect(getProfile("missing3@example.com", key)).rejects.toMatchObject({ status: 429 });
+  });
+});


### PR DESCRIPTION
## What was missing

#128's fix asked for two complementary limits: a per-IP limiter on the
discovery routes **and** "a stricter budget for operations that miss the
local cache." #130 shipped the former; the closer audit flagged the latter as
the remaining gap — a flat per-IP limiter counts a cheap cached read the same
as an expensive outbound WebFinger+actor+outbox resolution, so a caller could
burn its whole budget on cache-miss work.

## What changed

- `RL_REMOTE_MISS_MAX` (default 20/min per caller), charged *only* when a
  lookup actually leaves the cache: `getProfile` on an uncached handle, and
  `getPosts` re-crawling a stale outbox. A fresh cache hit never reaches the
  meter; on exhaustion the caller gets `429` before any outbound work.
- The caller key (`u:{id}` signed-in / `ip:{ip}` anonymous) is threaded from
  the routes into `getProfile`/`getProfileView`/`getPosts`.
- Extracted the pure fixed-window counter into `lib/rateLimitCore.ts` (no Hono
  dependency) so the service can meter by key without importing `hono/deno`,
  which would break the Node-based unit test runner.

## What was verified

- `deno task check` clean; 219 unit tests (2 new: fresh cache hits never hit
  the meter, and the 3rd cache miss in a window returns 429).
- Integration suite (62 tests) green against throwaway Postgres 16.

## Deploy notes

Optional env (`RL_REMOTE_MISS_MAX`). A plain `docker compose up -d` applies the
default; set it to configure the tighter cap.