### PR TITLE
feat(backup): restic sidecar with daily snapshots, S3-compatible off-site

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -146,3 +146,35 @@
 #UPLOADS_DIR=/data/uploads
 # Where generated secrets are persisted when not supplied via env/files.
 #STATE_DIR=/data/state
+
+# ── Backups (on by default, local — nothing to set) ──
+# Daily encrypted snapshots (database + uploads + state + secrets) via restic.
+# Out of the box they stay on this host in the `backups` volume: a fresh
+# `docker compose up` is already protected against accidental deletes. To also
+# survive disk loss, point the repository at S3-compatible storage (Cloudflare
+# R2, AWS S3, MinIO, Backblaze B2, …) — only the endpoint + keys change,
+# nothing else (no vendor lock-in; restic's format is open).
+#   Manual run:  docker compose exec backup backup-now
+#   List:        docker compose exec backup restic snapshots
+#   Restore:     ./backup/restore.sh [snapshot-id]   (stops backend, restores, restarts)
+#BACKUP_ENABLED=true
+# Daily at 02:00 UTC (5-field cron, UTC — the container runs on UTC).
+#BACKUP_SCHEDULE=0 2 * * *
+# Local default (stays on this host). Off-site examples:
+#   R2:     s3:https://<account-id>.r2.cloudflarestorage.com/omicron-backups
+#   AWS:    s3:s3.amazonaws.com/omicron-backups   (+ BACKUP_S3_REGION below)
+#   MinIO:  s3:http://minio:9000/omicron-backups
+#BACKUP_REPOSITORY=/backups/restic
+# Region for S3-compatible backends ("auto" is what R2 wants; for AWS set e.g.
+# eu-central-1). Ignored for the local default. AWS_DEFAULT_REGION wins if set.
+#BACKUP_S3_REGION=auto
+# Keys for the off-site backend (R2 API token, AWS IAM keys, …). Unused locally.
+#AWS_ACCESS_KEY_ID=
+#AWS_SECRET_ACCESS_KEY=
+# Retention: keep the last 3 daily snapshots, plus 1 weekly; older ones are
+# pruned automatically after each run.
+#BACKUP_KEEP_DAILY=3
+#BACKUP_KEEP_WEEKLY=1
+#BACKUP_KEEP_MONTHLY=0
+# Encryption password: auto-generated into the `secrets` volume on first boot.
+# SAVE A COPY OFFLINE (password manager) — backups cannot be restored without it.

