### PR TITLE
docs: back-up-before-danger rule plus AGENTS.md pointer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# AGENTS.md
+
+Agent instructions for this repo live in [CLAUDE.md](./CLAUDE.md) — it is the
+single source of truth. Follow it exactly; do not duplicate its rules here.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,17 @@
 # CLAUDE.md
 
+## Safety (STRICT)
+
+Before any dangerous operation — migrations, upgrades, restores, manual DB
+writes, volume deletes — take a backup first and confirm the snapshot exists:
+
+```sh
+docker compose exec backup backup-now
+docker compose exec backup restic snapshots
+```
+
+No user data is ever lost to an untested change.
+
 ## Project Overview
 
 This is a **federated blogging platform** (Medium-like, ActivityPub-powered).


### PR DESCRIPTION
## What was missing

Agents working in this repo were never told to snapshot before dangerous operations. One migration or manual DB write away from losing user data with no recovery path — even though the backup sidecar (#140) makes a snapshot one command.

Addition, not a correction: nothing documented was wrong.

## What changed

- `CLAUDE.md`: new STRICT Safety section — `backup-now` + confirm snapshot before migrations, upgrades, restores, manual DB writes, volume deletes.
- `AGENTS.md` (new): three lines deferring to `CLAUDE.md` as the single source of truth, so rules can't drift between two files.

## Checks

CI only — docs-only change, no app code touched.