### PR TITLE
fix(federation): serve Replies collection as Hono route, not 2nd dispatcher

### DIFF
--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -10,6 +10,7 @@ import { registerJobHandlers } from "@/queue/handlers.ts";
 import { healthRoutes } from "@/routes/health.ts";
 import { apiRoutes } from "@/routes/index.ts";
 import { sessionMiddleware } from "@/routes/middleware.ts";
+import { repliesRoutes } from "@/routes/replies.ts";
 import type { AppEnv } from "@/routes/types.ts";
 import { wellKnownRoutes } from "@/routes/wellKnown.ts";
 import { federationRunning } from "@/services/federationState.ts";
@@ -115,6 +116,12 @@ export async function buildApp() {
     // lets the NodeInfo JRD here take the path back from Fedify's own
     // single-version one. See routes/wellKnown.ts.
     app.route("/", wellKnownRoutes);
+    // The per-post Replies collection. A plain Hono route rather than a Fedify
+    // object dispatcher — Fedify allows one dispatcher per object class and
+    // reading lists already own OrderedCollection — mounted here for the same
+    // reason: anything under /users/* would otherwise 404 inside Fedify before
+    // Hono routes run. See routes/replies.ts.
+    app.route("/", repliesRoutes);
 
     const { getFederation } = await import("@/federation/mod.ts");
     const { withAttributionDomains } = await import("@/federation/attribution.ts");

--- a/apps/backend/src/federation/mod.ts
+++ b/apps/backend/src/federation/mod.ts
@@ -29,7 +29,6 @@ import {
 } from "@fedify/fedify/vocab";
 import { RedisKvStore, RedisMessageQueue } from "@fedify/redis";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
-import * as commentsRepo from "@/db/repositories/comments.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as listsRepo from "@/db/repositories/readingLists.ts";
@@ -42,16 +41,7 @@ import type { Post } from "@/db/schema.ts";
 import { buildPerson } from "@/federation/actor.ts";
 import { articleLanguage, buildArticle, isPubliclyAddressed } from "@/federation/article.ts";
 import { setupNodeInfo } from "@/federation/nodeinfo.ts";
-import {
-  buildNote,
-  commentApUri,
-  ingestNote,
-  ingestNoteDelete,
-  ingestNoteUpdate,
-  isCommentFederable,
-  noteContext,
-  postApUri,
-} from "@/federation/note.ts";
+import { buildNote, ingestNote, ingestNoteDelete, ingestNoteUpdate, noteContext } from "@/federation/note.ts";
 import { cacheActor } from "@/federation/remote.ts";
 import { sameOrigin } from "@/lib/domain.ts";
 import { textToNoteHtml } from "@/lib/html.ts";
@@ -220,14 +210,17 @@ function setupLists(f: Federation<ContextData>) {
   );
 }
 
-// ── Replies: local comments as Notes + the per-post Replies collection ────
-// A local comment is fetchable as a Note at
-// /users/{identifier}/comments/{commentId} (author-scoped like the outbox, so
-// it stays inside the already-proxied /users/* prefix), and every public post
-// advertises /users/{identifier}/posts/{postId}/replies from its Article (see
-// buildArticle). Together they are what lets Mastodon thread both directions:
-// our responses render under the remote copy of the post, and remote replies
-// already ingested here re-federate as part of the thread.
+// ── Notes: local comments fetchable as ActivityPub objects ───────────────
+// A local comment answers at /users/{identifier}/comments/{commentId}
+// (author-scoped like the outbox, so it stays inside the already-proxied
+// /users/* prefix). The per-post Replies collection advertised from every
+// public Article is NOT a second Fedify dispatcher — Fedify allows exactly one
+// object dispatcher per class and reading lists already own OrderedCollection
+// (a second registration throws RouterError and crashes the backend at boot)
+// — so it is a plain Hono route instead (see routes/replies.ts), mounted ahead
+// of the federation middleware. Together they are what lets Mastodon thread
+// both directions: our responses render under the remote copy of the post, and
+// remote replies already ingested here re-federate as part of the thread.
 function setupNotes(f: Federation<ContextData>) {
   f.setObjectDispatcher(Note, "/users/{identifier}/comments/{commentId}", async (ctx, { identifier, commentId }) => {
     const nctx = await noteContext(federationOrigin(), identifier, commentId);
@@ -242,60 +235,6 @@ function setupNotes(f: Federation<ContextData>) {
       audience: { to: PUBLIC_COLLECTION, cc: ctx.getFollowersUri(identifier) },
     });
   });
