### PR TITLE
fix(headers): dedupe X-Content-Type-Options, add Permissions-Policy

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -27,9 +27,20 @@
 # order, so the federation paths win and all other paths fall through.
 (routes) {
 	# Security hardening applied to every response: stop browsers from MIME
-	# sniffing and trust the declared Content-Type instead.
+	# sniffing and trust the declared Content-Type instead, and switch off the
+	# powerful browser APIs a blogging platform never uses (camera, microphone,
+	# geolocation, …) so an XSS hole can't reach for them.
+	#
+	# `>` defers the set until the response is being written, *replacing* any
+	# value the upstream already sent. A plain `header` here runs before the
+	# proxy and is *added* alongside the app's own header — the same doubling
+	# the @anubis_boot block below documents — which is exactly the duplicate
+	# X-Content-Type-Options a headers scan flags. The values below intentionally
+	# match apps/frontend/src/hooks.server.ts so direct-to-app dev traffic and
+	# Caddy-served prod traffic carry identical headers.
 	header {
-		X-Content-Type-Options nosniff
+		>X-Content-Type-Options nosniff
+		>Permissions-Policy "accelerometer=(), ambient-light-sensor=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), usb=(), xr-spatial-tracking=()"
 	}
 
 	# Anubis reads the client IP from X-Real-IP and refuses the request outright

--- a/apps/frontend/src/hooks.server.ts
+++ b/apps/frontend/src/hooks.server.ts
@@ -147,6 +147,15 @@ export const handle: Handle = async ({ event, resolve }) => {
   response.headers.set("X-Frame-Options", "DENY");
   // Don't leak full URLs (which can carry handles/slugs) to third-party origins.
   response.headers.set("Referrer-Policy", "strict-origin-when-cross-origin");
+  // Switch off the powerful browser APIs a blogging platform never uses, so an
+  // XSS hole can't reach for them. The value must stay identical to the
+  // Permissions-Policy in the root Caddyfile: in prod Caddy applies its own copy
+  // as a deferred set (replacing this one, no duplicate), while direct-to-app
+  // dev traffic carries this one.
+  response.headers.set(
+    "Permissions-Policy",
+    "accelerometer=(), ambient-light-sensor=(), camera=(), display-capture=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-get=(), screen-wake-lock=(), usb=(), xr-spatial-tracking=()",
+  );
   // Isolate our browsing context from cross-origin openers.
   response.headers.set("Cross-Origin-Opener-Policy", "same-origin");
 


### PR DESCRIPTION
## The symptom

A security-headers scan of the apex domain (grade A) flagged two findings: a **duplicate `X-Content-Type-Options`** header and a **missing `Permissions-Policy`**.

## The root cause

The duplicate is a layering bug. Caddy's plain `header { X-Content-Type-Options nosniff }` runs *before* the proxy and is *added* alongside the upstream's own header — the exact doubling the `@anubis_boot` block in the same Caddyfile already documents for Cache-Control. SvelteKit sets its own copy in `hooks.server.ts:144`, so every app response carried `nosniff` twice.

## The fix

- **Caddyfile**: both headers now use deferred sets (`>Field value`), which replace at write time instead of doubling. This also extends both headers to the backend-served federation paths (`/.well-known/*`, `/users/*`, …), which previously got only the Caddy copy.
- **hooks.server.ts**: adds the identical `Permissions-Policy` next to the other app-owned headers, with a comment pointing at its Caddyfile twin. Direct-to-app dev traffic and Caddy-served prod traffic now carry the same value.
- The policy disables camera/mic/geolocation/payment/USB/WebAuthn and other powerful APIs a blogging platform never uses; fullscreen/autoplay/PiP/share are deliberately left alone so embedded media in posts keeps working.

## What was verified

- `oxfmt --check` clean, `oxlint` exit 0, `svelte-check` 0 errors 0 warnings.
- Caddy syntax could not be validated locally (no binary here); the `>` form matches the existing `@anubis_boot` precedent in the same file, and CI's Docker build exercises the Caddyfile.
- Not yet re-scanned: re-run the headers scan after deploy to confirm both findings clear.

## Deploy notes

Takes effect from a plain `docker compose up -d --build` (Caddy reloads its config, frontend restarts). No migration, no env changes.