### PR TITLE
fix(federation): refuse private-network hosts in remote actor discovery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,10 @@
 # "true" enables ActivityPub (WebFinger, actor, inbox/outbox). When false, the
 # instance is a standalone blog. Needs a real domain + HTTPS to be useful.
 #FEDERATION_ENABLED=false
+# LAN-dev escape hatch: "true" lets remote discovery (GET /api/remote/*) talk
+# to private hosts (loopback, RFC1918, .local, …) for testing against a local
+# instance. NEVER enable on an internet-reachable host — it reopens SSRF.
+#ALLOW_PRIVATE_FEDERATION=false
 
 # ── Secrets (normally auto-generated — leave unset) ──
 # By default the stack generates a session secret and the bundled Postgres

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -119,6 +119,15 @@ const schema = z.object({
     .string()
     .transform((v) => v.toLowerCase() !== "false")
     .default(true),
+  // LAN / integration-test escape hatch for federation egress. When false
+  // (the default) remote handles that resolve to loopback, RFC1918, link-local,
+  // or other private hosts are refused before any outbound fetch. Set to "true"
+  // only for local development against instances on a private network — never
+  // on an internet-reachable host.
+  ALLOW_PRIVATE_FEDERATION: z
+    .string()
+    .transform((v) => v.toLowerCase() === "true")
+    .default(false),
   SESSION_SECRET: z.string().min(8),
   PORT: z.coerce.number().int().positive().default(8000),
   UPLOADS_DIR: z.string().min(1).default("./uploads"),
@@ -240,6 +249,7 @@ function load() {
     DATABASE_URL: resolveDatabaseUrl(),
     APP_DOMAIN: Deno.env.get("APP_DOMAIN"),
     FEDERATION_ENABLED: Deno.env.get("FEDERATION_ENABLED"),
+    ALLOW_PRIVATE_FEDERATION: Deno.env.get("ALLOW_PRIVATE_FEDERATION"),
     SESSION_SECRET: resolveSessionSecret(),
     PORT: Deno.env.get("PORT"),
     UPLOADS_DIR: Deno.env.get("UPLOADS_DIR"),

--- a/apps/backend/src/federation/outboundGuard.ts
+++ b/apps/backend/src/federation/outboundGuard.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { config } from "@/config.ts";
+import { isBlockedHostSyntax } from "@/federation/ssrf.ts";
 
 // Outbound federation guards shared by the read-side resolution paths (remote
 // profile / posts / recommendations browsing). Those paths make requests that
@@ -80,7 +81,15 @@ function sweepOrigins(now: number) {
 
 // Runs an outbound action under the global and per-origin semaphores, returning
 // its result or null on abort/timeout. `host` keys the per-origin budget.
+//
+// Second-layer SSRF gate: syntactically-private hosts (loopback, RFC1918,
+// localhost, …) are refused before a permit is even acquired, so a caller that
+// bypasses the handle-level check in federation/remote.ts still cannot burn
+// outbound budget toward them. DNS-level checks live in federation/ssrf.ts (and
+// in Fedify's own fetch layer); this stays syntactic so unit tests with fake
+// hosts never touch the network.
 export async function runOutbound<T>(host: string, action: (signal: AbortSignal) => Promise<T>): Promise<T> {
+  if (isBlockedHostSyntax(host)) throw new Error(`Refusing outbound federation to blocked host: ${host}`);
   sweepOrigins(Date.now());
   const deadline = AbortSignal.timeout(config.REMOTE_LOOKUP_TIMEOUT_MS);
   const releaseGlobal = await GLOBAL_SEMAPHORE.acquire();

--- a/apps/backend/src/federation/remote.ts
+++ b/apps/backend/src/federation/remote.ts
@@ -10,6 +10,7 @@ import type { RemoteActor } from "@/db/schema.ts";
 import { articleLanguage, isPubliclyAddressed } from "@/federation/article.ts";
 import { getFederation } from "@/federation/mod.ts";
 import { runOutbound } from "@/federation/outboundGuard.ts";
+import { extractHandleHost, isBlockedHandle, isHostAllowed } from "@/federation/ssrf.ts";
 import { sameOrigin } from "@/lib/domain.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
 import { normalizeTags } from "@/lib/tags.ts";
@@ -32,8 +33,24 @@ function fediHandle(handle: string): string {
 }
 
 // The host portion of a `user@host` (or `@user@host`) handle, for blocklist checks.
+// Port-stripped and normalized via the SSRF guard so `user@127.0.0.1:8000`
+// keys the per-origin budget by `127.0.0.1`, not the raw `127.0.0.1:8000`.
 function handleHost(handle: string): string {
-  return handle.replace(/^@/, "").split("@").pop() ?? "";
+  return extractHandleHost(handle) ?? handle.replace(/^@/, "").split("@").pop() ?? "";
+}
+
+// SSRF gate: syntactically-blocked handles (private IPs, localhost,
+// single-label docker names, malformed shapes) are refused without any I/O.
+// Handles that look public still need the DNS check below, which fails closed.
+function handleBlockedSync(handle: string): boolean {
+  return isBlockedHandle(handle);
+}
+
+async function handleAllowed(handle: string): Promise<boolean> {
+  if (handleBlockedSync(handle)) return false;
+  const host = extractHandleHost(handle);
+  if (host === null) return false;
+  return await isHostAllowed(host);
 }
 
 // A signed document loader (keyed to the oldest local user) so instances that
@@ -49,8 +66,15 @@ async function signedLoader(): Promise<DocumentLoader | undefined> {
 // Resolves `user@host` via WebFinger, then caches the actor document. Runs under
 // the global + per-origin outbound semaphores and a total deadline so a slow or
 // hostile remote cannot occupy a request handler indefinitely. Returns null on
-// any failure (blocked domain, timeout, non-actor) — the caller negative-caches.
+// any failure (blocked domain, SSRF-denied host, timeout, non-actor) — the
+// caller negative-caches.
 export async function resolveActor(handle: string): Promise<RemoteActor | null> {
+  // SSRF guard first (no I/O on the fast path): never emit WebFinger/actor
+  // fetches toward loopback, RFC1918, link-local, or other private hosts from
+  // an unauthenticated handle. Fedify's own validatePublicUrl enforces the same
+  // at the fetch layer; this makes the property explicit and testable here.
+  if (handleBlockedSync(handle)) return null;
+  if (!(await handleAllowed(handle))) return null;
   // Never reach out to a defederated domain.
   if (await blockedDomainsRepo.isBlocked(handleHost(handle))) return null;
   return await runOutbound(handleHost(handle), async (signal) => {
@@ -108,6 +132,8 @@ export async function cacheActor(actor: Actor, handle?: string): Promise<RemoteA
 // profile still renders from whatever is cached.
 export async function fetchOutboxPosts(handle: string, remoteActorId: string): Promise<void> {
   try {
+    if (handleBlockedSync(handle)) return;
+    if (!(await handleAllowed(handle))) return;
     if (await blockedDomainsRepo.isBlocked(handleHost(handle))) return;
     await runOutbound(handleHost(handle), async (signal) => {
       if (signal.aborted) return;

--- a/apps/backend/src/federation/ssrf.ts
+++ b/apps/backend/src/federation/ssrf.ts
@@ -1,0 +1,325 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { lookup } from "node:dns/promises";
+import { isIP } from "node:net";
+import { config } from "@/config.ts";
+
+// Explicit SSRF guard for read-side federation (GET /api/remote/*).
+//
+// Fedify already refuses private-network URLs by default (validatePublicUrl on
+// WebFinger + documentLoader, including redirect re-validation), but that
+// protection lives in node_modules — invisible to this repo's tests and one
+// `allowPrivateAddress: true` away from disappearing. This module makes the
+// property explicit, fail-closed, and pinned by unit tests:
+//
+//   1. Syntactic layer (no I/O): reject localhost, *.localhost, private/reserved
+//      IP literals (including decimal/octal/hex spellings like 2130706433 or
+//      0x7f.0.0.1), 0.0.0.0, IPv6 loopback/link-local/unique-local/multicast,
+//      single-label hosts (docker service names like `postgres`), and private
+//      LAN suffixes (.local, .internal, …).
+//   2. DNS layer: resolve the host and reject if ANY A/AAAA is private, or if
+//      resolution fails at all (fail closed).
+//
+// When ALLOW_PRIVATE_FEDERATION=true (LAN dev only) every check is skipped.
+
+function allowPrivate(): boolean {
+  try {
+    return (config as { ALLOW_PRIVATE_FEDERATION?: boolean }).ALLOW_PRIVATE_FEDERATION === true;
+  } catch {
+    return false;
+  }
+}
+
+// Splits `host` / `host:port` / `[v6]` / `[v6]:port`. Returns null on malformed
+// input. A bare IPv6 literal without brackets (`::1`) has more than one colon
+// and is treated as host-without-port (bracketed form is required for a port).
+export function splitHostPort(input: string): { host: string; port: string | null } | null {
+  const s = input.trim();
+  if (!s) return null;
+  if (s.startsWith("[")) {
+    const close = s.indexOf("]");
+    if (close < 0) return null;
+    const host = s.slice(1, close);
+    const rest = s.slice(close + 1);
+    if (!rest) return { host, port: null };
+    if (!rest.startsWith(":")) return null;
+    const port = rest.slice(1);
+    if (!/^\d{1,5}$/.test(port)) return null;
+    const n = Number(port);
+    if (n < 1 || n > 65535) return null;
+    return { host, port };
+  }
+  const colons = (s.match(/:/g) ?? []).length;
+  if (colons > 1) return { host: s, port: null };
+  if (colons === 1) {
+    const idx = s.indexOf(":");
+    const host = s.slice(0, idx);
+    const port = s.slice(idx + 1);
+    if (!host || !/^\d{1,5}$/.test(port)) return null;
+    const n = Number(port);
+    if (n < 1 || n > 65535) return null;
+    return { host, port };
+  }
+  return { host: s, port: null };
+}
+
+export function normalizeHost(host: string): string {
+  let h = host.trim().toLowerCase();
+  if (h.startsWith("[") && h.endsWith("]")) h = h.slice(1, -1);
+  if (h.endsWith(".")) h = h.slice(0, -1);
+  return h;
+}
+
+// The host portion of a `user@host` (or `@user@host`) handle, without port,
+// lowercased, brackets/trailing-dot stripped. Null when the handle is malformed
+// (no @, empty user/host, illegal characters, bad port).
+export function extractHandleHost(handle: string): string | null {
+  const bare = handle.trim().replace(/^@/, "");
+  const at = bare.lastIndexOf("@");
+  if (at <= 0 || at === bare.length - 1) return null;
+  const user = bare.slice(0, at);
+  const hostport = bare.slice(at + 1);
+  if (!user || user.includes("@")) return null;
+  if (/[\s/?#]/.test(user) || /[\s/?#@]/.test(hostport)) return null;
+  const split = splitHostPort(hostport);
+  if (!split || !split.host) return null;
+  if (/[\s/?#@]/.test(split.host)) return null;
+  const host = normalizeHost(split.host);
+  if (!host || host.length > 253) return null;
+  return host;
+}
+
+// Parses one numeric IPv4 part: hex (0x..), octal (leading 0), else decimal.
+function parseIPv4Part(part: string): number | null {
+  if (!part) return null;
+  if (/^0[xX][0-9a-fA-F]+$/.test(part)) {
+    const v = parseInt(part, 16);
+    return Number.isSafeInteger(v) && v >= 0 && v <= 0xffffffff ? v : null;
+  }
+  if (/^0[0-7]+$/.test(part) && part.length > 1) {
+    const v = parseInt(part, 8);
+    return Number.isSafeInteger(v) && v >= 0 && v <= 0xffffffff ? v : null;
+  }
+  if (/^\d+$/.test(part)) {
+    // A leading zero with 8/9 is not valid octal — inet_aton rejects it.
+    if (part.length > 1 && part.startsWith("0")) return null;
+    const v = parseInt(part, 10);
+    return Number.isSafeInteger(v) && v >= 0 && v <= 0xffffffff ? v : null;
+  }
+  return null;
+}
+
+// inet_aton semantics (1–4 parts) → 32-bit number. Null when not an IPv4 form.
+export function parseIPv4ToNumber(input: string): number | null {
+  const parts = input.split(".");
+  if (parts.length < 1 || parts.length > 4) return null;
+  const vals: number[] = [];
+  for (const p of parts) {
+    const v = parseIPv4Part(p);
+    if (v === null) return null;
+    vals.push(v);
+  }
+  if (vals.length === 4) {
+    if (vals.some((v) => v > 255)) return null;
+    return vals[0] * 2 ** 24 + vals[1] * 2 ** 16 + vals[2] * 2 ** 8 + vals[3];
+  }
+  if (vals.length === 3) {
+    if (vals[0] > 255 || vals[1] > 255 || vals[2] > 65535) return null;
+    return vals[0] * 2 ** 24 + vals[1] * 2 ** 16 + vals[2];
+  }
+  if (vals.length === 2) {
+    if (vals[0] > 255 || vals[1] > 0xffffff) return null;
+    return vals[0] * 2 ** 24 + vals[1];
+  }
+  if (vals[0] > 0xffffffff) return null;
+  return vals[0];
+}
+
+const IPV4_BLOCKS: Array<[number, number]> = [
+  [0x00000000, 8], // 0.0.0.0/8 ("this network")
+  [0x0a000000, 8], // 10/8 RFC1918
+  [0x64400000, 10], // 100.64/10 CGNAT
+  [0x7f000000, 8], // 127/8 loopback
+  [0xa9fe0000, 16], // 169.254/16 link-local (+ cloud metadata)
+  [0xac100000, 12], // 172.16/12 RFC1918
+  [0xc0000000, 24], // 192.0.0.0/24
+  [0xc0000200, 24], // 192.0.2.0/24 TEST-NET-1
+  [0xc0586300, 24], // 192.88.99.0/24 (deprecated 6to4 relay)
+  [0xc0a80000, 16], // 192.168/16 RFC1918
+  [0xc6120000, 15], // 198.18/15 benchmark
+  [0xc6336400, 24], // 198.51.100/24 TEST-NET-2
+  [0xcb007100, 24], // 203.0.113/24 TEST-NET-3
+  [0xe0000000, 4], // 224/4 multicast
+  [0xf0000000, 4], // 240/4 reserved
+];
+
+export function isPrivateIPv4Number(n: number): boolean {
+  for (const [base, prefix] of IPV4_BLOCKS) {
+    const block = 2 ** (32 - prefix);
+    if (Math.floor(n / block) === Math.floor(base / block)) return true;
+  }
+  return false;
+}
+
+function expandIPv6(address: string): number[] | null {
+  let a = address.toLowerCase();
+  const v4delim = a.lastIndexOf(":");
+  if (a.includes(".") && v4delim >= 0) {
+    const v4 = parseIPv4ToNumber(a.substring(v4delim + 1));
+    if (v4 === null) return null;
+    const high = Math.floor(v4 / 65536);
+    const low = v4 % 65536;
+    a = `${a.substring(0, v4delim + 1)}${high.toString(16)}:${low.toString(16)}`;
+  }
+  if (a === "::") return [0, 0, 0, 0, 0, 0, 0, 0];
+  if (a.startsWith("::")) a = `0000${a}`;
+  if (a.endsWith("::")) a = `${a}0000`;
+  const colons = (a.match(/:/g) ?? []).length;
+  a = a.replace("::", `:0000`.repeat(8 - colons) + ":");
+  const parts = a.split(":");
+  if (parts.length !== 8) return null;
+  const words: number[] = [];
+  for (const p of parts) {
+    if (!/^[0-9a-f]{1,4}$/.test(p)) return null;
+    words.push(parseInt(p, 16));
+  }
+  return words;
+}
+
+function matchIPv6Prefix(words: number[], prefix: string): boolean {
+  const [addr, lenText] = prefix.split("/");
+  const len = Number(lenText);
+  const pw = expandIPv6(addr);
+  if (!pw) return false;
+  let rem = len;
+  for (let i = 0; i < 8 && rem > 0; i++) {
+    if (rem >= 16) {
+      if (words[i] !== pw[i]) return false;
+      rem -= 16;
+    } else {
+      const mask = (0xffff << (16 - rem)) & 0xffff;
+      if ((words[i] & mask) !== (pw[i] & mask)) return false;
+      rem = 0;
+    }
+  }
+  return true;
+}
+
+const IPV6_BLOCKS = [
+  "::/16", // :: + ::1 (loopback sits inside)
+  "2001::/32", // Teredo
+  "2002::/16", // 6to4
+  "64:ff9b:1::/48", // local-use NAT64
+  "fc00::/7", // unique-local
+  "fe80::/10", // link-local
+  "ff00::/8", // multicast
+];
+
+export function isPrivateIPv6(host: string): boolean {
+  const words = expandIPv6(host);
+  if (!words) return true; // unparseable colon-host: fail closed
+  if (IPV6_BLOCKS.some((p) => matchIPv6Prefix(words, p))) return true;
+  // IPv4-mapped / NAT64 with an embedded private v4 (e.g. ::ffff:127.0.0.1).
+  if (host.includes(".")) {
+    const v4part = host.substring(host.lastIndexOf(":") + 1);
+    const n = parseIPv4ToNumber(v4part);
+    if (n === null || isPrivateIPv4Number(n)) return true;
+  }
+  return false;
+}
+
+const PRIVATE_SUFFIXES = [
+  ".localhost",
+  ".local",
+  ".internal",
+  ".lan",
+  ".home",
+  ".corp",
+  ".localdomain",
+  ".intranet",
+  ".private",
+];
+
+// Pure syntactic check: true = must not federate with this host (no DNS).
+export function isBlockedHostSyntax(hostportOrHost: string): boolean {
+  if (allowPrivate()) return false;
+  const split = splitHostPort(hostportOrHost.trim());
+  if (!split || !split.host) return true;
+  const host = normalizeHost(split.host);
+  if (!host || host.length > 253) return true;
+  if (/[\s/?#@]/.test(host)) return true;
+
+  if (host === "localhost") return true;
+  if (PRIVATE_SUFFIXES.some((s) => host === s.slice(1) || host.endsWith(s))) return true;
+
+  // IPv6 literal (contains a colon).
+  if (host.includes(":")) return isPrivateIPv6(host) ? true : isIP(host) !== 6;
+
+  // IPv4 literal, including decimal/octal/hex spellings.
+  const v4 = parseIPv4ToNumber(host);
+  if (v4 !== null) return isPrivateIPv4Number(v4);
+  // Numeric-looking but unparseable (e.g. 999.1.1.1, 09.0.0.1): fail closed —
+  // it may be an IP encoding this parser does not cover.
+  if (/^[0-9xX.]+$/.test(host)) return true;
+
+  // Single-label hosts never identify a public fediverse instance; in compose
+  // they are docker service names (postgres, redis, backend) that resolve to
+  // private IPs. Block without burning a DNS lookup.
+  if (!host.includes(".")) return true;
+
+  return false;
+}
+
+// True when the handle must not trigger outbound federation (bad shape or a
+// syntactically-blocked host). Pure — safe to call before any I/O.
+export function isBlockedHandle(handle: string): boolean {
+  if (allowPrivate()) return false;
+  const host = extractHandleHost(handle);
+  if (host === null) return true;
+  // Re-append nothing: extractHandleHost already stripped the port, but the
+  // syntax check accepts either form.
+  return isBlockedHostSyntax(host);
+}
+
+async function resolveHostIPs(host: string): Promise<string[]> {
+  const recs = await lookup(host, { all: true });
+  return recs.map((r) => r.address);
+}
+
+// Full check: syntax + DNS (every A/AAAA must be public). Fail closed — DNS
+// errors, empty answers, and unparseable addresses all deny.
+export async function isHostAllowed(hostportOrHost: string): Promise<boolean> {
+  if (allowPrivate()) return true;
+  if (isBlockedHostSyntax(hostportOrHost)) return false;
+  const split = splitHostPort(hostportOrHost.trim());
+  if (!split) return false;
+  const host = normalizeHost(split.host);
+  // Literal IPs were fully decided by the syntax layer (public → allow).
+  if (parseIPv4ToNumber(host) !== null) return true;
+  if (host.includes(":")) return isIP(host) === 6;
+  let ips: string[];
+  try {
+    ips = await resolveHostIPs(host);
+  } catch {
+    return false;
+  }
+  if (ips.length === 0) return false;
+  for (const ip of ips) {
+    const fam = isIP(ip);
+    if (fam === 4) {
+      const n = parseIPv4ToNumber(ip);
+      if (n === null || isPrivateIPv4Number(n)) return false;
+    } else if (fam === 6) {
+      if (isPrivateIPv6(ip)) return false;
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+export async function isHandleAllowed(handle: string): Promise<boolean> {
+  if (allowPrivate()) return true;
+  const host = extractHandleHost(handle);
+  if (host === null) return false;
+  return await isHostAllowed(host);
+}

--- a/apps/backend/src/federation/ssrf_test.ts
+++ b/apps/backend/src/federation/ssrf_test.ts
@@ -1,0 +1,164 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Pins the SSRF guard behind GHSA-A1: anonymous GET /api/remote/users/:handle
+// must never trigger outbound fetches toward loopback, RFC1918, link-local
+// (incl. cloud metadata), or other private hosts — no matter the IP spelling.
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config.ts", () => ({
+  config: { ALLOW_PRIVATE_FEDERATION: false },
+}));
+
+vi.mock("node:dns/promises", () => ({
+  lookup: vi.fn<() => Promise<unknown>>(),
+}));
+
+import {
+  extractHandleHost,
+  isBlockedHandle,
+  isBlockedHostSyntax,
+  isHostAllowed,
+  parseIPv4ToNumber,
+} from "@/federation/ssrf.ts";
+
+describe("extractHandleHost", () => {
+  it("strips a leading @ and any port", () => {
+    expect(extractHandleHost("@alice@example.com")).toBe("example.com");
+    expect(extractHandleHost("x@127.0.0.1:8000")).toBe("127.0.0.1");
+    expect(extractHandleHost("x@[::1]:8000")).toBe("::1");
+  });
+
+  it("lowercases and strips a trailing dot", () => {
+    expect(extractHandleHost("x@LOCALHOST.")).toBe("localhost");
+    expect(extractHandleHost("x@Example.COM.")).toBe("example.com");
+  });
+
+  it.each(["alice", "@alice", "a@b@c@d/e", "x@", "@", "x@host/path", "x@host?q=1", ""])(
+    "rejects malformed handle %j",
+    (bad) => {
+      expect(extractHandleHost(bad)).toBe(null);
+    },
+  );
+});
+
+describe("parseIPv4ToNumber", () => {
+  it("parses dotted decimal", () => {
+    expect(parseIPv4ToNumber("127.0.0.1")).toBe(0x7f000001);
+    expect(parseIPv4ToNumber("10.0.0.1")).toBe(0x0a000001);
+  });
+
+  it("parses decimal/octal/hex spellings to the same loopback", () => {
+    expect(parseIPv4ToNumber("2130706433")).toBe(0x7f000001);
+    expect(parseIPv4ToNumber("0x7f.0x0.0x0.0x1")).toBe(0x7f000001);
+    expect(parseIPv4ToNumber("0x7f000001")).toBe(0x7f000001);
+    expect(parseIPv4ToNumber("0177.0.0.01")).toBe(0x7f000001);
+  });
+
+  it("rejects out-of-range octets", () => {
+    expect(parseIPv4ToNumber("999.1.1.1")).toBe(null);
+    expect(parseIPv4ToNumber("1.2.3.256")).toBe(null);
+  });
+});
+
+describe("isBlockedHostSyntax", () => {
+  it.each([
+    "127.0.0.1",
+    "127.0.0.1:8000",
+    "2130706433",
+    "0x7f.0.0.1",
+    "0x7f000001",
+    "0177.0.0.1",
+    "::1",
+    "[::1]",
+    "[::1]:8000",
+  ])("blocks loopback spelling %s", (h) => {
+    expect(isBlockedHostSyntax(h)).toBe(true);
+  });
+
+  it.each([
+    "10.0.0.1",
+    "172.16.0.1",
+    "172.31.255.255",
+    "192.168.1.1",
+    "169.254.169.254",
+    "0.0.0.0",
+    "100.64.0.1",
+    "192.0.2.1",
+    "198.51.100.1",
+    "203.0.113.1",
+    "224.0.0.1",
+    "fc00::1",
+    "fe80::1",
+    "ff02::1",
+    "::",
+    "::ffff:127.0.0.1",
+  ])("blocks reserved host %s", (h) => {
+    expect(isBlockedHostSyntax(h)).toBe(true);
+  });
+
+  it.each([
+    "localhost",
+    "LOCALHOST",
+    "localhost.",
+    "foo.localhost",
+    "app.local",
+    "svc.internal",
+    "box.lan",
+    "postgres",
+    "redis",
+    "backend",
+  ])("blocks local-only name %s", (h) => {
+    expect(isBlockedHostSyntax(h)).toBe(true);
+  });
+
+  it("fails closed on numeric-looking garbage", () => {
+    expect(isBlockedHostSyntax("999.999.999.999")).toBe(true);
+    expect(isBlockedHostSyntax("09.0.0.1")).toBe(true);
+  });
+
+  it.each(["example.com", "mastodon.social", "a.b.example.com", "8.8.8.8", "1.1.1.1", "2606:4700:4700::1111"])(
+    "allows public host %s (DNS decides the rest)",
+    (h) => {
+      expect(isBlockedHostSyntax(h)).toBe(false);
+    },
+  );
+});
+
+describe("isBlockedHandle", () => {
+  it.each(["x@127.0.0.1:8000", "x@169.254.169.254", "x@localhost", "x@postgres", "x@[::1]"])(
+    "blocks the GHSA PoC handle %s without any I/O",
+    (h) => {
+      expect(isBlockedHandle(h)).toBe(true);
+    },
+  );
+
+  it("allows a normal federated handle syntactically", () => {
+    expect(isBlockedHandle("alice@mastodon.social")).toBe(false);
+  });
+
+  it("blocks malformed handles", () => {
+    expect(isBlockedHandle("notahandle")).toBe(true);
+  });
+});
+
+describe("isHostAllowed (DNS layer)", () => {
+  it("denies when every answer is private, allows when all are public", async () => {
+    const { lookup } = await import("node:dns/promises");
+    const mocked = vi.mocked(lookup);
+    mocked.mockReset();
+    mocked.mockResolvedValueOnce([{ address: "93.184.215.14", family: 4 }] as never);
+    expect(await isHostAllowed("example.com")).toBe(true);
+    mocked.mockResolvedValueOnce([
+      { address: "93.184.215.14", family: 4 },
+      { address: "10.0.0.1", family: 4 },
+    ] as never);
+    expect(await isHostAllowed("rebind.example.com")).toBe(false);
+  });
+
+  it("denies on DNS failure (fail closed)", async () => {
+    const { lookup } = await import("node:dns/promises");
+    const mocked = vi.mocked(lookup);
+    mocked.mockReset();
+    mocked.mockRejectedValueOnce(new Error("ENOTFOUND"));
+    expect(await isHostAllowed("nxdomain.invalid-test-host")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Symptom

Unauthenticated `GET /api/remote/users/:handle` passes the raw path param to `remoteProfilesService.getProfileView()` → `resolveActor(handle)`, which gated only on the admin defederation blocklist. A crafted `user@host` (loopback, RFC1918, link-local/cloud-metadata, alternate IP spellings, docker service names like `postgres`) could force the backend to emit WebFinger/actor/outbox fetches toward internal hosts, with response timing plus negative-cache behavior as a port-scan oracle.

## Root cause

In `apps/backend/src/federation/remote.ts`, `handleHost()` preserved ports and IP literals untouched, and `federation/outboundGuard.ts:runOutbound` enforced only concurrency + deadline. No private-IP/reserved-IP denylist and no redirect-to-private guard existed in our code. Evidence: `routes/remote.ts:50-59`, `services/remoteProfiles.ts:44-61,98-110`, `federation/remote.ts:53-70,109-162`, `lib/domain.ts` strict-hostname regex (rejects IPs, so operators could not block them via the UI either).

Note on severity: Fedify 2.3.6 already refuses private URLs by default (`validatePublicUrl` on WebFinger + documentLoader incl. redirect re-validation — verified `http://127.0.0.1/`, `169.254.169.254`, `0x7f.0.0.1`, `2130706433`, `[::1]` all BLOCK, `example.com` ALLOW). So direct egress is most likely already dead. But that protection is implicit in `node_modules`, unpinned by any test here, and TOCTOU-exposed on DNS rebinding — hence an explicit, tested guard rather than relying on it.

## Fix

- New `federation/ssrf.ts`: syntactic denylist (localhost/`*.localhost`, private/reserved v4 incl. decimal/octal/hex spellings, `0.0.0.0`, v6 loopback/link-local/unique-local/multicast + embedded private v4, single-label hosts, `.local/.internal/.lan/…`, malformed handles) + fail-closed DNS (any private A/AAAA or resolution failure denies).
- `resolveActor`/`fetchOutboxPosts` refuse blocked handles before any I/O; `runOutbound` re-checks syntactically as a second layer.
- `ALLOW_PRIVATE_FEDERATION=true` (default `false`, new row in `.env.example`) restores LAN-dev behavior. Requiring auth or lowering rate limits was deliberately not the fix — those leave logged-in-attacker SSRF intact.

## Verification

- New `federation/ssrf_test.ts`: handle parsing, alt-IP spellings, loopback/RFC1918/metadata/reserved, localhost/LAN/single-label, fail-closed numerics, public-host allows, mocked-DNS allow/rebind-deny/NXDOMAIN-deny.
- `pnpm vitest run src/`: 26 files, 283 tests, all pass. `pnpm fmt:check` clean, `pnpm lint` clean for new files.
- Not run: `deno check` (no `deno` binary in this environment; fails identically on clean `main`) and live staging egress PoC.

## Deploy notes

Plain `docker compose up -d --build` suffices. No migration. Operators who federate against LAN hosts for testing must set `ALLOW_PRIVATE_FEDERATION=true` (never on internet-reachable hosts).