-
-  f.setObjectDispatcher(
-    OrderedCollection,
-    "/users/{identifier}/posts/{postId}/replies",
-    async (ctx, { identifier, postId }) => {
-      const user = await usersRepo.findByUsername(identifier);
-      if (!user) return null;
-      const post = await postsRepo.findById(postId);
-      if (!post || post.post.authorId !== user.id) return null;
-      // Served to the whole internet, so private authors' posts 404 here —
-      // the same line isCommentFederable draws for ingest and delivery.
-      if (!isCommentFederable(post.post, user.isPrivate)) return null;
-
-      const origin = federationOrigin();
-      const postUri = postApUri(origin, post.post);
-      const rows = await commentsRepo.listForReplies(post.post.id);
-      const items = rows.map((row) => {
-        const inReplyTo = new URL(postUri);
-        const url = new URL(`${postUri}#comment-${row.comment.id}`);
-        const audience = { to: PUBLIC_COLLECTION, cc: ctx.getFollowersUri(identifier) };
-        if (row.author) {
-          return buildNote(identifier, {
-            id: new URL(row.comment.apId ?? commentApUri(origin, row.author.username, row.comment.id)),
-            attribution: ctx.getActorUri(row.author.username),
-            contentHtml: textToNoteHtml(row.comment.content),
-            published: row.comment.createdAt,
-            inReplyTo,
-            url,
-            audience,
-          });
-        }
-        // An ingested remote reply, re-served so the thread is complete for
-        // whoever fetches the collection. Attribution stays the original
-        // actor's id — we are not its author.
-        return buildNote(identifier, {
-          id: new URL(row.comment.apId!),
-          attribution: new URL(row.remoteActor!.apId),
-          contentHtml: textToNoteHtml(row.comment.content),
-          published: row.comment.createdAt,
-          inReplyTo,
-          url,
-          audience,
-        });
-      });
-
-      return new OrderedCollection({
-        id: ctx.getObjectUri(OrderedCollection, { identifier, postId }),
-        totalItems: await commentsRepo.countTopLevel(post.post.id),
-        // Capped at the oldest 20 (see listForReplies): enough for a thread
-        // view without turning one popular post into a megabyte.
-        items,
-      });
-    },
-  );
 }
 
 // Drops inbound activities whose sender is on a defederated domain (exact host

--- a/apps/backend/src/federation/mod_test.ts
+++ b/apps/backend/src/federation/mod_test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+// Boot regression test: constructing the Federation object must not throw.
+// Dispatchers are only *registered* here (no I/O, no database), so this catches
+// exactly the failure that once crash-looped the backend in production — two
+// object dispatchers for one vocabulary class, which Fedify rejects with a
+// RouterError. Any future dispatcher registration runs through this.
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/config.ts", () => ({
+  config: {},
+}));
+
+import { getFederation } from "@/federation/mod.ts";
+
+describe("getFederation", () => {
+  it("registers every dispatcher without throwing", () => {
+    expect(() => getFederation()).not.toThrow();
+  });
+});

--- a/apps/backend/src/federation/note.ts
+++ b/apps/backend/src/federation/note.ts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Context } from "@fedify/fedify";
-import { isActor, Note } from "@fedify/fedify/vocab";
+import { isActor, Note, OrderedCollection, PUBLIC_COLLECTION } from "@fedify/fedify/vocab";
 import * as commentsRepo from "@/db/repositories/comments.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import type { PostWithAuthor } from "@/db/repositories/posts.ts";
@@ -11,7 +11,7 @@ import type { Comment, Post } from "@/db/schema.ts";
 import { isPubliclyAddressed } from "@/federation/article.ts";
 import { cacheActor } from "@/federation/remote.ts";
 import { sameOrigin } from "@/lib/domain.ts";
-import { htmlToText } from "@/lib/html.ts";
+import { htmlToText, textToNoteHtml } from "@/lib/html.ts";
 import { federationOrigin } from "@/services/federationState.ts";
 import * as notifications from "@/services/notifications.ts";
 
@@ -347,6 +347,63 @@ export async function ingestNoteDelete(objectHref: string, actorHref: string): P
   const actor = await remoteActorsRepo.findByApId(actorHref);
   if (!actor || actor.id !== existing.remoteActorId) return;
   await commentsRepo.remove(existing.id);
