### PR TITLE
fix(auth): require email confirmation before sign-in by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,8 +101,11 @@
 #SMTP_USERNAME=
 #SMTP_PASSWORD=
 #SMTP_TLS=false            # implicit TLS (465); false = STARTTLS (587)
-# Require email confirmation before sign-in (for closed/invite instances).
-#EMAIL_VERIFICATION_REQUIRED=false
+# Require email confirmation before sign-in (Mastodon parity: register creates
+# the account but sign-in stays blocked until the link is clicked; links live
+# 24h and a sign-in attempt re-sends). Default true — set "false" only for
+# local dev without working email. The setup-wizard admin is always verified.
+#EMAIL_VERIFICATION_REQUIRED=true
 # Have I Been Pwned check for leaked passwords (k-anonymity, no plaintext leaves the server).
 #HIBP_CHECK_ENABLED=true
 

--- a/apps/backend/src/auth/auth.ts
+++ b/apps/backend/src/auth/auth.ts
@@ -54,6 +54,10 @@ export const auth = betterAuth({
     enabled: true,
     minPasswordLength: 12,
     maxPasswordLength: 128,
+    // When EMAIL_VERIFICATION_REQUIRED is set (the default), Better Auth skips
+    // the session here and returns { token: null, user } — the account row
+    // exists but cannot sign in until the confirmation link is clicked. This
+    // is Mastodon parity: register → "check your inbox" → click → sign in.
     autoSignIn: true,
     requireEmailVerification: config.EMAIL_VERIFICATION_REQUIRED,
     password: {
@@ -67,6 +71,12 @@ export const auth = betterAuth({
   },
   emailVerification: {
     sendOnSignUp: true,
+    // Mastodon parity: a sign-in attempt with an unverified address re-sends
+    // the confirmation mail (rate-limited by the login limiter), the link
+    // lives 24 hours, and clicking it signs the user straight in.
+    sendOnSignIn: true,
+    autoSignInAfterVerification: true,
+    expiresIn: 60 * 60 * 24,
     sendVerificationEmail: ({ user, token }) => {
       queue.add("send_email_verification", {
         to: user.email,

--- a/apps/backend/src/config.ts
+++ b/apps/backend/src/config.ts
@@ -228,13 +228,17 @@ const schema = z.object({
     .transform((v) => v.toLowerCase() === "true")
     .default(false),
 
-  // When true, new accounts must confirm their email before they can sign in
-  // (the gate for closed/invite instances). When false, verification mail is
-  // still sent as a courtesy but never blocks access.
+  // When true (the default), new accounts must confirm their email before
+  // they can sign in — Mastodon parity: register creates the account but no
+  // session, and sign-in stays blocked until the link is clicked. Set to
+  // "false" only for local development without working email (the
+  // verification link is then only in the backend log via the `console`
+  // transport). The setup-wizard admin is always auto-verified, so the owner
+  // can never be locked out.
   EMAIL_VERIFICATION_REQUIRED: z
     .string()
-    .transform((v) => v.toLowerCase() === "true")
-    .default(false),
+    .transform((v) => v.toLowerCase() !== "false")
+    .default(true),
 
   // Have I Been Pwned k-anonymity check. When false, leaked-password checks are
   // skipped entirely (air-gapped installs).

--- a/apps/backend/src/services/instanceSetup.ts
+++ b/apps/backend/src/services/instanceSetup.ts
@@ -164,6 +164,10 @@ export async function publicInfo(): Promise<{
   federationEnabled: boolean;
   setupComplete: boolean;
   emailEnabled: boolean;
+  // Whether a new account must confirm its email before it can sign in
+  // (EMAIL_VERIFICATION_REQUIRED). The register page reads this to decide
+  // between "check your inbox" and an instant sign-in.
+  emailVerificationRequired: boolean;
   bannerText: string | null;
   bannerImageUrl: string | null;
 }> {
@@ -181,6 +185,7 @@ export async function publicInfo(): Promise<{
     federationEnabled: federationRunning(),
     setupComplete,
     emailEnabled: emailMode !== "console",
+    emailVerificationRequired: config.EMAIL_VERIFICATION_REQUIRED,
     bannerText,
     bannerImageUrl,
   };

--- a/apps/frontend/src/lib/components/Footer.test.ts
+++ b/apps/frontend/src/lib/components/Footer.test.ts
@@ -14,6 +14,7 @@ describe("Footer", () => {
           federationEnabled: true,
           setupComplete: true,
           emailEnabled: false,
+          emailVerificationRequired: true,
           bannerText: null,
           bannerImageUrl: null,
         },

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -403,6 +403,10 @@ export type InstanceInfo = {
   // "check your inbox" — password reset, email verification — have to say so
   // rather than promising a message that will never arrive.
   emailEnabled: boolean;
+  // True when the instance blocks sign-in until the confirmation link is
+  // clicked (EMAIL_VERIFICATION_REQUIRED). Register then ends at
+  // "check your inbox" instead of an instant sign-in.
+  emailVerificationRequired: boolean;
   // Admin-customizable signed-out visitor card; null means "use the built-in
   // default" (a generated sentence / the bundled artwork).
   bannerText: string | null;

--- a/apps/frontend/src/routes/login/+page.svelte
+++ b/apps/frontend/src/routes/login/+page.svelte
@@ -20,6 +20,13 @@
   let showPassword = $state(false);
   let error = $state("");
   let busy = $state(false);
+  // Set when sign-in is refused because the address is not confirmed yet.
+  // Better Auth answers 403 EMAIL_NOT_VERIFIED (and re-sends the link when
+  // sendOnSignIn is on); we surface a resend action rather than a dead end.
+  let needsVerification = $state(false);
+  let resending = $state(false);
+  let resent = $state(false);
+  let resendError = $state("");
 
   const field =
     "h-11 rounded-input border border-input bg-background shadow-btn px-3.5 text-sm outline-hidden transition-colors placeholder:text-muted-foreground focus:border-foreground";
@@ -28,6 +35,9 @@
   async function submit(e: SubmitEvent) {
     e.preventDefault();
     error = "";
+    needsVerification = false;
+    resent = false;
+    resendError = "";
     busy = true;
     try {
       // The single field accepts a username or an email; route to the matching
@@ -36,6 +46,12 @@
         ? await authClient.signIn.email({ email: identifier, password })
         : await authClient.signIn.username({ username: identifier, password });
       if (res.error) {
+        const code = (res.error as { code?: string }).code ?? "";
+        if (code === "EMAIL_NOT_VERIFIED" || /verif|confirm/i.test(res.error.message ?? "")) {
+          needsVerification = true;
+          error = "Check your inbox to confirm your email before signing in — a fresh link is on its way.";
+          return;
+        }
         error = res.error.message ?? "Invalid username or password.";
         return;
       }
@@ -45,6 +61,29 @@
       error = err instanceof Error ? err.message : "Something went wrong.";
     } finally {
       busy = false;
+    }
+  }
+
+  async function resendConfirmation() {
+    // Resending needs the login email; a username alone cannot address it.
+    const addr = identifier.includes("@") ? identifier.trim() : "";
+    if (!addr) {
+      resendError = "Enter your email address above to resend the confirmation link.";
+      return;
+    }
+    resendError = "";
+    resending = true;
+    try {
+      const res = await authClient.sendVerificationEmail({ email: addr, callbackURL: "/verify-email" });
+      if (res.error) {
+        resendError = res.error.message ?? "Something went wrong.";
+        return;
+      }
+      resent = true;
+    } catch (err) {
+      resendError = err instanceof Error ? err.message : "Something went wrong.";
+    } finally {
+      resending = false;
     }
   }
 </script>
@@ -100,7 +139,26 @@
       </button>
     </div>
   </div>
-  {#if error}<p class="text-sm text-destructive" role="alert">{error}</p>{/if}
+  {#if error}
+    <p class="text-sm text-destructive" role="alert">{error}</p>
+    {#if needsVerification}
+      <div class="flex flex-col gap-2">
+        {#if resent}
+          <p class="text-xs text-muted-foreground" aria-live="polite">
+            A fresh link is on its way — it expires in 24 hours.
+          </p>
+        {/if}
+        {#if resendError}<p class="text-xs text-destructive" role="alert">{resendError}</p>{/if}
+        <div class="flex items-center gap-2 text-sm">
+          <Button onclick={resendConfirmation} disabled={resending} variant="link" class="px-0">
+            {resending ? "Sending…" : "Resend confirmation link"}
+          </Button>
+          <span class="text-muted-foreground">·</span>
+          <Button href="/verify-email" variant="link" class="px-0">Enter a different email</Button>
+        </div>
+      </div>
+    {/if}
+  {/if}
   <Button type="submit" disabled={busy} variant="solid" class="mt-1 h-11">
     {busy ? "Signing in…" : "Sign in"}
   </Button>

--- a/apps/frontend/src/routes/register/+page.svelte
+++ b/apps/frontend/src/routes/register/+page.svelte
@@ -14,6 +14,9 @@
 
   const instance = $derived(page.data.instance as InstanceInfo | null);
   const appName = $derived(instance?.name || env.PUBLIC_APP_NAME || "Omicron");
+  // Fail closed on stale data: an instance that does not advertise the flag
+  // is treated as requiring confirmation (the backend default).
+  const verificationRequired = $derived(instance?.emailVerificationRequired !== false);
 
   const MAX_DISPLAY_NAME_LEN = 60;
 
@@ -27,6 +30,10 @@
   let showConfirm = $state(false);
   let error = $state("");
   let busy = $state(false);
+  let registeredEmail = $state("");
+  let resending = $state(false);
+  let resent = $state(false);
+  let resendError = $state("");
   let touched = $state({ username: false, email: false, password: false, confirm: false, terms: false });
 
   let pwned = $state<boolean | null>(null);
@@ -153,6 +160,14 @@
         error = res.error.message ?? "Something went wrong.";
         return;
       }
+      // With confirmation required the account exists but has no session yet
+      // (Better Auth returns token: null) — Mastodon parity: end at
+      // "check your inbox", never signed in. Without it, keep the instant
+      // sign-in.
+      if (verificationRequired) {
+        registeredEmail = email.trim();
+        return;
+      }
       await invalidateAll();
       goto("/");
     } catch (err) {
@@ -161,223 +176,269 @@
       busy = false;
     }
   }
+
+  async function resendConfirmation() {
+    resendError = "";
+    resending = true;
+    try {
+      const res = await authClient.sendVerificationEmail({ email: registeredEmail, callbackURL: "/verify-email" });
+      if (res.error) {
+        resendError = res.error.message ?? "Something went wrong.";
+        return;
+      }
+      resent = true;
+    } catch (err) {
+      resendError = err instanceof Error ? err.message : "Something went wrong.";
+    } finally {
+      resending = false;
+    }
+  }
 </script>
 
 <PageTitle text="Create account" />
 
-<div class="mb-8 text-center">
-  <div class="mb-4 flex justify-center"><img src={logo} alt="" class="h-12 w-auto" /></div>
-  <h1 class="text-2xl font-bold tracking-tight text-foreground">Create your account</h1>
-  <p class="mt-1.5 text-sm text-muted-foreground">
-    {#if instance?.federationEnabled}
-      Join {appName} and follow writers across the fediverse.
-    {:else}
-      Join {appName} and start writing.
-    {/if}
-  </p>
-</div>
-
-<form onsubmit={submit} class="flex flex-col gap-4" novalidate>
-  <div class="flex flex-col gap-1.5">
-    <Label.Root for="displayName" class={labelClass}
-      >Display name <span class="font-normal text-muted-foreground">(optional)</span></Label.Root
-    >
-    <input
-      id="displayName"
-      bind:value={displayName}
-      autocomplete="name"
-      placeholder="Ada Lovelace"
-      maxlength={MAX_DISPLAY_NAME_LEN}
-      aria-describedby="displayName-hint"
-      class={field}
-    />
-    <p id="displayName-hint" class="text-xs text-muted-foreground">
-      {displayName.length}/{MAX_DISPLAY_NAME_LEN} — shown on posts and your profile. Long names are truncated with an ellipsis;
-      hover to see the full name.
+{#if registeredEmail}
+  <div class="flex flex-col items-center text-center">
+    <div class="mb-5 flex size-14 items-center justify-center rounded-full bg-muted text-foreground">
+      <Icon name="mail" size={26} />
+    </div>
+    <h1 class="text-2xl font-bold tracking-tight text-foreground">Check your inbox</h1>
+    <p class="mt-2 max-w-xs text-sm leading-relaxed text-muted-foreground">
+      Your account is created. Click the confirmation link we sent to
+      <span class="font-medium text-foreground">{registeredEmail}</span> to activate it, then sign in. The link expires in
+      24 hours.
     </p>
-    {#if displayName.length > MAX_DISPLAY_NAME_LEN}
-      <p class="text-xs text-destructive" aria-live="polite">
-        Display name must be at most {MAX_DISPLAY_NAME_LEN} characters.
-      </p>
+    {#if resent}
+      <p class="mt-3 text-xs text-muted-foreground" aria-live="polite">A fresh link is on its way.</p>
     {/if}
+    {#if resendError}<p class="mt-3 text-sm text-destructive" role="alert">{resendError}</p>{/if}
+    <Button onclick={resendConfirmation} disabled={resending} variant="outline" class="mt-6 h-11 w-full">
+      {resending ? "Sending…" : "Resend confirmation link"}
+    </Button>
+    <Button href="/login" variant="solid" class="mt-2 h-11 w-full">Back to sign in</Button>
+  </div>
+{:else}
+  <div class="mb-8 text-center">
+    <div class="mb-4 flex justify-center"><img src={logo} alt="" class="h-12 w-auto" /></div>
+    <h1 class="text-2xl font-bold tracking-tight text-foreground">Create your account</h1>
+    <p class="mt-1.5 text-sm text-muted-foreground">
+      {#if instance?.federationEnabled}
+        Join {appName} and follow writers across the fediverse.
+      {:else}
+        Join {appName} and start writing.
+      {/if}
+    </p>
   </div>
 
-  <div class="flex flex-col gap-1.5">
-    <Label.Root for="username" class={labelClass}>Username</Label.Root>
-    <input
-      id="username"
-      bind:value={username}
-      onblur={() => (touched.username = true)}
-      autocomplete="username"
-      autocapitalize="off"
-      spellcheck={false}
-      placeholder="a-z, 0-9, _"
-      aria-invalid={!!usernameError}
-      aria-describedby={usernameError ? "username-error" : undefined}
-      class={field}
-    />
-    <p id="username-error" class={errClass} aria-live="polite">{usernameError}</p>
-  </div>
-
-  <div class="flex flex-col gap-1.5">
-    <Label.Root for="email" class={labelClass}>Email</Label.Root>
-    <input
-      id="email"
-      type="email"
-      bind:value={email}
-      onblur={() => (touched.email = true)}
-      autocomplete="email"
-      spellcheck={false}
-      placeholder="ada@example.com"
-      aria-invalid={!!emailError}
-      aria-describedby={emailError ? "email-error" : "email-hint"}
-      class={field}
-    />
-    {#if emailError}
-      <p id="email-error" class={errClass} aria-live="polite">{emailError}</p>
-    {:else}
-      <p id="email-hint" class="text-xs text-muted-foreground">We’ll send a verification link to this address.</p>
-    {/if}
-  </div>
-
-  <div class="flex flex-col gap-1.5">
-    <Label.Root for="password" class={labelClass}>Password</Label.Root>
-    <div class="relative">
-      <input
-        id="password"
-        type={showPassword ? "text" : "password"}
-        bind:value={password}
-        onblur={() => (touched.password = true)}
-        autocomplete="new-password"
-        placeholder={`At least ${MIN_PASSWORD_LEN} characters`}
-        aria-invalid={!!passwordError}
-        aria-describedby="password-error password-reqs password-strength"
-        class={`${field} w-full pr-10`}
-      />
-      <button
-        type="button"
-        onclick={() => (showPassword = !showPassword)}
-        aria-label={showPassword ? "Hide password" : "Show password"}
-        aria-pressed={showPassword}
-        aria-controls="password"
-        title={showPassword ? "Hide password" : "Show password"}
-        class="absolute top-1/2 right-2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+  <form onsubmit={submit} class="flex flex-col gap-4" novalidate>
+    <div class="flex flex-col gap-1.5">
+      <Label.Root for="displayName" class={labelClass}
+        >Display name <span class="font-normal text-muted-foreground">(optional)</span></Label.Root
       >
-        <Icon name="eye" size={16} />
-      </button>
+      <input
+        id="displayName"
+        bind:value={displayName}
+        autocomplete="name"
+        placeholder="Ada Lovelace"
+        maxlength={MAX_DISPLAY_NAME_LEN}
+        aria-describedby="displayName-hint"
+        class={field}
+      />
+      <p id="displayName-hint" class="text-xs text-muted-foreground">
+        {displayName.length}/{MAX_DISPLAY_NAME_LEN} — shown on posts and your profile. Long names are truncated with an ellipsis;
+        hover to see the full name.
+      </p>
+      {#if displayName.length > MAX_DISPLAY_NAME_LEN}
+        <p class="text-xs text-destructive" aria-live="polite">
+          Display name must be at most {MAX_DISPLAY_NAME_LEN} characters.
+        </p>
+      {/if}
     </div>
 
-    {#if password}
-      <div id="password-strength" class="flex items-center gap-1.5">
-        <div class="flex flex-1 gap-1">
-          {#each [1, 2, 3, 4] as i (i)}
-            <div
-              class={`h-1.5 flex-1 rounded-full transition-colors ${i <= strength.score ? (strength.score <= 1 ? "bg-destructive" : strength.score === 2 ? "bg-tertiary" : strength.score === 3 ? "bg-foreground/60" : "bg-foreground") : "bg-muted"}`}
-            ></div>
-          {/each}
-        </div>
-        <span
-          class={`min-w-12 text-right text-xs font-medium ${strength.score <= 1 ? "text-destructive" : strength.score === 2 ? "text-tertiary" : "text-muted-foreground"}`}
+    <div class="flex flex-col gap-1.5">
+      <Label.Root for="username" class={labelClass}>Username</Label.Root>
+      <input
+        id="username"
+        bind:value={username}
+        onblur={() => (touched.username = true)}
+        autocomplete="username"
+        autocapitalize="off"
+        spellcheck={false}
+        placeholder="a-z, 0-9, _"
+        aria-invalid={!!usernameError}
+        aria-describedby={usernameError ? "username-error" : undefined}
+        class={field}
+      />
+      <p id="username-error" class={errClass} aria-live="polite">{usernameError}</p>
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <Label.Root for="email" class={labelClass}>Email</Label.Root>
+      <input
+        id="email"
+        type="email"
+        bind:value={email}
+        onblur={() => (touched.email = true)}
+        autocomplete="email"
+        spellcheck={false}
+        placeholder="ada@example.com"
+        aria-invalid={!!emailError}
+        aria-describedby={emailError ? "email-error" : "email-hint"}
+        class={field}
+      />
+      {#if emailError}
+        <p id="email-error" class={errClass} aria-live="polite">{emailError}</p>
+      {:else}
+        <p id="email-hint" class="text-xs text-muted-foreground">
+          {#if verificationRequired}We’ll send a confirmation link to this address — you’ll need it to sign in.{:else}We’ll
+            send a verification link to this address.{/if}
+        </p>
+      {/if}
+    </div>
+
+    <div class="flex flex-col gap-1.5">
+      <Label.Root for="password" class={labelClass}>Password</Label.Root>
+      <div class="relative">
+        <input
+          id="password"
+          type={showPassword ? "text" : "password"}
+          bind:value={password}
+          onblur={() => (touched.password = true)}
+          autocomplete="new-password"
+          placeholder={`At least ${MIN_PASSWORD_LEN} characters`}
+          aria-invalid={!!passwordError}
+          aria-describedby="password-error password-reqs password-strength"
+          class={`${field} w-full pr-10`}
+        />
+        <button
+          type="button"
+          onclick={() => (showPassword = !showPassword)}
+          aria-label={showPassword ? "Hide password" : "Show password"}
+          aria-pressed={showPassword}
+          aria-controls="password"
+          title={showPassword ? "Hide password" : "Show password"}
+          class="absolute top-1/2 right-2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
         >
-          {#if pwnedChecking}Checking…{:else}{strength.label}{/if}
-        </span>
+          <Icon name="eye" size={16} />
+        </button>
       </div>
-    {/if}
 
-    <ul id="password-reqs" class="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
-      {#each reqs as r (r.id)}
-        <li class={`flex items-center gap-1.5 ${r.ok ? "text-foreground" : "text-muted-foreground"}`}>
+      {#if password}
+        <div id="password-strength" class="flex items-center gap-1.5">
+          <div class="flex flex-1 gap-1">
+            {#each [1, 2, 3, 4] as i (i)}
+              <div
+                class={`h-1.5 flex-1 rounded-full transition-colors ${i <= strength.score ? (strength.score <= 1 ? "bg-destructive" : strength.score === 2 ? "bg-tertiary" : strength.score === 3 ? "bg-foreground/60" : "bg-foreground") : "bg-muted"}`}
+              ></div>
+            {/each}
+          </div>
           <span
-            class={`inline-flex size-4 items-center justify-center rounded-full border text-[10px] ${r.ok ? "border-foreground bg-foreground text-background" : "border-border bg-background"}`}
+            class={`min-w-12 text-right text-xs font-medium ${strength.score <= 1 ? "text-destructive" : strength.score === 2 ? "text-tertiary" : "text-muted-foreground"}`}
           >
-            {#if r.ok}<Icon name="check" size={10} />{/if}
+            {#if pwnedChecking}Checking…{:else}{strength.label}{/if}
           </span>
-          {r.label}
-        </li>
-      {/each}
-    </ul>
-    {#if pwned === true}
-      <p class="text-xs font-medium text-destructive" aria-live="polite">
-        This password was found in a breach — choose a different one.
-      </p>
-    {:else if pwned === false && password.length >= MIN_PASSWORD_LEN}
-      <p class="text-xs text-muted-foreground" aria-live="polite">Not found in known breaches.</p>
-    {/if}
-    {#if passwordError}<p id="password-error" class={errClass} aria-live="polite">{passwordError}</p>{/if}
-  </div>
+        </div>
+      {/if}
 
-  <div class="flex flex-col gap-1.5">
-    <Label.Root for="confirmPassword" class={labelClass}>Confirm password</Label.Root>
-    <div class="relative">
-      <input
-        id="confirmPassword"
-        type={showConfirm ? "text" : "password"}
-        bind:value={confirmPassword}
-        onblur={() => (touched.confirm = true)}
-        autocomplete="new-password"
-        aria-invalid={!!confirmError}
-        aria-describedby={confirmError ? "confirm-error" : undefined}
-        class={`${field} w-full pr-10`}
-      />
-      <button
-        type="button"
-        onclick={() => (showConfirm = !showConfirm)}
-        aria-label={showConfirm ? "Hide password" : "Show password"}
-        aria-pressed={showConfirm}
-        aria-controls="confirmPassword"
-        title={showConfirm ? "Hide password" : "Show password"}
-        class="absolute top-1/2 right-2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
-      >
-        <Icon name="eye" size={16} />
-      </button>
+      <ul id="password-reqs" class="grid grid-cols-1 gap-1 text-xs sm:grid-cols-2">
+        {#each reqs as r (r.id)}
+          <li class={`flex items-center gap-1.5 ${r.ok ? "text-foreground" : "text-muted-foreground"}`}>
+            <span
+              class={`inline-flex size-4 items-center justify-center rounded-full border text-[10px] ${r.ok ? "border-foreground bg-foreground text-background" : "border-border bg-background"}`}
+            >
+              {#if r.ok}<Icon name="check" size={10} />{/if}
+            </span>
+            {r.label}
+          </li>
+        {/each}
+      </ul>
+      {#if pwned === true}
+        <p class="text-xs font-medium text-destructive" aria-live="polite">
+          This password was found in a breach — choose a different one.
+        </p>
+      {:else if pwned === false && password.length >= MIN_PASSWORD_LEN}
+        <p class="text-xs text-muted-foreground" aria-live="polite">Not found in known breaches.</p>
+      {/if}
+      {#if passwordError}<p id="password-error" class={errClass} aria-live="polite">{passwordError}</p>{/if}
     </div>
-    {#if confirmError}<p id="confirm-error" class={errClass} aria-live="polite">{confirmError}</p>{/if}
-  </div>
 
-  <label class="flex items-start gap-2.5 rounded-input border border-border bg-muted/30 p-3">
-    <Checkbox.Root
-      bind:checked={acceptTerms}
-      onCheckedChange={() => (touched.terms = true)}
-      id="terms"
-      aria-invalid={!!termsError}
-      aria-describedby={termsError ? "terms-error" : undefined}
-      class="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-sm border border-input bg-background shadow-btn data-[state=checked]:border-foreground data-[state=checked]:bg-foreground data-[state=checked]:text-background"
-    >
-      {#snippet children({ checked })}
-        {#if checked}<Icon name="check" size={12} />{/if}
-      {/snippet}
-    </Checkbox.Root>
-    <span class="text-sm leading-snug text-foreground">
-      I agree to the <a href="/privacy" class="underline underline-offset-4 hover:text-muted-foreground"
-        >Privacy Policy</a
+    <div class="flex flex-col gap-1.5">
+      <Label.Root for="confirmPassword" class={labelClass}>Confirm password</Label.Root>
+      <div class="relative">
+        <input
+          id="confirmPassword"
+          type={showConfirm ? "text" : "password"}
+          bind:value={confirmPassword}
+          onblur={() => (touched.confirm = true)}
+          autocomplete="new-password"
+          aria-invalid={!!confirmError}
+          aria-describedby={confirmError ? "confirm-error" : undefined}
+          class={`${field} w-full pr-10`}
+        />
+        <button
+          type="button"
+          onclick={() => (showConfirm = !showConfirm)}
+          aria-label={showConfirm ? "Hide password" : "Show password"}
+          aria-pressed={showConfirm}
+          aria-controls="confirmPassword"
+          title={showConfirm ? "Hide password" : "Show password"}
+          class="absolute top-1/2 right-2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <Icon name="eye" size={16} />
+        </button>
+      </div>
+      {#if confirmError}<p id="confirm-error" class={errClass} aria-live="polite">{confirmError}</p>{/if}
+    </div>
+
+    <label class="flex items-start gap-2.5 rounded-input border border-border bg-muted/30 p-3">
+      <Checkbox.Root
+        bind:checked={acceptTerms}
+        onCheckedChange={() => (touched.terms = true)}
+        id="terms"
+        aria-invalid={!!termsError}
+        aria-describedby={termsError ? "terms-error" : undefined}
+        class="mt-0.5 flex size-4 shrink-0 items-center justify-center rounded-sm border border-input bg-background shadow-btn data-[state=checked]:border-foreground data-[state=checked]:bg-foreground data-[state=checked]:text-background"
       >
-      and <a href="/contact" class="underline underline-offset-4 hover:text-muted-foreground">Terms</a>.
-    </span>
-  </label>
-  {#if termsError}<p id="terms-error" class={errClass} aria-live="polite">{termsError}</p>{/if}
+        {#snippet children({ checked })}
+          {#if checked}<Icon name="check" size={12} />{/if}
+        {/snippet}
+      </Checkbox.Root>
+      <span class="text-sm leading-snug text-foreground">
+        I agree to the <a href="/privacy" class="underline underline-offset-4 hover:text-muted-foreground"
+          >Privacy Policy</a
+        >
+        and <a href="/contact" class="underline underline-offset-4 hover:text-muted-foreground">Terms</a>.
+      </span>
+    </label>
+    {#if termsError}<p id="terms-error" class={errClass} aria-live="polite">{termsError}</p>{/if}
 
-  <div class="rounded-input border border-border bg-background px-3 py-2.5">
-    <p class="flex items-center gap-1.5 text-xs font-medium text-foreground">
-      <Icon name="shieldOff" size={14} /> Bot protection
+    <div class="rounded-input border border-border bg-background px-3 py-2.5">
+      <p class="flex items-center gap-1.5 text-xs font-medium text-foreground">
+        <Icon name="shieldOff" size={14} /> Bot protection
+      </p>
+      <p class="mt-1 text-xs leading-relaxed text-muted-foreground">
+        This form is protected by Anubis proof-of-work. Most visitors see no challenge; automated abuse is slowed at the
+        edge.
+      </p>
+    </div>
+
+    {#if error}<p class="text-sm font-medium text-destructive" role="alert" aria-live="assertive">{error}</p>{/if}
+
+    <Button type="submit" disabled={!canSubmit} variant="solid" class="mt-1 h-11" aria-disabled={!canSubmit}>
+      {busy ? "Creating…" : "Create account"}
+    </Button>
+    <p class="text-center text-xs leading-relaxed text-muted-foreground">
+      {#if verificationRequired}
+        After signing up, we’ll email you a confirmation link. Click it to activate your account, then sign in.
+      {:else}
+        After signing up, we’ll email you a verification link. You can sign in right away; verified email may be
+        required later depending on this instance’s settings.
+      {/if}
     </p>
-    <p class="mt-1 text-xs leading-relaxed text-muted-foreground">
-      This form is protected by Anubis proof-of-work. Most visitors see no challenge; automated abuse is slowed at the
-      edge.
-    </p>
-  </div>
+  </form>
 
-  {#if error}<p class="text-sm font-medium text-destructive" role="alert" aria-live="assertive">{error}</p>{/if}
-
-  <Button type="submit" disabled={!canSubmit} variant="solid" class="mt-1 h-11" aria-disabled={!canSubmit}>
-    {busy ? "Creating…" : "Create account"}
-  </Button>
-  <p class="text-center text-xs leading-relaxed text-muted-foreground">
-    After signing up, we’ll email you a verification link. You can sign in right away; verified email may be required
-    later depending on this instance’s settings.
+  <p class="mt-8 text-center text-sm text-muted-foreground">
+    Already have an account?
+    <Button href="/login" variant="link">Sign in</Button>
   </p>
-</form>
-
-<p class="mt-8 text-center text-sm text-muted-foreground">
-  Already have an account?
-  <Button href="/login" variant="link">Sign in</Button>
-</p>
+{/if}

--- a/apps/frontend/src/routes/verify-email/+page.svelte
+++ b/apps/frontend/src/routes/verify-email/+page.svelte
@@ -1,5 +1,6 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
+  import { invalidateAll } from "$app/navigation";
   import { page } from "$app/stores";
   import logo from "$lib/assets/omicron.svg";
   import { authClient } from "$lib/auth-client";
@@ -38,6 +39,9 @@
       errorMsg = res.error.message ?? "This verification link is invalid or has expired.";
       view = "error";
     } else {
+      // With autoSignInAfterVerification the click also signs the user in —
+      // refresh the session so the nav lands in the signed-in state.
+      await invalidateAll();
       view = "success";
     }
   });
@@ -78,9 +82,9 @@
     </div>
     <h1 class="text-2xl font-bold tracking-tight text-foreground">Email confirmed</h1>
     <p class="mt-2 max-w-xs text-sm leading-relaxed text-muted-foreground">
-      Your email address is verified. You're all set.
+      Your email address is verified. You're signed in and all set.
     </p>
-    <Button href="/login" variant="solid" class="mt-6 h-11 w-full">Continue to sign in</Button>
+    <Button href="/" variant="solid" class="mt-6 h-11 w-full">Continue</Button>
   </div>
 {:else if view === "error"}
   <div class="flex flex-col items-center text-center">


### PR DESCRIPTION
## Symptom

A visitor filled in the registration form and landed signed in immediately. Verification mail was sent but never gated anything, so anyone could occupy an arbitrary email address and act before proving ownership.

## Root cause

- `EMAIL_VERIFICATION_REQUIRED` defaulted to `false` (`apps/backend/src/config.ts`), so Better Auth created a session on sign-up (`autoSignIn: true` in `apps/backend/src/auth/auth.ts`).
- The register page (`apps/frontend/src/routes/register/+page.svelte`) unconditionally ran `goto("/")` after sign-up, and nothing distinguished the verified from the unverified state.

## Fix

Mastodon parity — register creates the account but no session:

- `EMAIL_VERIFICATION_REQUIRED` now defaults to `true` (explicit `"false"` opts out for local dev without SMTP). The setup-wizard admin stays auto-verified via the existing create hook, so the owner can never be locked out.
- `emailVerification` now sets `sendOnSignIn: true` (a sign-in attempt with an unverified address re-sends the link, rate-limited by the login limiter), `autoSignInAfterVerification: true`, and `expiresIn: 24h`.
- `publicInfo` exposes `emailVerificationRequired` so the register page can branch; register ends at a "check your inbox" state with resend instead of signing in.
- Login detects `EMAIL_NOT_VERIFIED` and offers a resend action rather than a dead-end error; verify-email refreshes the session on success since the click now signs the user in.
- I checked the bundled better-auth 1.7.2 sources: the username sign-in plugin enforces `requireEmailVerification` the same way email sign-in does, so there is no bypass via the username field.

An alternative considered was letting unverified users sign in but blocking writes; rejected because it leaves identity squatting (someone else's address taken and posting) intact, while Mastodon's confirm-before-first-login is the fediverse standard.

## What was verified

- Frontend `svelte-check`: 0 errors, 0 warnings.
- Frontend `vitest run`: 8 files / 34 tests pass.
- `oxfmt` / `oxlint`: clean.
- Backend tests not run here (`deno` unavailable in this environment) — please run `vitest run src/` in CI.

## Deploy notes

- Takes effect on a plain `docker compose up -d --build` (backend restart). No migration: `email_verified` column already exists.
- Existing unverified sessions stay valid until expiry; all new sign-ins are gated.
- Instances on the default `console` email transport must either configure real mail before inviting readers or set `EMAIL_VERIFICATION_REQUIRED=false`; otherwise new users cannot self-serve confirmation.
- Docs update follows separately in omicron-docs (env default + email page).