### PR TITLE
feat(federation): two-way federated replies (Responses <-> Notes)

### DIFF
--- a/apps/backend/drizzle/0035_remote_comments.sql
+++ b/apps/backend/drizzle/0035_remote_comments.sql
@@ -1,0 +1,15 @@
+-- Federated replies ("Responses" from Mastodon and friends). Lets a comment be
+-- authored by either a local user (`author_id`) or a cached remote actor
+-- (`remote_actor_id`) whose Note reply arrived over federation — the same
+-- local-or-remote shape `follows`/`notifications`/`recommendations` use.
+--
+-- `author_id` drops NOT NULL (existing rows all keep theirs); the new CHECK
+-- keeps it exactly-one-kind per row. `ap_id` is the comment's ActivityPub URI:
+-- the canonical Note id for an inbound remote reply (dedupe + Update/Delete
+-- routing), minted lazily for a local comment on first outbound federation.
+ALTER TABLE "comments" ALTER COLUMN "author_id" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "comments" ADD COLUMN IF NOT EXISTS "remote_actor_id" uuid;--> statement-breakpoint
+ALTER TABLE "comments" ADD COLUMN IF NOT EXISTS "ap_id" text;--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_remote_actor_id_remote_actors_id_fk" FOREIGN KEY ("remote_actor_id") REFERENCES "remote_actors"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "comments_ap_id_idx" ON "comments" ("ap_id");--> statement-breakpoint
+ALTER TABLE "comments" ADD CONSTRAINT "comments_author_kind_ck" CHECK (("author_id" is null) <> ("remote_actor_id" is null));

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1788000000000,
       "tag": "0034_better_auth",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1788708046999,
+      "tag": "0035_remote_comments",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/db/repositories/comments.ts
+++ b/apps/backend/src/db/repositories/comments.ts
@@ -1,17 +1,30 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { and, asc, desc, eq, inArray, isNull, lt, or, sql } from "drizzle-orm";
 import { db } from "@/db/client.ts";
-import { comments, type NewComment, users } from "@/db/schema.ts";
+import { comments, type NewComment, remoteActors, users } from "@/db/schema.ts";
 import { type Cursor, DEFAULT_PAGE_SIZE } from "@/lib/pagination.ts";
 
 // Comment DB access. Top-level comments are newest-first and cursor-paginated
 // like posts; their replies are fetched in one batched query (oldest-first).
+//
+// A comment's author is either a local user or a cached remote actor (a Note
+// reply that arrived over federation) — exactly one of the two joins hits per
+// row, enforced by `comments_author_kind_ck`. Callers pick the author shape via
+// `authorOf` (see routes/serializers.ts `commentView`).
 
 const authorColumns = {
   id: users.id,
   username: users.username,
   displayName: users.displayName,
   avatarUrl: users.avatarUrl,
+};
+
+const remoteAuthorColumns = {
+  id: remoteActors.id,
+  handle: remoteActors.handle,
+  displayName: remoteActors.displayName,
+  avatarUrl: remoteActors.avatarUrl,
+  apId: remoteActors.apId,
 };
 
 export type CommentWithAuthor = Awaited<ReturnType<typeof listByPost>>[number];
@@ -21,6 +34,14 @@ export async function create(data: NewComment) {
   return row;
 }
 