+}
+
+// Builds the post's Replies collection payload (plain JSON-LD, ready to
+// serve): the oldest 20 top-level responses — local and ingested remote alike
+// — with an honest `totalItems`. Served by a plain Hono route (see
+// routes/replies.ts), not a Fedify object dispatcher: Fedify allows exactly
+// one dispatcher per object class and reading lists already own
+// OrderedCollection, so a second registration crashes the backend at boot.
+// Null when the post isn't local, is unpublished, or belongs to a private
+// author — the collection is public, so it must never name those.
+export async function repliesPayload(
+  origin: string,
+  identifier: string,
+  postId: string,
+): Promise<Record<string, unknown> | null> {
+  const user = await usersRepo.findByUsername(identifier);
+  if (!user) return null;
+  const post = await postsRepo.findById(postId);
+  if (!post || post.post.authorId !== user.id) return null;
+  if (!isCommentFederable(post.post, user.isPrivate)) return null;
+
+  const postUri = postApUri(origin, post.post);
+  const followersUri = `${origin}/users/${identifier}/followers`;
+  const rows = await commentsRepo.listForReplies(post.post.id);
+  const items = rows.map((row) => {
+    const common = {
+      contentHtml: textToNoteHtml(row.comment.content),
+      published: row.comment.createdAt,
+      inReplyTo: new URL(postUri),
+      url: new URL(`${postUri}#comment-${row.comment.id}`),
+      audience: { to: PUBLIC_COLLECTION, cc: new URL(followersUri) },
+    };
+    if (row.author) {
+      return buildNote(identifier, {
+        ...common,
+        id: new URL(row.comment.apId ?? commentApUri(origin, row.author.username, row.comment.id)),
+        attribution: new URL(`${origin}/users/${row.author.username}`),
+      });
+    }
+    // An ingested remote reply, re-served so the thread is complete for
+    // whoever fetches the collection. Attribution stays the original actor's
+    // id — we are not its author. Remote rows always carry an apId.
+    return buildNote(identifier, {
+      ...common,
+      id: new URL(row.comment.apId!),
+      attribution: new URL(row.remoteActor!.apId),
+    });
+  });
+
+  const collection = new OrderedCollection({
+    id: new URL(`${origin}/users/${identifier}/posts/${post.post.id}/replies`),
+    totalItems: await commentsRepo.countTopLevel(post.post.id),
+    // Capped at the oldest 20 (see listForReplies): enough for a thread view
+    // without turning one popular post into a megabyte.
+    items,
+  });
+  return (await collection.toJsonLd()) as Record<string, unknown>;
 }
 
 // Finds a comment by ActivityPub URI: exact `apId` match first (remote Notes

--- a/apps/backend/src/routes/replies.ts
+++ b/apps/backend/src/routes/replies.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { Hono } from "hono";
+import { repliesPayload } from "@/federation/note.ts";
+import { federationOrigin } from "@/services/federationState.ts";
+
+// A post's Replies collection as plain JSON-LD. Mounted ahead of the Fedify
+// middleware (see app.ts) so this path answers here instead of 404ing inside
+// Fedify, which owns no dispatcher for it. Remote servers discover the URI
+// from the Article's `replies` property and fetch it to render the thread.
+export const repliesRoutes = new Hono();
+
+repliesRoutes.get("/users/:identifier/posts/:postId/replies", async (c) => {
+  const payload = await repliesPayload(federationOrigin(), c.req.param("identifier"), c.req.param("postId"));
+  if (!payload) return c.notFound();
+  return c.json(payload, 200, { "content-type": "application/activity+json" });
+});


### PR DESCRIPTION
## The symptom

Production outage: after deploying #138, the backend crash-looped at boot (`RouterError: Object dispatcher for OrderedCollection already set`), so Caddy could reach neither the app nor its TLS ask endpoint — the whole site served `SSL_ERROR_INTERNAL_ERROR_ALERT`.

## The root cause

Fedify allows exactly **one** object dispatcher per vocabulary class. Reading lists already register one for `OrderedCollection` (`setupLists`), and #138 registered a second for the post Replies collection (`setupNotes`). Registration throws, the throw happens inside `getFederation()` during `buildApp()`, the process dies, Docker restarts it, repeat.

Why CI missed it: the Docker build only builds the image, backend tests are unit-level (no boot), and svelte-check pins serializer shapes — nothing constructs the Federation object.

## The fix

- The Replies collection is now a plain Hono JSON route (`routes/replies.ts`, logic in `note.ts:repliesPayload`) at the **same URI**, mounted ahead of the Fedify middleware exactly like the NodeInfo routes. No Caddy change, no URI change, still inside `/users/*` (bypasses Anubis like all federation traffic).
- `setupNotes` keeps only the `Note` dispatcher (no conflict — sole registrant for that class).
- Adds `federation/mod_test.ts`: constructing the Federation object must not throw. This test fails on the pre-fix code and passes now — the missing gate, permanently installed.

## What was verified

- `deno task check` 4/4 (type, fmt, lint, 295 tests incl. the new boot test).
- The production stack trace is the negative control: the same `getFederation()` path threw there.

## Deploy notes

Backend-only change: `docker compose up -d --build backend` on the host. No migration, no Caddy change. Caddy needs no recreate — once the backend answers, the pending on-demand issuance completes from the existing `caddy_data` state.