### PR TITLE
fix(frontend): keep feed-language header clear of the dismiss button

### DIFF
--- a/apps/frontend/src/lib/components/FeedLanguageFilter.svelte
+++ b/apps/frontend/src/lib/components/FeedLanguageFilter.svelte
@@ -48,8 +48,13 @@
         <Icon name="close" size={13} />
       </ButtonPrimitive.Root>
     {/if}
-    <div class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6">
-      <div class={compact ? "min-w-0 flex-1 pr-8" : "min-w-0 flex-1"}>
+    <!-- Compact card: the dismiss button owns the top-right corner, so the
+         header row stays out of its lane — the text on stacked layouts, the
+         whole row (including the mode toggle) once it sits side by side. -->
+    <div
+      class={`flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between sm:gap-6 ${compact ? "sm:pr-8" : ""}`}
+    >
+      <div class={compact ? "min-w-0 flex-1 pr-8 sm:pr-0" : "min-w-0 flex-1"}>
         <p class="flex items-center gap-1.5 text-sm font-medium text-foreground">
           <Icon name="languages" size={15} /> Feed languages
         </p>


### PR DESCRIPTION
## Symptom

In the compact feed-languages card, the dismiss X sits in the top-right corner almost touching the Show/Hide mode toggle — only the heading text was inset from it, so on layouts where the toggle sits at the row's right end it lands directly under the X.

## Fix

`FeedLanguageFilter.svelte`: the header row now carries the same right inset (`sm:pr-8`) in compact mode, so the toggle keeps the X's lane clear; the text block keeps its own inset only on stacked mobile (where the row inset doesn't apply). Non-compact (settings) layout untouched.

## Verified

- `pnpm test`: 34/34 pass; `pnpm lint`, `pnpm fmt:check` clean; `pnpm svelte-check`: 0/0.
- Visual check on device still needed after deploy.

## Deploy notes

Frontend-only; `docker compose up -d --build frontend`, hard-refresh. No migrations, no env changes.