+// Idempotent ingest of a federated reply, keyed by its ActivityPub id —
+// re-delivery (or a Create racing its own Update) resolves to the same row.
+export async function createRemote(data: Omit<NewComment, "authorId"> & { remoteActorId: string; apId: string }) {
+  const [row] = await db.insert(comments).values(data).onConflictDoNothing({ target: comments.apId }).returning();
+  if (row) return row;
+  return findByApId(data.apId);
+}
+
 export function findById(id: string) {
   return db
     .select()
@@ -28,6 +49,25 @@ export function findById(id: string) {
     .where(eq(comments.id, id))
     .limit(1)
     .then((r) => r[0] ?? null);
+}
+
+// A comment by its ActivityPub URI — the canonical Note id for a remote reply,
+// or the lazily-minted one for a federated local comment. Backs inbound
+// Update/Delete routing and reply-to-comment threading.
+export function findByApId(apId: string) {
+  return db
+    .select()
+    .from(comments)
+    .where(eq(comments.apId, apId))
+    .limit(1)
+    .then((r) => r[0] ?? null);
+}
+
+// Mints (or re-mints) the ActivityPub URI of a local comment on its first
+// outbound federation, so the Note id is stable across edits and deletes.
+export async function setApId(id: string, apId: string) {
+  const [row] = await db.update(comments).set({ apId }).where(eq(comments.id, id)).returning();
+  return row;
 }
 
 export async function update(id: string, content: string) {
@@ -46,25 +86,47 @@ function beforeCursor(cursor: Cursor | null) {
   return or(lt(comments.createdAt, ts), and(eq(comments.createdAt, ts), lt(comments.id, cursor.id)));
 }
 
-// Hides comments whose (always-local) author the viewer has blocked, or who has
-// blocked the viewer — blocks are bidirectional locally. Undefined for guests,
-// so `and()` drops it and comments are unfiltered when logged out.
+// Hides comments the viewer blocked, or (for local authors) who blocked the
+// viewer — blocks are bidirectional locally. Remote authors can only be
+// filtered on the viewer's outgoing remote blocks: an inbound Block severs the
+// follow edge without persisting, so an unknown inbound block is invisible
+// here. Undefined for guests, so `and()` drops the filters when logged out.
+//
+// `authorId` is nullable now, so each half is guarded by its own null check —
+// a bare `null NOT IN (…)` would evaluate to null and drop the row.
 function notBlocked(viewerId: string | null) {
   if (!viewerId) return undefined;
-  return sql`${comments.authorId} not in (
-    select target_user_id from blocks
-      where user_id = ${viewerId} and target_user_id is not null
-    union
-    select user_id from blocks where target_user_id = ${viewerId}
-  )`;
+  return and(
+    or(
+      isNull(comments.authorId),
+      sql`${comments.authorId} not in (
+        select target_user_id from blocks
+          where user_id = ${viewerId} and target_user_id is not null
+        union
+        select user_id from blocks where target_user_id = ${viewerId}
+      )`,
+    ),
+    or(
+      isNull(comments.remoteActorId),
+      sql`${comments.remoteActorId} not in (
+        select target_remote_actor_id from blocks
+          where user_id = ${viewerId} and target_remote_actor_id is not null
+      )`,
+    ),
+  );
+}
+
+function withAuthors() {
+  return db
+    .select({ comment: comments, author: authorColumns, remoteActor: remoteAuthorColumns })
+    .from(comments)
+    .leftJoin(users, eq(comments.authorId, users.id))
+    .leftJoin(remoteActors, eq(comments.remoteActorId, remoteActors.id));
 }
 
 // Top-level comments only (parentId is null), newest first.
 export function listByPost(postId: string, cursor: Cursor | null, viewerId: string | null, limit = DEFAULT_PAGE_SIZE) {
-  return db
-    .select({ comment: comments, author: authorColumns })
-    .from(comments)
-    .innerJoin(users, eq(comments.authorId, users.id))
+  return withAuthors()
     .where(and(eq(comments.postId, postId), isNull(comments.parentId), notBlocked(viewerId), beforeCursor(cursor)))
     .orderBy(desc(comments.createdAt), desc(comments.id))
     .limit(limit + 1);
@@ -73,17 +135,32 @@ export function listByPost(postId: string, cursor: Cursor | null, viewerId: stri
 // All replies for the given parent comments, oldest first.
 export function listReplies(parentIds: string[], viewerId: string | null) {
   if (parentIds.length === 0) return Promise.resolve([] as CommentWithAuthor[]);
-  return db
-    .select({ comment: comments, author: authorColumns })
-    .from(comments)
-    .innerJoin(users, eq(comments.authorId, users.id))
+  return withAuthors()
     .where(and(inArray(comments.parentId, parentIds), notBlocked(viewerId)))
     .orderBy(asc(comments.createdAt), asc(comments.id));
 }
 
-// Every response on the instance, for NodeInfo's usage figures. Comments are
-// always local — the column is a FK to `users`, so a remote reply is never one
-// of these — which is why there is nothing to filter here.
+// Oldest-first top-level comments for the post's federated Replies collection.
+// Local and remote alike: both are Responses, and both federate back out.
+export function listForReplies(postId: string, limit = 20) {
+  return withAuthors()
+    .where(and(eq(comments.postId, postId), isNull(comments.parentId)))
+    .orderBy(asc(comments.createdAt), asc(comments.id))
+    .limit(limit);
+}
+
+// Honest `totalItems` for the Replies collection above (the item list is
+// capped, the count is not).
+export async function countTopLevel(postId: string): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(comments)
+    .where(and(eq(comments.postId, postId), isNull(comments.parentId)));
+  return row?.n ?? 0;
+}
+
+// Every response on the instance, for NodeInfo's usage figures. Local and
+// federated replies alike — both are responses left on this instance's posts.
 export async function countAll(): Promise<number> {
   const [row] = await db.select({ n: sql<number>`count(*)::int` }).from(comments);
   return row?.n ?? 0;

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 import {
   type AnyPgColumn,
   boolean,
+  check,
   customType,
   date,
   index,
@@ -423,6 +424,14 @@ export const recommendations = pgTable(
 // on the client, never as HTML. `parentId` is null for top-level comments and
 // points at the top-level comment a reply belongs to (replies are not nested
 // beyond one level — replying to a reply attaches to its top-level parent).
+//
+// A comment has exactly one author of two kinds: a local user (`authorId`) or
+// a cached remote actor (`remoteActorId`) whose Note reply arrived over
+// federation (Mastodon, …). Remote bodies arrive as HTML and are flattened to
+// plain text on ingest (see federation/note.ts), so the escaped-render
+// invariant holds for both kinds. `apId` is the comment's ActivityPub URI —
+// the canonical Note id for a remote reply (dedupe + Update/Delete routing),
+// minted lazily for a local comment on its first outbound federation.
 export const comments = pgTable(
   "comments",
   {
@@ -430,16 +439,19 @@ export const comments = pgTable(
     postId: uuid("post_id")
       .notNull()
       .references(() => posts.id, { onDelete: "cascade" }),
-    authorId: uuid("author_id")
-      .notNull()
-      .references(() => users.id, { onDelete: "cascade" }),
+    authorId: uuid("author_id").references(() => users.id, { onDelete: "cascade" }),
+    remoteActorId: uuid("remote_actor_id").references(() => remoteActors.id, { onDelete: "cascade" }),
     parentId: uuid("parent_id").references((): AnyPgColumn => comments.id, { onDelete: "cascade" }),
     content: text("content").notNull(),
+    apId: text("ap_id"),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => [
     index("comments_post_created_idx").on(t.postId, t.createdAt.desc(), t.id.desc()),
     index("comments_parent_idx").on(t.parentId, t.createdAt, t.id),
+    uniqueIndex("comments_ap_id_idx").on(t.apId),
+    // Exactly one author kind per row: local XOR remote.
+    check("comments_author_kind_ck", sql`(${t.authorId} is null) <> (${t.remoteActorId} is null)`),
   ],
 );
 

--- a/apps/backend/src/federation/article.ts
+++ b/apps/backend/src/federation/article.ts
@@ -82,6 +82,14 @@ export function buildArticle(
     to: PUBLIC_COLLECTION,
     cc: ctx.getFollowersUri(identifier),
   };
+  // Thread discovery: points at this post's Replies collection (see
+  // federation/mod.ts), so Mastodon renders the local + federated Responses
+  // under the post instead of an empty thread. Omitted for followers-only
+  // posts — that collection is served publicly, so it must never name them.
+  const replies =
+    to.href === PUBLIC_COLLECTION.href
+      ? new URL(`/users/${identifier}/posts/${post.id}/replies`, federationOrigin())
+      : undefined;
   return new Article({
     id: new URL(`/posts/${post.id}`, ctx.getActorUri(identifier)),
     attribution: ctx.getActorUri(identifier),
@@ -95,6 +103,7 @@ export function buildArticle(
     cc,
     url: new URL(`/posts/${post.id}`, ctx.getActorUri(identifier)),
     tags: tags.map((t) => new Hashtag({ name: `#${t.name}`, href: new URL(`/tags/${t.slug}`, federationOrigin()) })),
+    replies,
   });
 }
 

--- a/apps/backend/src/federation/deliver.ts
+++ b/apps/backend/src/federation/deliver.ts
@@ -3,6 +3,7 @@ import type { Context } from "@fedify/fedify";
 import type { Actor } from "@fedify/fedify/vocab";
 import { Create, Delete, isActor, PUBLIC_COLLECTION, Tombstone, Update } from "@fedify/fedify/vocab";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
+import * as commentsRepo from "@/db/repositories/comments.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
@@ -10,9 +11,135 @@ import * as usersRepo from "@/db/repositories/users.ts";
 import { buildPerson } from "@/federation/actor.ts";
 import { buildArticle, type ArticleAudience } from "@/federation/article.ts";
 import { getFederation } from "@/federation/mod.ts";
+import { buildNote, commentApUri, isCommentFederable, noteContext } from "@/federation/note.ts";
+import { textToNoteHtml } from "@/lib/html.ts";
 import { federationOrigin } from "@/services/federationState.ts";
 
-// Resolves a local author's remote followers into deliverable actor objects,
+// Sends a Create(Note) — or an Update(Note) for an edit — of a local comment
+// to everyone holding the other side of the thread: the commenter's remote
+// followers, plus the post author's remote followers for a local post, or the
+// remote post's own actor for a cached one (that's the inbox threading it).
+// Only public-post comments federate (see isCommentFederable); replies on a
+// private author's posts stay local-only. The Note id is stable, so an Update
+// carries the same object id the remote instance already cached.
+export async function deliverComment(commentId: string, action: "create" | "update" = "create"): Promise<void> {
+  const origin = federationOrigin();
+  const comment = await commentsRepo.findById(commentId);
+  if (!comment || !comment.authorId) return;
+
+  const author = await usersRepo.findById(comment.authorId);
+  if (!author) return;
+
+  const nctx = await noteContext(origin, author.username, comment.id);
+  if (!nctx) return;
+
+  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const recipients = await commentRecipients(ctx, author.id, nctx.postAuthorId, nctx.postApId);
+  if (recipients.length === 0) return;
+
+  const actorUri = ctx.getActorUri(author.username);
+  const followersUri = ctx.getFollowersUri(author.username);
+  const note = buildNote(author.username, {
+    id: new URL(nctx.noteId),
+    attribution: actorUri,
+    contentHtml: textToNoteHtml(nctx.comment.content),
+    published: nctx.comment.createdAt,
+    inReplyTo: new URL(nctx.inReplyTo),
+    url: new URL(`${nctx.postUrl}#comment-${nctx.comment.id}`),
+    audience: { to: PUBLIC_COLLECTION, cc: followersUri },
+  });
+
+  const activity =
+    action === "update"
+      ? new Update({
+          id: new URL(`/users/${author.username}/comments/${comment.id}/updates/${crypto.randomUUID()}`, origin),
+          actor: actorUri,
+          object: note,
+          tos: [PUBLIC_COLLECTION],
+        })
+      : new Create({
+          id: new URL(`/users/${author.username}/comments/${comment.id}/activity`, origin),
+          actor: actorUri,
+          object: note,
+          tos: [PUBLIC_COLLECTION],
+        });
+
+  await ctx.sendActivity({ identifier: author.username }, recipients, activity);
+}
+
+// Sends a Delete for a local comment that has already been removed from the
+// DB. Mirrors deliverPostDelete: the caller passes the former author id and
+// the post id (whose row still exists), and the Tombstone id matches the Note
+// id remote instances cached.
+export async function deliverCommentDelete(commentId: string, authorId: string, postId: string): Promise<void> {
+  const origin = federationOrigin();
+  const author = await usersRepo.findById(authorId);
+  if (!author) return;
+
+  const post = await postsRepo.findById(postId);
+  if (!post) return;
+  if (post.post.authorId) {
+    const postAuthor = await usersRepo.findById(post.post.authorId);
+    if (!postAuthor || !isCommentFederable(post.post, postAuthor.isPrivate)) return;
+  } else if (!isCommentFederable(post.post, false)) {
+    return;
+  }
+
+  const ctx = getFederation().createContext(new URL(origin), undefined);
+  const recipients = await commentRecipients(
+    ctx,
+    author.id,
+    post.post.authorId,
+    post.post.remote ? (post.post.apId ?? null) : null,
+  );
+  if (recipients.length === 0) return;
+
+  const actorUri = ctx.getActorUri(author.username);
+  await ctx.sendActivity(
+    { identifier: author.username },
+    recipients,
+    new Delete({
+      id: new URL(`/users/${author.username}/comments/${commentId}/delete/${crypto.randomUUID()}`, origin),
+      actor: actorUri,
+      object: new Tombstone({ id: new URL(commentApUri(origin, author.username, commentId)) }),
+      tos: [PUBLIC_COLLECTION],
+    }),
+  );
+}
+
+// The inboxes an outbound comment activity goes to: the commenter's remote
+// followers, plus whoever holds the other side of the thread — the post
+// author's remote followers for a local post, or the remote post's own actor
+// for a cached one (that's the inbox that needs to thread it under the post).
+async function commentRecipients(
+  ctx: Context<unknown>,
+  commentAuthorId: string,
+  postAuthorId: string | null,
+  remotePostApId: string | null,
+): Promise<Actor[]> {
+  const seen = new Set<string>();
+  const recipients: Actor[] = [];
+  const push = (actor: Actor) => {
+    if (actor.id && !seen.has(actor.id.href)) {
+      seen.add(actor.id.href);
+      recipients.push(actor);
+    }
+  };
+  for (const actor of await remoteRecipients(ctx, commentAuthorId)) push(actor);
+  if (postAuthorId && postAuthorId !== commentAuthorId) {
+    for (const actor of await remoteRecipients(ctx, postAuthorId)) push(actor);
+  } else if (remotePostApId) {
+    try {
+      const object = await ctx.lookupObject(remotePostApId);
+      if (isActor(object)) push(object);
+    } catch {
+      // The post author's instance is unreachable; the followers still get it.
+    }
+  }
+  return recipients;
+}
+
+// Resolves a local user's remote followers into deliverable actor objects,
 // skipping any on a defederated domain (exact host or subdomain). Shared by
 // every outbound post activity (Create / Update / Delete).
 async function remoteRecipients(ctx: Context<unknown>, authorId: string): Promise<Actor[]> {

--- a/apps/backend/src/federation/mod.ts
+++ b/apps/backend/src/federation/mod.ts
@@ -21,6 +21,7 @@ import {
   Follow,
   Hashtag,
   isActor,
+  Note,
   OrderedCollection,
   PUBLIC_COLLECTION,
   Undo,
@@ -28,6 +29,7 @@ import {
 } from "@fedify/fedify/vocab";
 import { RedisKvStore, RedisMessageQueue } from "@fedify/redis";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
+import * as commentsRepo from "@/db/repositories/comments.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as listsRepo from "@/db/repositories/readingLists.ts";
@@ -40,8 +42,19 @@ import type { Post } from "@/db/schema.ts";
 import { buildPerson } from "@/federation/actor.ts";
 import { articleLanguage, buildArticle, isPubliclyAddressed } from "@/federation/article.ts";
 import { setupNodeInfo } from "@/federation/nodeinfo.ts";
+import {
+  buildNote,
+  commentApUri,
+  ingestNote,
+  ingestNoteDelete,
+  ingestNoteUpdate,
+  isCommentFederable,
+  noteContext,
+  postApUri,
+} from "@/federation/note.ts";
 import { cacheActor } from "@/federation/remote.ts";
 import { sameOrigin } from "@/lib/domain.ts";
+import { textToNoteHtml } from "@/lib/html.ts";
 import { getRedis, redisEnabled, redisFactory } from "@/lib/redis.ts";
 import { sanitizePostHtml } from "@/lib/sanitize.ts";
 import { normalizeTags } from "@/lib/tags.ts";
@@ -66,6 +79,7 @@ export function getFederation(): Federation<ContextData> {
   setupActor(f);
   setupFollowers(f);
   setupLists(f);
+  setupNotes(f);
   setupInbox(f);
   setupOutbox(f);
   federation = f;
@@ -200,6 +214,84 @@ function setupLists(f: Federation<ContextData>) {
         name: list.title,
         summary: list.description || undefined,
         totalItems: items.length,
+        items,
+      });
+    },
+  );
+}
+
+// ── Replies: local comments as Notes + the per-post Replies collection ────
+// A local comment is fetchable as a Note at
+// /users/{identifier}/comments/{commentId} (author-scoped like the outbox, so
+// it stays inside the already-proxied /users/* prefix), and every public post
+// advertises /users/{identifier}/posts/{postId}/replies from its Article (see
+// buildArticle). Together they are what lets Mastodon thread both directions:
+// our responses render under the remote copy of the post, and remote replies
+// already ingested here re-federate as part of the thread.
+function setupNotes(f: Federation<ContextData>) {
+  f.setObjectDispatcher(Note, "/users/{identifier}/comments/{commentId}", async (ctx, { identifier, commentId }) => {
+    const nctx = await noteContext(federationOrigin(), identifier, commentId);
+    if (!nctx) return null;
+    return buildNote(identifier, {
+      id: new URL(nctx.noteId),
+      attribution: ctx.getActorUri(identifier),
+      contentHtml: textToNoteHtml(nctx.comment.content),
+      published: nctx.comment.createdAt,
+      inReplyTo: new URL(nctx.inReplyTo),
+      url: new URL(`${nctx.postUrl}#comment-${nctx.comment.id}`),
+      audience: { to: PUBLIC_COLLECTION, cc: ctx.getFollowersUri(identifier) },
+    });
+  });
+
+  f.setObjectDispatcher(
+    OrderedCollection,
+    "/users/{identifier}/posts/{postId}/replies",
+    async (ctx, { identifier, postId }) => {
+      const user = await usersRepo.findByUsername(identifier);
+      if (!user) return null;
+      const post = await postsRepo.findById(postId);
+      if (!post || post.post.authorId !== user.id) return null;
+      // Served to the whole internet, so private authors' posts 404 here —
+      // the same line isCommentFederable draws for ingest and delivery.
+      if (!isCommentFederable(post.post, user.isPrivate)) return null;
+
+      const origin = federationOrigin();
+      const postUri = postApUri(origin, post.post);
+      const rows = await commentsRepo.listForReplies(post.post.id);
+      const items = rows.map((row) => {
+        const inReplyTo = new URL(postUri);
+        const url = new URL(`${postUri}#comment-${row.comment.id}`);
+        const audience = { to: PUBLIC_COLLECTION, cc: ctx.getFollowersUri(identifier) };
+        if (row.author) {
+          return buildNote(identifier, {
+            id: new URL(row.comment.apId ?? commentApUri(origin, row.author.username, row.comment.id)),
+            attribution: ctx.getActorUri(row.author.username),
+            contentHtml: textToNoteHtml(row.comment.content),
+            published: row.comment.createdAt,
+            inReplyTo,
+            url,
+            audience,
+          });
+        }
+        // An ingested remote reply, re-served so the thread is complete for
+        // whoever fetches the collection. Attribution stays the original
+        // actor's id — we are not its author.
+        return buildNote(identifier, {
+          id: new URL(row.comment.apId!),
+          attribution: new URL(row.remoteActor!.apId),
+          contentHtml: textToNoteHtml(row.comment.content),
+          published: row.comment.createdAt,
+          inReplyTo,
+          url,
+          audience,
+        });
+      });
+
+      return new OrderedCollection({
+        id: ctx.getObjectUri(OrderedCollection, { identifier, postId }),
+        totalItems: await commentsRepo.countTopLevel(post.post.id),
+        // Capped at the oldest 20 (see listForReplies): enough for a thread
+        // view without turning one popular post into a megabyte.
         items,
       });
     },
@@ -390,10 +482,17 @@ function setupInbox(f: Federation<ContextData>) {
     })
     .on(Create, async (ctx, create) => {
       if (await fromBlockedDomain(create.actorId)) return;
+      const object = await create.getObject(ctx);
+      // A remote actor replied to one of our posts (or to a known reply) —
+      // ingest the Note as a response. Any other Note is ordinary microblog
+      // traffic and stays out, matching the long-form-only stance below.
+      if (object instanceof Note) {
+        await ingestNote(ctx, object);
+        return;
+      }
       // Ingest a remote post. This is a long-form blogging platform, so we only
       // accept ActivityPub Articles (Omicron, WriteFreely, Ghost, Plume, …) and
       // ignore microblog Notes (Mastodon, Pixelfed, …) outright.
-      const object = await create.getObject(ctx);
       if (!(object instanceof Article)) return;
       await ingestArticle(ctx, object);
     })
@@ -431,9 +530,14 @@ function setupInbox(f: Federation<ContextData>) {
     })
     .on(Update, async (ctx, update) => {
       if (await fromBlockedDomain(update.actorId)) return;
+      const object = await update.getObject(ctx);
+      // A remote author edited their reply — refresh the cached copy.
+      if (object instanceof Note) {
+        await ingestNoteUpdate(ctx, object);
+        return;
+      }
       // A remote author edited one of their Articles. Re-sanitize and update the
       // cached copy in place. Only Articles we already cache are touched.
-      const object = await update.getObject(ctx);
       if (!(object instanceof Article) || !object.id || !update.actorId) return;
       const existing = await postsRepo.findByApId(object.id.href);
       if (!existing) return;
@@ -470,7 +574,12 @@ function setupInbox(f: Federation<ContextData>) {
 
       // Delete(post): drop the cached copy, but only when the deleter owns it.
       const post = await postsRepo.findByApId(objectId);
-      if (!post) return;
+      if (!post) {
+        // Not a cached post — maybe a cached reply. ingestNoteDelete no-ops
+        // unless the row exists and the deleter wrote it.
+        if (del.actorId) await ingestNoteDelete(objectId, del.actorId.href);
+        return;
+      }
       const actor = await remoteActorsRepo.findByApId(del.actorId.href);
       if (!actor || actor.id !== post.remoteActorId) return;
       await postsRepo.removeByApId(objectId);

--- a/apps/backend/src/federation/note.ts
+++ b/apps/backend/src/federation/note.ts
@@ -1,0 +1,365 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import type { Context } from "@fedify/fedify";
+import { isActor, Note } from "@fedify/fedify/vocab";
+import * as commentsRepo from "@/db/repositories/comments.ts";
+import * as postsRepo from "@/db/repositories/posts.ts";
+import type { PostWithAuthor } from "@/db/repositories/posts.ts";
+import * as relationsRepo from "@/db/repositories/relations.ts";
+import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
+import * as usersRepo from "@/db/repositories/users.ts";
+import type { Comment, Post } from "@/db/schema.ts";
+import { isPubliclyAddressed } from "@/federation/article.ts";
+import { cacheActor } from "@/federation/remote.ts";
+import { sameOrigin } from "@/lib/domain.ts";
+import { htmlToText } from "@/lib/html.ts";
+import { federationOrigin } from "@/services/federationState.ts";
+import * as notifications from "@/services/notifications.ts";
+
+// Federated replies: local Responses ↔ ActivityPub Notes.
+//
+// A local comment federates out as a Note whose `inReplyTo` is the post's
+// ActivityPub URI (or the parent comment's Note URI for a reply), and a remote
+// Note with such an `inReplyTo` ingests back into the same `comments` table —
+// so a Mastodon reply shows under Responses, and a local reply shows in the
+// Mastodon thread. Bodies are plain text on both sides of the boundary:
+// inbound HTML is flattened with `htmlToText`, outbound text is wrapped with
+// `textToNoteHtml`, which is what keeps the client's escaped rendering safe
+// for remote content too.
+
+// Inbound bodies are capped like local ones (see services/comments.ts
+// MAX_LENGTH) — the column itself is unbounded, so without a cap one hostile
+// instance could stuff megabytes into a Responses thread.
+const MAX_REMOTE_LENGTH = 2000;
+
+// A comment federates — in either direction — only on a published post whose
+// audience is fully public: a cached remote post (only public ones are ever
+// cached, see federation/mod.ts) or a local post by a non-private author.
+// Replies on a private author's posts stay local-only: the Replies collection
+// below is served to the whole internet, so it must never name them, and the
+// same line is drawn for what we accept and what we send.
+export function isCommentFederable(post: Pick<Post, "status" | "remote">, authorIsPrivate: boolean): boolean {
+  if (post.status !== "published") return false;
+  if (post.remote) return true;
+  return !authorIsPrivate;
+}
+
+// Extracts a Note's body as plain text: Mastodon wraps it in `<p>`, encodes
+// entities, and prefixes a mention (`<span class="h-card">…</span>`) that
+// flattens into an inert `@user` string. Empty when the Note carries nothing
+// renderable (e.g. an attachment-only post) — the caller drops those.
+export function noteText(note: Note): string {
+  return htmlToText(note.content?.toString() ?? "")
+    .slice(0, MAX_REMOTE_LENGTH)
+    .trim();
+}
+
+// The ActivityPub URI of a local comment, derived deterministically from its
+// author and id so the dispatcher, delivery, and inbox routing all agree
+// without a lookup. Scoped under the author's actor path (Mastodon's
+// `/users/{name}/statuses/{id}` shape), which keeps it inside the already
+// reverse-proxied `/users/*` federation prefix — no Caddy change needed.
+export function commentApUri(origin: string, identifier: string, commentId: string): string {
+  return `${origin}/users/${identifier}/comments/${commentId}`;
+}
+
+// Parses our own comment URI back into `{ identifier, commentId }` — the
+// fallback that resolves an `inReplyTo` pointing at a local comment we never
+// federated (no `apId` minted yet). Pure and unit-tested; the DB lookup that
+// follows confirms the row actually exists and is local.
+export function parseLocalCommentRef(href: string): { identifier: string; commentId: string } | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  const match = /^\/users\/([^/]+)\/comments\/([^/]+)$/.exec(url.pathname);
+  if (!match) return null;
+  return { identifier: match[1], commentId: match[2] };
+}
+
+// Parses our own post URI back into its id. Local posts carry no stored `apId`
+// (their federated address is derived — see postApUri), so without this an
+// `inReplyTo` naming our `/posts/{id}` address would never resolve. Pure and
+// unit-tested; the DB lookup that follows confirms the row exists.
+export function parseLocalPostRef(href: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return null;
+  }
+  const match = /^\/posts\/([^/]+)$/.exec(url.pathname);
+  return match ? match[1] : null;
+}
+
+// Finds a post by ActivityPub URI: exact `apId` match first (cached remote
+// posts), then our own derived `/posts/{id}` address (local posts). Always
+// returns the joined read shape, so callers get author visibility either way.
+export async function findPostByApUri(href: string): Promise<PostWithAuthor | null> {
+  const byApId = await postsRepo.findByApId(href);
+  if (byApId) return postsRepo.findById(byApId.id);
+  const postId = parseLocalPostRef(href);
+  if (!postId) return null;
+  if (new URL(href).origin !== federationOrigin()) return null;
+  return postsRepo.findById(postId);
+}
+
+// The canonical ActivityPub URI of a post: a cached remote post's own id, or
+// the local `/posts/{id}` address remote instances already know from Articles.
+export function postApUri(origin: string, post: Pick<Post, "id" | "remote" | "apId">): string {
+  if (post.remote && post.apId) return post.apId;
+  return `${origin}/posts/${post.id}`;
+}
+
+export type NoteAudience = {
+  to: URL;
+  cc?: URL;
+};
+
+// Builds the ActivityPub Note for a comment: stable id, attribution to whoever
+// wrote it (a local actor URI, or the remote actor's own id when re-serving an
+// ingested reply in the Replies collection), HTML body, and the `inReplyTo`
+// (`replyTarget`) that threads it under the post or parent comment.
+export function buildNote(
+  identifier: string,
+  opts: {
+    id: URL;
+    attribution: URL;
+    contentHtml: string;
+    published?: Date;
+    inReplyTo: URL;
+    url: URL;
+    audience: NoteAudience;
+  },
+): Note {
+  return new Note({
+    id: opts.id,
+    attribution: opts.attribution,
+    content: opts.contentHtml,
+    published: opts.published ? Temporal.Instant.from(opts.published.toISOString()) : undefined,
+    replyTarget: opts.inReplyTo,
+    url: opts.url,
+    to: opts.audience.to,
+    cc: opts.audience.cc,
+  });
+}
+
+// Loads everything the Note dispatcher and outbound delivery need for one
+// local comment: the comment, its post, the audience, and the resolved
+// `inReplyTo` URI (parent comment's Note URI, else the post's URI). Mints the
+// comment's `apId` on first use so the id is stable across edits and deletes.
+// Null when the comment isn't local, its post is gone, or either side opted
+// out of federation (private author, unpublished post).
+export async function noteContext(
+  origin: string,
+  identifier: string,
+  commentId: string,
+): Promise<{
+  comment: Comment;
+  noteId: string;
+  inReplyTo: string;
+  postUrl: string;
+  postAuthorId: string | null;
+  postApId: string | null;
+} | null> {
+  const comment = await commentsRepo.findById(commentId);
+  if (!comment || !comment.authorId) return null;
+
+  const author = await usersRepo.findById(comment.authorId);
+  if (!author || author.username !== identifier) return null;
+
+  const post = await postsRepo.findById(comment.postId);
+  if (!post) return null;
+  if (post.post.authorId) {
+    const postAuthor = await usersRepo.findById(post.post.authorId);
+    if (!postAuthor || !isCommentFederable(post.post, postAuthor.isPrivate)) return null;
+  } else if (!isCommentFederable(post.post, false)) {
+    return null;
+  }
+
+  const noteId = comment.apId ?? commentApUri(origin, identifier, comment.id);
+  if (!comment.apId) await commentsRepo.setApId(comment.id, noteId);
+
+  let inReplyTo: string;
+  if (comment.parentId) {
+    const parent = await commentsRepo.findById(comment.parentId);
+    if (!parent) return null;
+    inReplyTo =
+      parent.apId ??
+      (parent.authorId
+        ? await (async () => {
+            const parentAuthor = await usersRepo.findById(parent.authorId!);
+            return parentAuthor ? commentApUri(origin, parentAuthor.username, parent.id) : postApUri(origin, post.post);
+          })()
+        : postApUri(origin, post.post));
+  } else {
+    inReplyTo = postApUri(origin, post.post);
+  }
+
+  return {
+    comment,
+    noteId,
+    inReplyTo,
+    postUrl: postApUri(origin, post.post),
+    postAuthorId: post.post.authorId,
+    postApId: post.post.remote ? (post.post.apId ?? null) : null,
+  };
+}
+
+// Ingests a remote Note as a response on the post (or comment) its `inReplyTo`
+// names — shared by the inbox Create handler. Mirrors `ingestArticle`'s
+// guards: dedupe by ActivityPub id, public addressing only (#123), and the
+// same-origin authority check, plus the reply-target resolution Articles never
+// needed. Returns the stored comment, or undefined when the Note isn't a reply
+// to anything local (ordinary microblog traffic we don't cache).
+export async function ingestNote(ctx: Context<unknown>, note: Note): Promise<Comment | undefined> {
+  if (!note.id) return undefined;
+  const apId = note.id.href;
+
+  const existing = await commentsRepo.findByApId(apId);
+  if (existing) return existing;
+
+  // Privacy/security (#123), same as Articles: a followers-only or direct
+  // Note must not be persisted and surfaced on public read paths.
+  if (!isPubliclyAddressed(note)) return undefined;
+
+  if (!note.attributionId) return undefined;
+  const author = await ctx.lookupObject(note.attributionId);
+  if (!isActor(author) || !author.id) return undefined;
+
+  // Authority check, same as Articles: the Note id and its attributed actor
+  // must share an origin, or any instance could post under anyone's name.
+  if (!sameOrigin(note.id, author.id)) return undefined;
+
+  // Our own Notes never arrive inbound — we author those. Without this, a
+  // relayed echo of our own federated response would be cached as a "remote"
+  // duplicate of itself.
+  if (new URL(author.id.href).origin === federationOrigin()) return undefined;
+
+  // Resolve the reply target: every `inReplyTo` is tried in order, first a
+  // post (cached remote by `apId`, local by its derived `/posts/{id}`
+  // address), then a known comment (whose post we adopt). Anything else — a
+  // Note replying into a thread we never saw — is ordinary microblog traffic,
+  // not a response to us.
+  let post: PostWithAuthor | null = null;
+  let parentId: string | null = null;
+  for (const target of note.replyTargetIds) {
+    const candidate = await findPostByApUri(target.href);
+    if (candidate) {
+      post = candidate;
+      break;
+    }
+    const parent = await findCommentByApUri(target.href);
+    if (parent) {
+      const parentPost = await postsRepo.findById(parent.postId);
+      if (!parentPost) continue;
+      post = parentPost;
+      // Replies flatten to one level, same as local ones (see
+      // services/comments.ts): replying to a reply attaches to its top-level
+      // parent.
+      parentId = parent.parentId ?? parent.id;
+      break;
+    }
+  }
+  if (!post) return undefined;
+  const postId = post.post.id;
+  if (post.post.authorId) {
+    const postAuthor = await usersRepo.findById(post.post.authorId);
+    if (!postAuthor || !isCommentFederable(post.post, postAuthor.isPrivate)) return undefined;
+  } else if (!isCommentFederable(post.post, false)) {
+    return undefined;
+  }
+
+  const actor = await cacheActor(author);
+
+  // A local author who blocked this remote actor doesn't get their replies —
+  // the same rule that keeps a blocked follower out (see mod.ts Follow).
+  if (post.post.authorId && (await relationsRepo.hasRemote("block", post.post.authorId, actor.id))) {
+    return undefined;
+  }
+
+  const content = noteText(note);
+  if (!content) return undefined;
+
+  const comment = await commentsRepo.createRemote({
+    postId,
+    remoteActorId: actor.id,
+    parentId,
+    content,
+    apId,
+    createdAt: note.published ? new Date(note.published.epochMilliseconds) : undefined,
+  });
+  if (!comment) return undefined;
+
+  // Notify like a local reply would: the post's local author always hears
+  // about a new response; a reply additionally pings the local author of the
+  // comment it answers (a remote parent has no local recipient to ping).
+  if (post.post.authorId) {
+    await notifications.notify({
+      recipientId: post.post.authorId,
+      type: "comment",
+      remoteActorId: actor.id,
+      postId,
+      commentId: comment.id,
+    });
+  }
+  if (parentId) {
+    const parent = await commentsRepo.findById(parentId);
+    if (parent?.authorId && parent.authorId !== post.post.authorId) {
+      await notifications.notify({
+        recipientId: parent.authorId,
+        type: "reply",
+        remoteActorId: actor.id,
+        postId,
+        commentId: comment.id,
+      });
+    }
+  }
+
+  return comment;
+}
+
+// A remote author edited their Note: re-flatten and update the cached copy in
+// place. Only comments we actually hold are touched, and only by the actor who
+// wrote them.
+export async function ingestNoteUpdate(ctx: Context<unknown>, note: Note): Promise<void> {
+  if (!note.id || !note.attributionId) return;
+  const existing = await commentsRepo.findByApId(note.id.href);
+  if (!existing || !existing.remoteActorId) return;
+
+  const updater = await ctx.lookupObject(note.attributionId);
+  if (!isActor(updater) || !updater.id) return;
+  const actor = await remoteActorsRepo.findByApId(updater.id.href);
+  if (!actor || actor.id !== existing.remoteActorId) return;
+
+  const content = noteText(note);
+  if (!content) return;
+  await commentsRepo.update(existing.id, content);
+}
+
+// A remote author deleted their Note: drop the cached copy, but only when the
+// deleter owns it. The mirrored notification is left in place — it still
+// describes something that happened, and its comment link simply 404s.
+export async function ingestNoteDelete(objectHref: string, actorHref: string): Promise<void> {
+  const existing = await commentsRepo.findByApId(objectHref);
+  if (!existing || !existing.remoteActorId) return;
+  const actor = await remoteActorsRepo.findByApId(actorHref);
+  if (!actor || actor.id !== existing.remoteActorId) return;
+  await commentsRepo.remove(existing.id);
+}
+
+// Finds a comment by ActivityPub URI: exact `apId` match first (remote Notes
+// and minted local ones), then our own never-federated comment path. The
+// path-derived row still goes through the caller's ownership checks, so a
+// hostile instance can't hijack a local id by minting a colliding URI —
+// colliding with a *remote* row is impossible (exact match wins) and with a
+// local row fails the author check in Update/Delete.
+export async function findCommentByApUri(href: string): Promise<Comment | null> {
+  const byApId = await commentsRepo.findByApId(href);
+  if (byApId) return byApId;
+  const ref = parseLocalCommentRef(href);
+  if (!ref) return null;
+  if (new URL(href).origin !== federationOrigin()) return null;
+  return commentsRepo.findById(ref.commentId);
+}

--- a/apps/backend/src/federation/note_test.ts
+++ b/apps/backend/src/federation/note_test.ts
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Unit tests for the federated-replies plumbing: the URI scheme shared by the
+// Note dispatcher, outbound delivery, and inbox routing must agree, and only
+// public-post comments may federate in either direction. The module under test
+// pulls in repos (whose postgres pool connects lazily — no DB here) and
+// config (Deno env access), so config is mocked; the logic tested is real.
+import { Note } from "@fedify/fedify/vocab";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config.ts", () => ({
+  config: { APP_DOMAIN: "omicron.example", ALLOW_PRIVATE_FEDERATION: false },
+}));
+
+import {
+  commentApUri,
+  isCommentFederable,
+  noteText,
+  parseLocalCommentRef,
+  parseLocalPostRef,
+  postApUri,
+} from "@/federation/note.ts";
+import { htmlToText, textToNoteHtml } from "@/lib/html.ts";
+
+const ORIGIN = "https://omicron.example";
+
+describe("commentApUri / parseLocalCommentRef", () => {
+  it("round-trips a local comment URI", () => {
+    const id = "123e4567-e89b-12d3-a456-426614174000";
+    const uri = commentApUri(ORIGIN, "alice", id);
+    expect(uri).toBe(`${ORIGIN}/users/alice/comments/${id}`);
+    expect(parseLocalCommentRef(uri)).toEqual({ identifier: "alice", commentId: id });
+  });
+
+  it("rejects foreign paths and garbage", () => {
+    expect(parseLocalCommentRef(`${ORIGIN}/posts/abc`)).toBeNull();
+    expect(parseLocalCommentRef(`${ORIGIN}/users/alice`)).toBeNull();
+    expect(parseLocalCommentRef("https://mastodon.social/users/bob/statuses/123")).toBeNull();
+    expect(parseLocalCommentRef("not a url")).toBeNull();
+  });
+});
+
+describe("postApUri", () => {
+  it("uses the canonical id for a cached remote post", () => {
+    expect(postApUri(ORIGIN, { id: "x", remote: true, apId: "https://remote.example/posts/1" })).toBe(
+      "https://remote.example/posts/1",
+    );
+  });
+
+  it("derives the local address otherwise", () => {
+    expect(postApUri(ORIGIN, { id: "abc", remote: false, apId: null })).toBe(`${ORIGIN}/posts/abc`);
+  });
+});
+
+describe("parseLocalPostRef", () => {
+  it("resolves our derived post address", () => {
+    expect(parseLocalPostRef(`${ORIGIN}/posts/52683dce-2d3a-4b1c-9e5f-123456789abc`)).toBe(
+      "52683dce-2d3a-4b1c-9e5f-123456789abc",
+    );
+  });
+
+  it("rejects comment paths and garbage", () => {
+    expect(parseLocalPostRef(`${ORIGIN}/users/alice/comments/x`)).toBeNull();
+    expect(parseLocalPostRef("not a url")).toBeNull();
+  });
+});
+
+describe("isCommentFederable", () => {
+  const published = { status: "published" as const };
+  it("federates public posts only", () => {
+    expect(isCommentFederable({ ...published, remote: false }, false)).toBe(true);
+    expect(isCommentFederable({ ...published, remote: true }, false)).toBe(true);
+  });
+
+  it("keeps drafts, scheduled posts, and private authors' posts local-only", () => {
+    expect(isCommentFederable({ status: "draft", remote: false }, false)).toBe(false);
+    expect(isCommentFederable({ status: "scheduled", remote: false }, false)).toBe(false);
+    expect(isCommentFederable({ ...published, remote: false }, true)).toBe(false);
+  });
+});
+
+describe("noteText", () => {
+  it("flattens Note HTML to plain text", () => {
+    const note = new Note({ content: '<p><span><a href="https://x/@bob">@bob</a></span> hello <b>there</b></p>' });
+    expect(noteText(note)).toBe("@bob hello there");
+  });
+
+  it("is empty for contentless Notes and capped at local max length", () => {
+    expect(noteText(new Note({}))).toBe("");
+    expect(noteText(new Note({ content: "x".repeat(5000) })).length).toBe(2000);
+  });
+});
+
+describe("textToNoteHtml", () => {
+  it("escapes markup and round-trips through htmlToText", () => {
+    const text = "hello <script>alert(1)</script>\nsecond line";
+    const html = textToNoteHtml(text);
+    expect(html).not.toContain("<script>");
+    expect(htmlToText(html)).toBe("hello <script>alert(1)</script>\nsecond line");
+  });
+});

--- a/apps/backend/src/lib/html.ts
+++ b/apps/backend/src/lib/html.ts
@@ -51,3 +51,16 @@ export function htmlToText(html: string): string {
     .replace(/[ \t]*\n[ \t]*/g, "\n")
     .trim();
 }
+
+// The inverse of `htmlToText` for outbound federation: a local comment is
+// plain text, but an ActivityPub Note's `content` is HTML. Each paragraph is
+// escaped (never trusted as markup) and wrapped in `<p>`, so what a Mastodon
+// reader renders matches the escaped rendering here.
+export function textToNoteHtml(text: string): string {
+  return text
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0)
+    .map((line) => `<p>${escapeHtml(line)}</p>`)
+    .join("");
+}

--- a/apps/backend/src/queue/handlers.ts
+++ b/apps/backend/src/queue/handlers.ts
@@ -29,6 +29,22 @@ export function registerJobHandlers() {
     await deliverPostDelete(postId, authorId);
   });
 
+  // A local comment was created or edited; fan out a Create(Note) /
+  // Update(Note) so it threads under the post on remote instances.
+  registerHandler("federate_comment", async ({ commentId, action }) => {
+    if (!federationRunning()) return;
+    const { deliverComment } = await import("@/federation/deliver.ts");
+    await deliverComment(commentId, action ?? "create");
+  });
+
+  // A local comment was deleted; tombstone the Note on remote instances. The
+  // row is already gone, so the payload carries the former author + post ids.
+  registerHandler("federate_comment_delete", async ({ commentId, authorId, postId }) => {
+    if (!federationRunning()) return;
+    const { deliverCommentDelete } = await import("@/federation/deliver.ts");
+    await deliverCommentDelete(commentId, authorId, postId);
+  });
+
   // A user edited their own profile (name/bio/email/links/avatar); push an
   // Update(Person) so instances that already cached the old actor refresh it.
   registerHandler("federate_actor_update", async ({ userId }) => {

--- a/apps/backend/src/queue/queue.ts
+++ b/apps/backend/src/queue/queue.ts
@@ -13,6 +13,8 @@ export type JobName =
   | "federate_post"
   | "indexnow_submit"
   | "federate_post_delete"
+  | "federate_comment"
+  | "federate_comment_delete"
   | "federate_actor_update"
   | "federate_list_item"
   | "send_follow"
@@ -30,6 +32,8 @@ export type JobPayloads = {
   federate_post: { postId: string; action?: "create" | "update" };
   indexnow_submit: { postId: string };
   federate_post_delete: { postId: string; authorId: string };
+  federate_comment: { commentId: string; action?: "create" | "update" };
+  federate_comment_delete: { commentId: string; authorId: string; postId: string };
   federate_actor_update: { userId: string };
   federate_list_item: { listId: string; postId: string; action: "add" | "remove" };
   send_follow: { followerId: string; targetActor: string };

--- a/apps/backend/src/routes/posts.ts
+++ b/apps/backend/src/routes/posts.ts
@@ -236,6 +236,7 @@ postRoutes.post("/:id/comments", jsonBody(createCommentSchema), async (c) => {
           displayName: user.displayName,
           avatarUrl: user.avatarUrl,
         },
+        remoteActor: null,
       }),
     },
     201,

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -239,7 +239,9 @@ type LikeStats = { count: number; liked: boolean };
 
 // Accepts a plain author row plus optional like stats and nested replies (only
 // top-level comments carry replies). Replies are themselves rendered via
-// commentView so the shape is uniform at every level.
+// commentView so the shape is uniform at every level. The author is whichever
+// kind the row carries — a local user, or a cached remote actor shaped exactly
+// like `relationActorRemote` so `/@${username}` links resolve either way.
 export function commentView(
   row: CommentWithAuthor & {
     likeStats?: LikeStats;
@@ -249,17 +251,19 @@ export function commentView(
   id: string;
   content: string;
   createdAt: Date;
-  author: CommentWithAuthor["author"];
+  author: CommentWithAuthor["author"] | ReturnType<typeof relationActorRemote>;
   parentId: string | null;
   likeCount: number;
   liked: boolean;
   replies: ReturnType<typeof commentView>[];
 } {
+  const author = row.author ?? (row.remoteActor ? relationActorRemote(row.remoteActor) : null);
+  if (!author) throw new Error("commentView: comment has neither local nor remote author");
   return {
     id: row.comment.id,
     content: row.comment.content,
     createdAt: row.comment.createdAt,
-    author: row.author,
+    author,
     parentId: row.comment.parentId,
     likeCount: row.likeStats?.count ?? 0,
     liked: row.likeStats?.liked ?? false,

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -251,7 +251,10 @@ export function commentView(
   id: string;
   content: string;
   createdAt: Date;
-  author: CommentWithAuthor["author"] | ReturnType<typeof relationActorRemote>;
+  // Non-null: exactly one join hits per row (see `comments_author_kind_ck`),
+  // and the throw below turns the impossible neither-side case into a 500
+  // instead of a malformed payload.
+  author: Exclude<CommentWithAuthor["author"], null> | ReturnType<typeof relationActorRemote>;
   parentId: string | null;
   likeCount: number;
   liked: boolean;

--- a/apps/backend/src/services/commentLikes.ts
+++ b/apps/backend/src/services/commentLikes.ts
@@ -16,19 +16,28 @@ async function statsOf(commentId: string, viewerId: string): Promise<commentLike
 export async function like(userId: string, commentId: string) {
   const comment = await commentsRepo.findById(commentId);
   if (!comment) throw notFound("Comment not found.");
-  // A block forbids liking a blocked user's comment (either direction). Comment
-  // authors are always local.
-  if (await relationsRepo.localBlockExists(userId, comment.authorId)) {
+  // A block forbids liking a blocked user's comment (either direction for a
+  // local author; outgoing only for a remote one — inbound remote blocks are
+  // invisible here, same as the comment listing).
+  if (comment.authorId) {
+    if (await relationsRepo.localBlockExists(userId, comment.authorId)) {
+      throw forbidden("You cannot like this comment.");
+    }
+  } else if (comment.remoteActorId && (await relationsRepo.hasRemote("block", userId, comment.remoteActorId))) {
     throw forbidden("You cannot like this comment.");
   }
   await commentLikesRepo.add(commentId, userId);
-  await notifications.notify({
-    recipientId: comment.authorId,
-    type: "comment_like",
-    actorId: userId,
-    postId: comment.postId,
-    commentId,
-  });
+  // Only a local author can receive an in-app notification; a remote one has
+  // no inbox here. (The Like itself stays local-only — it never federates.)
+  if (comment.authorId) {
+    await notifications.notify({
+      recipientId: comment.authorId,
+      type: "comment_like",
+      actorId: userId,
+      postId: comment.postId,
+      commentId,
+    });
+  }
   return statsOf(commentId, userId);
 }
 
@@ -36,12 +45,14 @@ export async function unlike(userId: string, commentId: string) {
   const comment = await commentsRepo.findById(commentId);
   if (!comment) throw notFound("Comment not found.");
   await commentLikesRepo.remove(commentId, userId);
-  await notifications.unnotify({
-    recipientId: comment.authorId,
-    type: "comment_like",
-    actorId: userId,
-    postId: comment.postId,
-    commentId,
-  });
+  if (comment.authorId) {
+    await notifications.unnotify({
+      recipientId: comment.authorId,
+      type: "comment_like",
+      actorId: userId,
+      postId: comment.postId,
+      commentId,
+    });
+  }
   return statsOf(commentId, userId);
 }

--- a/apps/backend/src/services/comments.ts
+++ b/apps/backend/src/services/comments.ts
@@ -6,6 +6,7 @@ import * as postsRepo from "@/db/repositories/posts.ts";
 import * as relationsRepo from "@/db/repositories/relations.ts";
 import { badRequest, forbidden, notFound } from "@/lib/http.ts";
 import { type Cursor, DEFAULT_PAGE_SIZE, encodeCursor } from "@/lib/pagination.ts";
+import { queue } from "@/queue/queue.ts";
 import * as notifications from "@/services/notifications.ts";
 
 // Business logic for comments. Content is plain text (max 2 000 chars); the
@@ -80,6 +81,10 @@ export async function create(authorId: string, postId: string, content: string, 
     });
   }
 
+  // Federate the response out as a Note (no-op unless the post is public and
+  // someone remote follows the thread — see deliverComment).
+  queue.add("federate_comment", { commentId: comment.id });
+
   return comment;
 }
 
@@ -96,11 +101,15 @@ export async function edit(userId: string, commentId: string, content: string) {
   if (!comment) throw notFound("Comment not found.");
   if (comment.authorId !== userId) throw forbidden("You can only edit your own comments.");
 
-  return commentsRepo.update(commentId, text);
+  const updated = await commentsRepo.update(commentId, text);
+  queue.add("federate_comment", { commentId, action: "update" });
+  return updated;
 }
 
 // Deletes a comment (and its replies, via cascade). Only the comment's author
-// or an admin may delete it.
+// or an admin may delete it. A deleted local comment federates a Delete(Note)
+// so remote threads drop it too; a removed remote reply just disappears here
+// (the original still lives on its home instance).
 export async function remove(userId: string, isAdmin: boolean, commentId: string) {
   const comment = await commentsRepo.findById(commentId);
   if (!comment) throw notFound("Comment not found.");
@@ -108,6 +117,13 @@ export async function remove(userId: string, isAdmin: boolean, commentId: string
     throw forbidden("You can only delete your own comments.");
   }
   await commentsRepo.remove(commentId);
+  if (comment.authorId) {
+    queue.add("federate_comment_delete", {
+      commentId: comment.id,
+      authorId: comment.authorId,
+      postId: comment.postId,
+    });
+  }
 }
 
 export async function list(


### PR DESCRIPTION
## The symptom

Omicron posts render nicely on Mastodon (link card, title, tags), but replies written there never appear under the post's Responses here (stuck at 0) — and local responses never leave this instance, so the Mastodon thread stays empty too.

## The root cause

Two gaps, one per direction:

- **Inbound:** the inbox Create handler (`federation/mod.ts`) accepted only `Article` objects, so every Mastodon `Create(Note)` was dropped by design. Even an accepted Note had nowhere to go: `comments.author_id` was NOT NULL (local users only) and nothing resolved a Note's `inReplyTo` to a local post — a gap confirmed by `grep inReplyTo` returning zero hits.
- **Outbound:** local comments never federated (`queue/handlers.ts` had no comment job), posts advertised no Replies collection, and no Note dispatcher existed — so remote instances couldn't thread anything under our Articles.

## The fix

**Inbound (remote reply -> Responses):** `federation/note.ts` ingests a Note when its `inReplyTo` resolves to a post we hold (cached remote by `apId`, local by its derived `/posts/{id}` address — local posts store no `apId`, which is why a plain `findByApId` would still miss) or to a known comment (threaded one level, like local replies). Same guards as Articles: public addressing only (#123), same-origin authority check, blocked-actor refusal, plus a self-author echo guard. Remote bodies flatten to plain text via `htmlToText` (2000-char cap like local), so the client's escaped rendering stays safe. `Update(Note)`/`Delete(Note)` propagate with ownership checks; the post author gets a `comment` notification (remote actor attached), the answered local author a `reply`.

**Outbound (Response -> thread):** comment create/edit/delete enqueue `federate_comment(_delete)` jobs sending `Create/Update/Delete(Note)` to the commenter's + post author's remote followers (or the cached post's own actor). Notes live at `/users/{name}/comments/{id}` with a per-post Replies collection at `/users/{name}/posts/{id}/replies` — both inside the already-proxied `/users/*` prefix, so **no Caddy change needed** — and every public Article now advertises its `replies` collection.

**Shared rule:** only public-post comments federate either way (`isCommentFederable`); private authors' posts stay local-only, since the Replies collection is public.

**Schema (0035):** `comments.author_id` nullable, new `remote_actor_id` FK + `ap_id` unique, CHECK enforces exactly one author kind. Migration verified against real Postgres 16: legacy rows survive, CHECK rejects both-null/both-set, `apId` dedupes re-delivery.

No frontend changes: `Comment.author` already accepted the remote shape, and `/@@user@host` links resolve.

## What was verified

- `deno task check`: 4/4 (type, fmt, lint, 294 tests incl. 11 new in `note_test.ts`).
- Fedify round-trip smoke tests: `replyTarget` serializes as `inReplyTo`; a Mastodon-shaped Note parses (`replyTargetIds`, attribution, mention flattening, timestamp).
- Migration exercised on Postgres 16 (see above).
- **Not verified:** live two-instance thread (needs staging + a Mastodon account replying). The case in your screenshots — reply from Mastodon to a post — is exactly the manual check to run after deploy.

## Deploy notes

Plain `docker compose up -d --build`; the additive migration auto-applies. No env changes, no Caddy change.

Docs: this changes user-visible federation behavior (Responses now sync both ways, with the private-posts exception) — say the word and I'll update omicron-docs separately.