### PR TITLE
fix(frontend): default brand and chrome strings to English

### DIFF
--- a/apps/frontend/src/lib/components/PageTitle.svelte
+++ b/apps/frontend/src/lib/components/PageTitle.svelte
@@ -15,8 +15,8 @@
   without threading layout data down to it.
 
   Omit `text` on a page that is the site itself (the home feed) and the title is
-  the instance name plus its tagline — `Omicron: fediverse üzərində müstəqil
-  bloq platforması` — so the home tab, bookmark and search result carry the
+  the instance name plus its tagline — `Omicron: an independent blogging
+  platform on the fediverse` — so the home tab, bookmark and search result carry the
   same promise a reader sees in the hero.
 -->
 <script lang="ts">
@@ -29,7 +29,7 @@
   const appName = $derived(
     ($page.data as { instance?: InstanceInfo | null }).instance?.name || env.PUBLIC_APP_NAME || "Omicron",
   );
-  const homeTitle = $derived(`${appName}: fediverse üzərində müstəqil bloq platforması`);
+  const homeTitle = $derived(`${appName}: an independent blogging platform on the fediverse`);
 </script>
 
 <svelte:head>

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -42,11 +42,11 @@
   // name comes from the instance settings (wizard/admin), falling back to the
   // build-time env and then the default.
   const appName = $derived(data.instance?.name || env.PUBLIC_APP_NAME || "Omicron");
-  const homeTitle = $derived(`${appName}: fediverse üzərində müstəqil bloq platforması`);
-  // 155 chars for `Omicron` (adjusts with instance name): hits the 150–160 target
+  const homeTitle = $derived(`${appName}: an independent blogging platform on the fediverse`);
+  // 152 chars for `Omicron` (adjusts with instance name): hits the 150–160 target
   // search engines show without truncation and matches the hero.
   const description = $derived(
-    `${appName} — fediverse üzərində müstəqil bloq platforması. Yaz, paylaş, kəşf et. ActivityPub ilə birləş, məlumatların sənə aid olsun və öz instansiyanı işlət.`,
+    `${appName} — an independent blogging platform on the fediverse. Write, share, discover. Federate with ActivityPub and own your data. Run your own instance.`,
   );
   // Every absolute URL we publish — the canonical link, og:url, the share image
   // — is built on the instance's configured origin rather than the hostname this

--- a/apps/frontend/src/routes/login/+page.svelte
+++ b/apps/frontend/src/routes/login/+page.svelte
@@ -129,10 +129,10 @@
       <button
         type="button"
         onclick={() => (showPassword = !showPassword)}
-        aria-label={showPassword ? "Parolu gizlət" : "Parolu göstər"}
+        aria-label={showPassword ? "Hide password" : "Show password"}
         aria-pressed={showPassword}
         aria-controls="password"
-        title={showPassword ? "Parolu gizlət" : "Parolu göstər"}
+        title={showPassword ? "Hide password" : "Show password"}
         class="absolute top-1/2 right-2 inline-flex size-7 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
       >
         <Icon name="eye" size={16} />


### PR DESCRIPTION
## Symptom

Browser tab shows `Omicron: fediverse üzərində ...` — the home title and meta description were hardcoded in Azerbaijani, as were the login password-toggle's aria-label/title.

## Fix

- `+layout.svelte`: home title → `{appName}: an independent blogging platform on the fediverse`; meta description rewritten in English (152 chars for `Omicron`, still in the 150–160 SEO window, still matches the hero).
- `PageTitle.svelte`: same home-title string + its doc comment.
- `login/+page.svelte`: password toggle → `Show/Hide password`.

Untouched: locale-aware relative-time formatters, the language picker (Azerbaijani stays a selectable content language), transliteration map — those are user-chosen i18n, not default chrome.

## Verified

- `pnpm test`: 34/34 pass; `pnpm lint`, `pnpm fmt:check` clean; `pnpm svelte-check`: 0/0.
- Repo-wide grep confirms no remaining `müstəqil / Parolu / bloq platforması` strings outside i18n machinery.

## Deploy notes

Frontend-only; `docker compose up -d --build frontend`, hard-refresh. No migrations, no env changes.