### PR TITLE
docs(claude): do not push AI checkpoint refs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,6 +171,10 @@ shows.
 Never credit an AI assistant as author, co-author, or contributor. No
 `Co-Authored-By` trailers, no "generated with" footers, in commits or PRs.
 
+Do not push AI checkpoint refs (`refs/claude/*`, `refs/cline/*`). They are
+authored as `Claude Code <noreply@anthropic.com>` and add a stale `claude`
+contributor on GitHub. Delete them locally if created.
+
 ### Pull request descriptions
 
 Write them for someone who has not seen the bug. A good one covers:


### PR DESCRIPTION
The symptom: the repo sidebar shows 3 contributors including claude, while the contributors API already lists only 2.

The root cause: Claude Code auto-creates refs/claude/checkpoint-* authored as Claude Code <noreply@anthropic.com>, which GitHub maps to the claude user. The refs were local-only and are now deleted, with no Claude authors left in any ref and no Co-authored-by trailers in origin/main.

The fix: document that refs/claude/* and refs/cline/* must not be pushed, so this does not recur. Merging this also gives GitHub a new commit on the default branch to recalculate the stale sidebar cache.

What was verified: git log --all --author=Claude is empty, git shortlog shows only the two human authors, gh api contributors lists 2, working tree clean except this docs change.

Deploy notes: none, docs only.