### PR TITLE
fix(frontend): stop scroll gestures that start on the left rail

### DIFF
--- a/apps/frontend/src/lib/actions/noPageScroll.ts
+++ b/apps/frontend/src/lib/actions/noPageScroll.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Makes an element a scroll dead zone: wheel and touch gestures that start on
+// it scroll neither the element nor the page behind it.
+//
+// This exists because a pinned rail with no overflow of its own (such as the
+// left navigation) still lets wheel events bubble through to the window, so
+// scrolling while hovering the rail moves the feed — which reads as the rail
+// itself scrolling. Stopping the gesture at the rail keeps it fixed in every
+// sense, like the discovery rail opposite it.
+//
+// Ctrl+wheel (trackpad pinch-zoom) is deliberately left alone: blocking it
+// would break page zoom, which is an accessibility tool, not scrolling.
+
+export function noPageScroll(node: HTMLElement) {
+  node.addEventListener("wheel", onWheel, { passive: false });
+  node.addEventListener("touchmove", onTouchMove, { passive: false });
+  return {
+    destroy() {
+      node.removeEventListener("wheel", onWheel);
+      node.removeEventListener("touchmove", onTouchMove);
+    },
+  };
+}
+
+function onWheel(e: WheelEvent) {
+  if (e.ctrlKey) return;
+  e.preventDefault();
+}
+
+function onTouchMove(e: TouchEvent) {
+  e.preventDefault();
+}

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -3,6 +3,7 @@
   import "../app.css";
   import { page } from "$app/stores";
   import { env } from "$env/dynamic/public";
+  import { noPageScroll } from "$lib/actions/noPageScroll";
   import { canonicalOrigin } from "$lib/canonical";
   import Discover from "$lib/components/Discover.svelte";
   import Footer from "$lib/components/Footer.svelte";
@@ -414,8 +415,13 @@
     >
       <!-- Left rail: primary navigation. Pinned under the nav (sticky + self-start
            on the grid item itself) with no scroll of its own — only the center
-           column scrolls with the page. -->
-      <aside class="hidden lg:sticky lg:top-24 lg:block lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-hidden">
+           column scrolls with the page. `use:noPageScroll` stops wheel/touch
+           gestures that start here from bubbling into page scroll, so hovering
+           the rail and scrolling moves nothing at all. -->
+      <aside
+        use:noPageScroll
+        class="hidden lg:sticky lg:top-24 lg:block lg:max-h-[calc(100vh-7rem)] lg:self-start lg:overflow-hidden"
+      >
         <SideNav user={data.user} {appName} instance={data.instance} />
       </aside>
 


### PR DESCRIPTION
## Symptom

After #145 pinned the left rail, scrolling with the cursor over the left column still moved the page. The rail has no overflow of its own, but wheel/touch gestures that start on it bubble through to the window and scroll the feed — which reads as the rail itself scrolling.

## Fix

New `noPageScroll` action (`lib/actions/noPageScroll.ts`) applied to the left rail in `+layout.svelte`: non-passive `wheel` + `touchmove` listeners call `preventDefault()`, so a gesture starting on the rail scrolls nothing — neither the rail nor the page. Ctrl+wheel (trackpad pinch-zoom) is exempt so page zoom keeps working. Rail links stay clickable/focusable; keyboard scrolling is unaffected.

Right rail and center feed are untouched.

## Verified

- `pnpm test`: 34/34 vitest pass
- `pnpm lint` (oxlint): clean
- `pnpm fmt:check`: clean
- `pnpm svelte-check`: 0 errors, 0 warnings
- Live-browser check still needed after deploy (same as #145).

## Deploy notes

Frontend-only; `docker compose up -d --build frontend` on the VPS, then hard-refresh. No migrations, no env changes.