--- a/backup/Dockerfile
+++ b/backup/Dockerfile
@@ -1,0 +1,15 @@
+# Backup sidecar: pg_dump + restic. Takes daily encrypted snapshots of the
+# database, uploads, state and secrets — to a local volume by default, or to
+# any S3-compatible backend (Cloudflare R2, AWS S3, MinIO, Backblaze B2, …)
+# via BACKUP_REPOSITORY. No vendor SDKs involved, restic's format is open.
+#
+# Keep the postgresql client major in sync with the `postgres` service image.
+FROM alpine:3
+RUN apk add --no-cache restic postgresql16-client \
+ && rm -rf /var/cache/apk/*
+COPY db-env.sh backup entrypoint restore-from /usr/local/bin/
+RUN chmod +x /usr/local/bin/db-env.sh /usr/local/bin/backup \
+      /usr/local/bin/entrypoint /usr/local/bin/restore-from \
+ && ln -sf backup /usr/local/bin/backup-now \
+ && mkdir -p /backups /etc/backup
+ENTRYPOINT ["entrypoint"]

--- a/backup/backup
+++ b/backup/backup
@@ -1,0 +1,79 @@
+#!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# One backup run: pg_dump → restic backup → forget/prune → check.
+# Usage: backup [tag]   (tag defaults to "manual"; the daily cron passes
+# "scheduled", the entrypoint passes "boot"). Also available as `backup-now`.
+set -eu
+
+TAG="${1:-manual}"
+
+# shellcheck disable=SC1091
+. /usr/local/bin/db-env.sh
+
+export RESTIC_REPOSITORY="${RESTIC_REPOSITORY:-${BACKUP_REPOSITORY:-/backups/restic}}"
+export RESTIC_PASSWORD_FILE="${RESTIC_PASSWORD_FILE:-${BACKUP_PASSWORD_FILE:-/run/secrets/backup_password}}"
+# One knob for the region (R2 wants "auto"); an explicit AWS_DEFAULT_REGION wins.
+if [ -z "${AWS_DEFAULT_REGION:-}" ] && [ -n "${BACKUP_S3_REGION:-}" ]; then
+  export AWS_DEFAULT_REGION="$BACKUP_S3_REGION"
+fi
+
+if [ ! -s "$RESTIC_PASSWORD_FILE" ]; then
+  echo "backup: password file missing or empty: $RESTIC_PASSWORD_FILE" >&2
+  exit 1
+fi
+
+# Fixed staging path (not mktemp): restic records absolute source paths, so a
+# stable path keeps the dump at the same location in every snapshot, which is
+# what restore-from relies on.
+STAGE=/tmp/omicron-backup
+mkdir -p "$STAGE"
+DUMP="$STAGE/db.dump"
+
+echo "backup [$TAG]: dumping database…"
+if [ -n "${DATABASE_URL:-}" ]; then
+  pg_dump --dbname="$DATABASE_URL" --format=custom --file="$DUMP"
+else
+  pg_dump --format=custom --dbname="$PGDATABASE" --file="$DUMP"
+fi
+
+echo "backup [$TAG]: opening repository $RESTIC_REPOSITORY…"
+if ! restic snapshots >/dev/null 2>&1; then
+  echo "backup [$TAG]: initialising new repository…"
+  restic init
+fi
+
+# Only back up sources that exist right now (config mounts may be absent on
+# exotic setups); a missing path would fail the whole run.
+SOURCES="$DUMP"
+for path in /data/uploads /data/state /run/secrets /etc/caddy/Caddyfile /data/cfg/botPolicy.yaml; do
+  if [ -e "$path" ]; then
+    SOURCES="$SOURCES $path"
+  fi
+done
+
+echo "backup [$TAG]: storing snapshot…"
+# shellcheck disable=SC2086
+restic backup --host omicron --tag "$TAG" $SOURCES
+
+echo "backup [$TAG]: pruning…"
+FORGET_ARGS=""
+for spec in "DAILY:${BACKUP_KEEP_DAILY:-3}:--keep-daily" \
+            "WEEKLY:${BACKUP_KEEP_WEEKLY:-1}:--keep-weekly" \
+            "MONTHLY:${BACKUP_KEEP_MONTHLY:-0}:--keep-monthly"; do
+  value="${spec#*:}"; value="${value%%:*}"
+  flag="${spec##*:}"
+  case "$value" in
+    ''|*[!0-9]*) echo "backup [$TAG]: ignoring non-numeric retention: $value" ;;
+    0) ;;
+    *) FORGET_ARGS="$FORGET_ARGS $flag $value" ;;
+  esac
+done
+# shellcheck disable=SC2086
+restic forget --prune $FORGET_ARGS
+
+echo "backup [$TAG]: checking repository…"
+restic check
+
+echo "backup [$TAG]: done."
+restic snapshots --compact

--- a/backup/db-env.sh
+++ b/backup/db-env.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Shared Postgres connection resolution for the backup sidecar. Mirrors the
+# backend's resolveDatabaseUrl(): an explicit DATABASE_URL wins, otherwise the
+# libpq variables are set from POSTGRES_* parts with the password read from
+# POSTGRES_PASSWORD_FILE (Docker secret) or POSTGRES_PASSWORD.
+#
+# Provides: DATABASE_URL (when explicit) or PGHOST/PGPORT/PGUSER/PGDATABASE/
+# PGPASSWORD. pg_dump/pg_restore/psql honour both. Source, don't execute.
+
+# Cron jobs don't inherit the container environment, so re-import the snapshot
+# the entrypoint saved at boot when it exists.
+if [ -f /etc/backup/env.sh ]; then
+  # shellcheck disable=SC1091
+  . /etc/backup/env.sh
+fi
+
+if [ -n "${DATABASE_URL:-}" ]; then
+  export DATABASE_URL
+  return 0 2>/dev/null || exit 0
+fi
+
+_backup_password() {
+  if [ -n "${POSTGRES_PASSWORD_FILE:-}" ] && [ -s "$POSTGRES_PASSWORD_FILE" ]; then
+    tr -d '\r\n' < "$POSTGRES_PASSWORD_FILE"
+  elif [ -n "${POSTGRES_PASSWORD:-}" ]; then
+    printf '%s' "$POSTGRES_PASSWORD"
+  fi
+}
+
+PGPASSWORD="$(_backup_password)"
+if [ -z "$PGPASSWORD" ]; then
+  echo "backup: no database password (set DATABASE_URL or POSTGRES_PASSWORD_FILE/POSTGRES_PASSWORD)" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+export PGPASSWORD
+export PGHOST="${POSTGRES_HOST:-postgres}"
+export PGPORT="${POSTGRES_PORT:-5432}"
+export PGUSER="${POSTGRES_USER:-omicron}"
+export PGDATABASE="${POSTGRES_DB:-omicron}"

--- a/backup/entrypoint
+++ b/backup/entrypoint
@@ -1,0 +1,41 @@
+#!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Backup sidecar entrypoint: snapshot the environment for cron jobs, run one
+# backup at boot (fail fast on bad config), then serve the daily schedule.
+set -eu
+
+if [ "${BACKUP_ENABLED:-true}" != "true" ]; then
+  echo "backup: BACKUP_ENABLED is not 'true' — sleeping (no backups will run)."
+  exec sleep infinity
+fi
+
+SCHEDULE="${BACKUP_SCHEDULE:-0 2 * * *}"
+REPO="${BACKUP_REPOSITORY:-/backups/restic}"
+
+mkdir -p /backups /etc/backup
+touch /var/log/backup.log
+
+# BusyBox crond does not pass the container environment to its jobs, so
+# persist the backup-relevant variables for db-env.sh to re-import. Values are
+# single-quoted (awk printf has no sed-& pitfall); none of these are multiline.
+env | grep -E '^(BACKUP_|RESTIC_|AWS_|DATABASE_URL|POSTGRES_|PG)' \
+  | awk -F= '{ v = substr($0, length($1) + 2); gsub(/\x27/, "\x27\\\x27\x27", v); printf "export %s=\x27%s\x27\n", $1, v }' \
+  > /etc/backup/env.sh || true
+chmod 600 /etc/backup/env.sh
+
+echo "backup: repository: $REPO"
+echo "backup: schedule (UTC): $SCHEDULE"
+
+echo "backup: running initial backup…"
+if /usr/local/bin/backup boot >>/var/log/backup.log 2>&1; then
+  echo "backup: initial backup OK."
+else
+  echo "backup: initial backup FAILED (see /var/log/backup.log) — keeping the schedule so it retries."
+fi
+
+printf '%s . /etc/backup/env.sh; /usr/local/bin/backup scheduled >> /var/log/backup.log 2>&1\n' \
+  "$SCHEDULE" > /etc/crontabs/root
+
+echo "backup: schedule installed; waiting."
+exec crond -f -d 8

--- a/backup/restore-from
+++ b/backup/restore-from
@@ -1,0 +1,40 @@
+#!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Restore database + uploads + state from a staging dir populated by
+# `restic restore --target <staging-dir>`. Runs inside the backup container
+# (it has the DB credentials and writable uploads/state mounts). Called by
+# backup/restore.sh — never run by hand against a live instance.
+set -eu
+
+STAGE="${1:?usage: restore-from <staging-dir>}"
+DUMP="$STAGE/tmp/omicron-backup/db.dump"
+
+if [ ! -f "$DUMP" ]; then
+  echo "restore-from: database dump not found: $DUMP" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+. /usr/local/bin/db-env.sh
+
+echo "restore-from: restoring database…"
+if [ -n "${DATABASE_URL:-}" ]; then
+  pg_restore --clean --if-exists --no-owner --dbname="$DATABASE_URL" "$DUMP"
+else
+  pg_restore --clean --if-exists --no-owner --dbname="$PGDATABASE" "$DUMP"
+fi
+
+restore_dir() {
+  if [ -d "$STAGE/$1" ]; then
+    cp -a "$STAGE/$1/." "/$1/"
+    echo "restore-from: restored $1"
+  else
+    echo "restore-from: not in snapshot, skipping: $1"
+  fi
+}
+restore_dir data/uploads
+restore_dir data/state
+
+rm -rf "$STAGE"
+echo "restore-from: done."

--- a/backup/restore.sh
+++ b/backup/restore.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# Restore this instance from a backup snapshot.
+# Usage: ./backup/restore.sh [snapshot-id]   (default: latest)
+#
+# Restores the database, uploads and state, then restarts the backend.
+# Secrets are deliberately NOT overwritten (a stale db_password would lock
+# Postgres out): the script prints how to inspect them instead.
+set -eu
+cd "$(dirname "$0")/.."
+
+SNAP="${1:-latest}"
+
+echo "==> available snapshots:"
+docker compose exec backup restic snapshots
+
+echo "==> restoring snapshot '$SNAP' into the backup container's staging area…"
+docker compose exec backup restic restore "$SNAP" --target /tmp/omicron-restore
+
+echo "==> stopping backend (postgres stays up)…"
+docker compose stop backend
+
+echo "==> restoring database + uploads + state…"
+docker compose exec backup restore-from /tmp/omicron-restore
+
+echo "==> starting backend…"
+docker compose start backend
+
+cat <<EOF
+==> done. Notes:
+- Files created after the snapshot was taken are left in place; uploads that
+  nothing references anymore are cleaned up by the daily upload GC.
+- Secrets were NOT touched. If you need them (e.g. rebuilding on a new host):
+    docker compose exec backup restic restore $SNAP --target /tmp/omicron-secrets
+    docker cp "\$(docker compose ps -q backup):/tmp/omicron-secrets/run/secrets" ./restored-secrets
+  then copy the files you need and remove the staging dir:
+    docker compose exec backup rm -rf /tmp/omicron-secrets
+EOF

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - -c
       - |
         set -e
-        for name in db_password session_secret anubis_ed25519_key; do
+        for name in db_password session_secret anubis_ed25519_key backup_password; do
           f="/secrets/$$name"
           if [ ! -s "$$f" ]; then
             head -c 32 /dev/urandom | od -An -tx1 | tr -d ' \n' > "$$f"
@@ -174,6 +174,60 @@ services:
       # just for local debugging, not on the public interface.
       - "127.0.0.1:5173:3000"
 
+  # Encrypted daily backups (database dump + uploads + state + secrets) with
+  # restic. Enabled out of the box and local-only by default — snapshots land
+  # in the `backups` volume, so a fresh `up` needs no config for basic safety
+  # against accidental deletes. Point BACKUP_REPOSITORY at an S3-compatible
+  # backend (Cloudflare R2, AWS S3, MinIO, Backblaze B2, …) to also survive
+  # disk loss; only the endpoint + keys change (no vendor lock-in, open format).
+  #   Manual run:  docker compose exec backup backup-now
+  #   List:        docker compose exec backup restic snapshots
+  #   Restore:     ./backup/restore.sh [snapshot-id]
+  backup:
+    build: ./backup
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      init-secrets:
+        condition: service_completed_successfully
+    environment:
+      BACKUP_ENABLED: ${BACKUP_ENABLED:-true}
+      BACKUP_SCHEDULE: "${BACKUP_SCHEDULE:-0 2 * * *}"
+      BACKUP_REPOSITORY: ${BACKUP_REPOSITORY:-/backups/restic}
+      BACKUP_KEEP_DAILY: ${BACKUP_KEEP_DAILY:-3}
+      BACKUP_KEEP_WEEKLY: ${BACKUP_KEEP_WEEKLY:-1}
+      BACKUP_KEEP_MONTHLY: ${BACKUP_KEEP_MONTHLY:-0}
+      BACKUP_PASSWORD_FILE: /run/secrets/backup_password
+      # Direct restic bindings so `docker compose exec backup restic …` works too.
+      RESTIC_REPOSITORY: ${BACKUP_REPOSITORY:-/backups/restic}
+      RESTIC_PASSWORD_FILE: /run/secrets/backup_password
+      DATABASE_URL: ${DATABASE_URL:-}
+      POSTGRES_USER: ${POSTGRES_USER:-omicron}
+      POSTGRES_DB: ${POSTGRES_DB:-omicron}
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-}
+      POSTGRES_PASSWORD_FILE: /run/secrets/db_password
+      BACKUP_S3_REGION: ${BACKUP_S3_REGION:-auto}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+      AWS_DEFAULT_REGION: ${AWS_DEFAULT_REGION:-}
+    volumes:
+      # Uploads/state are writable here only so restore.sh can copy files back;
+      # daily backups only ever read. Secrets stay read-only (restored by hand).
+      - backups:/backups
+      - uploads:/data/uploads
+      - state:/data/state
+      - secrets:/run/secrets:ro
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./botPolicy.yaml:/data/cfg/botPolicy.yaml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pidof crond"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+
   # AI-scraper shield. A proof-of-work challenge that browser-like scrapers
   # can't pass but real browsers solve in ~1s. It always runs but only sits in
   # the request path when an admin enables protection (Admin → Security), which
@@ -263,6 +317,7 @@ volumes:
   uploads:
   state:
   secrets:
+  backups:
   redis_data:
   caddy_data:
   caddy_config:


### PR DESCRIPTION
## Symptom

Instances had no automated backups — only ad-hoc pg_dump files left on the host (this instance had two: `omicron-db-2026-08-03.dump`, `omicron-backup-2026-08-31-1432.sql`). A lost `pgdata`/`uploads` volume meant a lost instance, and there was no documented restore path.

## Root cause

No backup component existed in the stack. The compose file persisted data in named volumes but nothing ever copied it anywhere.

## Fix (and why this fix)

New `backup` sidecar service (`backup/`: alpine + restic + postgresql16-client, ~60 MiB image) that runs `pg_dump` (custom format, never raw pgdata files) plus restic backup/forget-prune/check on a cron schedule — instead of the alternatives:

- **pg_dump + rclone**: simpler, but no dedup/encryption/retention without hand-rolled scripts.
- **WAL-G/pgBackRest**: point-in-time recovery, but heavy operationally for a small instance.
- **Managed DB backups**: vendor lock-in, rejected per project goals.

Restic was chosen because dedup + AES-256 authenticated encryption + retention are built in, the repo format is open, and R2/S3/MinIO/B2 are all the same S3-compatible backend — switching vendors is one env var, no code change.

Defaults keep the zero-config promise: enabled, local `backups` volume, daily 02:00 UTC, keep 3 daily + 1 weekly. Secrets stay `:ro` (restored by hand — a stale `db_password` would lock Postgres out); uploads/state are writable only so `restore.sh` can copy files back.

```
Manual run:  docker compose exec backup backup-now
List:        docker compose exec backup restic snapshots
Restore:     ./backup/restore.sh [snapshot-id]
```

Encryption password is auto-generated into the `secrets` volume (`backup_password`); the operator must save a copy offline.

## What was verified

- Image builds (restic 0.18.1 + postgresql16-client on alpine).
- Full cycle against throwaway Postgres (podman): boot backup → manual backup → DROP TABLE + deleted upload → restore — row and file both recovered byte-identical.
- Cron fires on schedule with the persisted env snapshot; `BACKUP_ENABLED=false` sleeps quietly.
- Deployed on the live instance (45.74.244.245): initial + manual snapshots present (`restic snapshots` shows boot + manual, ~5.8 MiB), whole stack healthy after rebuild.
- `sh -n` clean on all scripts; `docker-compose.yml` parses.

## Not verified

- No live R2/S3 round-trip yet (local repo only) — worth one `backup-now` after setting `BACKUP_REPOSITORY` + keys.

## Deploy notes

Plain `docker compose up -d --build` is enough. `init-secrets` generates `backup_password` on existing instances automatically. **Save the encryption password offline** (`docker compose exec backup cat /run/secrets/backup_password`) — without it backups cannot be restored.