### PR TITLE
feat(admin): show total user count on Users tab

### DIFF
--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -293,10 +293,11 @@ adminRoutes.post("/email/test", jsonBody(emailTestSchema), async (c) => {
 // ── Users ──────────────────────────────────────────────────────────────────
 
 // The admin user table, with an optional handle / name filter (?q=).
+// `total` is the unfiltered local-account count for the header.
 adminRoutes.get("/users", async (c) => {
   requireAdmin(c);
-  const rows = await moderation.listUsers(c.req.query("q") ?? "");
-  return c.json({ users: rows.map(adminUserView) });
+  const [rows, total] = await Promise.all([moderation.listUsers(c.req.query("q") ?? ""), moderation.countUsers()]);
+  return c.json({ users: rows.map(adminUserView), total });
 });
 
 const suspendSchema = z.object({ suspend: z.boolean() });

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -75,6 +75,13 @@ export function listUsers(query = ""): Promise<Awaited<ReturnType<typeof usersRe
   return usersRepo.listForAdmin(query);
 }
 
+// Total local accounts, unfiltered — the admin user table's header count.
+// Returned alongside the (possibly filtered / capped) list so the UI can show
+// "N accounts" even while searching.
+export function countUsers(): Promise<number> {
+  return usersRepo.countUsers();
+}
+
 // Suspends or reinstates a local account. Admins cannot suspend themselves or
 // other admins (protects the moderator team from lock-out and abuse). Suspending
 // clears the target's sessions so the block takes effect immediately.

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -132,7 +132,7 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
 
     // admin moderation
     adminUsers: (q?: string) =>
-      api.get<{ users: AdminUser[] }>(`/admin/users${q ? `?q=${encodeURIComponent(q)}` : ""}`),
+      api.get<{ users: AdminUser[]; total: number }>(`/admin/users${q ? `?q=${encodeURIComponent(q)}` : ""}`),
     suspendUser: (id: string, suspend: boolean) => api.post<{ ok: true }>(`/admin/users/${id}/suspend`, { suspend }),
     adminRemovePost: (id: string) => api.del<{ ok: true }>(`/admin/posts/${id}`),
     adminReports: (status?: "open" | "resolved") =>

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -13,6 +13,7 @@
   let { selfId }: { selfId: string } = $props();
 
   let users = $state<AdminUser[]>([]);
+  let total = $state(0);
   let loading = $state(true);
   let error = $state("");
   let query = $state("");
@@ -24,6 +25,7 @@
     try {
       const res = await endpoints().adminUsers(query.trim() || undefined);
       users = res.users;
+      total = res.total;
     } catch (e) {
       error = e instanceof ApiError ? e.message : "Failed to load users.";
     } finally {
@@ -67,6 +69,17 @@
 </script>
 
 <div class="flex flex-col gap-4">
+  <div class="flex items-center gap-2 text-sm text-muted-foreground">
+    <Icon name="users" size={16} />
+    {#if loading}
+      <span>Loading accounts…</span>
+    {:else if query.trim()}
+      <span>{users.length} of {total} {total === 1 ? "account" : "accounts"}</span>
+    {:else}
+      <span>{total} {total === 1 ? "account" : "accounts"} total</span>
+    {/if}
+  </div>
+
   <div class="relative">
     <span class="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground">
       <Icon name="search" size={16} />


### PR DESCRIPTION
## Symptom
Admins opening the Admin → Users tab see a bare search box and a row list, with no sense of instance size. The list is capped at 100 rows and shrinks silently under a search filter, so a growing instance looks identical to an empty one.

## Root cause
`GET /admin/users` returned only the (possibly filtered, capped) row array — `apps/backend/src/routes/admin.ts:296` mapped `moderation.listUsers()` straight to `{ users }`. The unfiltered count already existed in the repo (`usersRepo.countUsers()`) but was never exposed on this endpoint, so the UI had nothing to render as a header.

## Fix
- Backend `GET /admin/users` now returns `{ users, total }`, where `total` is the unfiltered local-account count fetched via a new `moderation.countUsers()` pass-through (keeps the no-direct-DB-in-routes rule intact).
- Frontend `adminUsers` typed as `{ users, total }`; `AdminUsers.svelte` renders a header row above the search box: `N accounts total`, or `M of N accounts` while filtering.
- Why this shape rather than deriving from `users.length`: length lies under both the 100-row cap and an active search; the server-side total stays truthful in both cases.

## Verified
- Frontend `pnpm exec svelte-check`: 0 errors, 0 warnings.
- Backend `pnpm run lint` (oxlint) clean; `pnpm run fmt:check` (oxfmt) clean after auto-format.
- Not verified: live browser run against seeded data; no existing integration test covers `/admin/users` (checked `apps/backend/tests/integration/`).

## Deploy notes
Plain `docker compose up -d --build` is enough. No migrations, no env changes, no Caddy changes. Old frontend against new backend (and vice versa) degrades gracefully — `total` is additive and the list shape is unchanged.