### PR TITLE
feat(og): generate dynamic share cards for profile pages

### DIFF
--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -112,9 +112,14 @@ export async function setKeyPair(id: string, keyPair: ActorKeyPair) {
 }
 
 // Partial update of mutable profile fields (display name, bio, avatar). Returns
-// the updated row.
+// the updated row. Stamps `updatedAt`, which versions the profile's share card
+// (see services/profileCard.ts) — any profile change is a new card URL.
 export async function update(id: string, data: Partial<NewUser>) {
-  const [row] = await db.update(users).set(data).where(eq(users.id, id)).returning();
+  const [row] = await db
+    .update(users)
+    .set({ ...data, updatedAt: new Date() })
+    .where(eq(users.id, id))
+    .returning();
   return row;
 }
 

--- a/apps/backend/src/lib/profileCard.ts
+++ b/apps/backend/src/lib/profileCard.ts
@@ -1,0 +1,375 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { readFile } from "node:fs/promises";
+import {
+  Drawables,
+  Gravity,
+  ImageMagick,
+  Magick,
+  MagickColor,
+  MagickFormat,
+  MagickImage,
+  Point,
+} from "@imagemagick/magick-wasm";
+import { coveredCodepoints } from "@/lib/fontCoverage.ts";
+import { initializeMagick } from "@/lib/magick.ts";
+
+// The share card drawn for a profile page, in the Substack spirit: who this is,
+// not just that somebody exists here. Avatar on the left, name, handle, bio and
+// a stats line on the right — so a shared profile link says something about the
+// person behind it instead of showing the same brand tile as every other page.
+//
+// Same visual language as the post card (lib/ogCard.ts): the same 1200x630
+// canvas, the same near-black ground, the same short white rule, the same face.
+// Two cards from one instance read as coming from the same place, whether the
+// link points at an article or at its author.
+//
+// Deliberately free of config, database and filesystem concerns — like
+// lib/ogCard.ts, whose caching lives in services/. This module takes plain
+// values plus optional avatar bytes and returns JPEG bytes, which is what makes
+// the layout testable.
+
+// The size every platform documents for a large summary card.
+const WIDTH = 1200;
+const HEIGHT = 630;
+const PAD = 88;
+
+// The vertical band the content lives in. Bounded above by the accent bar and
+// below by the site line, mirroring the post card so the two align side by side
+// in a timeline.
+const BAND_TOP = 132;
+const BAND_BOTTOM = 476;
+const SITE_BASELINE = 578;
+
+// The avatar is a square, cover-cropped: a banner is the author's composition,
+// but an avatar is an identity marker, and letterboxing it would shrink the
+// face it exists to show. Rounded-square fallback (not a circle): the wasm
+// build exposes no circle primitive, and a square photo beside a circle
+// fallback would read as two different designs.
+const AVATAR = 232;
+const AVATAR_X = PAD;
+const AVATAR_RADIUS = 48;
+const AVATAR_FALLBACK_BG = "#27272a";
+
+// The text column starts right of the avatar.
+const TEXT_X = PAD + AVATAR + 48;
+const TEXT_W = WIDTH - PAD - TEXT_X;
+
+// Tried largest-first: a short name gets to be big, a long one shrinks rather
+// than overflowing. Two lines at most — a name is not a paragraph.
+const NAME_SIZES = [64, 58, 52, 46];
+const MAX_NAME_LINES = 2;
+const NAME_LINE_HEIGHT = 1.16;
+const HANDLE_SIZE = 28;
+const BIO_SIZE = 30;
+const BIO_LINE_HEIGHT = 1.35;
+const MAX_BIO_LINES = 3;
+const STATS_SIZE = 26;
+const SITE_SIZE = 26;
+
+const BACKGROUND = "#0a0a0a";
+const NAME_COLOR = "#ffffff";
+const BIO_COLOR = "#e4e4e7";
+const DIM_COLOR = "#71717a";
+
+// Comfortably under WhatsApp's ~600KB ceiling; flat colour and text compress
+// far better than a photograph, so this lands well under it even with a face on
+// it.
+const QUALITY = 85;
+
+// The one face the card is drawn in, registered with ImageMagick under this
+// name. See assets/fonts/README.md for what it is and where it came from.
+const FONT = "omicron-og-card";
+const FONT_PATH = new URL("../../assets/fonts/Inter-SemiBold.ttf", import.meta.url);
+
+// Emoji and other pictographs are stripped before anything is measured. The
+// bundled face has no glyphs for them, and ImageMagick answers a missing glyph
+// with a blank advance rather than an error — so left in they punch holes in
+// the words. A bio minus its decorations is still the bio; a bio with gaps
+// where the rocket was is not.
+const PICTOGRAPHS = /[\p{Extended_Pictographic}\p{Emoji_Presentation}️‍]/gu;
+
+// More characters than the bio block could ever show, with room to spare. A bio
+// has a length limit of its own, but bounding the layout input here keeps one
+// pathological profile from holding a scraper while every measurement crosses
+// the wasm boundary.
+const MAX_BIO_CHARS = 220;
+const MAX_NAME_CHARS = 80;
+
+let fontReady: Promise<Set<number>> | null = null;
+
+/** Registers the card font once and returns what it can draw. */
+function loadFont(): Promise<Set<number>> {
+  if (!fontReady) {
+    fontReady = (async () => {
+      await initializeMagick();
+      const font = await readFile(FONT_PATH);
+      try {
+        Magick.addFont(FONT, font);
+      } catch {
+        // Already registered by the post card in this process — same face,
+        // same name. Registration is the only part that can collide; the
+        // coverage set below is derived from the file bytes either way.
+      }
+      return coveredCodepoints(font);
+    })().catch((err) => {
+      fontReady = null;
+      throw err;
+    });
+  }
+  return fontReady;
+}
+
+function clean(text: string): string {
+  return text.replace(PICTOGRAPHS, " ").replace(/\s+/g, " ").trim();
+}
+
+function drawable(size: number): Drawables {
+  return new Drawables().font(FONT).fontPointSize(size);
+}
+
+function widthOf(text: string, size: number): number {
+  // A failed measurement must not wrap everything onto one overflowing line;
+  // half the point size per character is a deliberate over-estimate, so the
+  // degraded case breaks early rather than running off the card.
+  return drawable(size).fontTypeMetrics(text)?.textWidth ?? text.length * size * 0.5;
+}
+
+function ascentOf(text: string, size: number): number {
+  return drawable(size).fontTypeMetrics(text)?.ascent ?? size * 0.8;
+}
+
+/** Greedy word wrap, breaking inside a word only when the word alone overflows. */
+function wrap(text: string, size: number, width: number): string[] {
+  const lines: string[] = [];
+  let line = "";
+  const push = () => {
+    if (line) lines.push(line);
+    line = "";
+  };
+
+  for (const word of text.split(" ")) {
+    const candidate = line ? `${line} ${word}` : word;
+    if (line && widthOf(candidate, size) > width) {
+      push();
+      line = word;
+    } else {
+      line = candidate;
+    }
+    // An unbroken run of characters can be wider than the column on its own,
+    // and no amount of word wrapping helps — break it where it lands. Binary
+    // search rather than a walk back from the end: each probe is a measurement
+    // through the wasm boundary.
+    while (widthOf(line, size) > width && line.length > 1) {
+      let low = 1;
+      let high = line.length - 1;
+      while (low < high) {
+        const mid = Math.ceil((low + high) / 2);
+        if (widthOf(line.slice(0, mid), size) > width) high = mid - 1;
+        else low = mid;
+      }
+      lines.push(line.slice(0, low));
+      line = line.slice(low);
+    }
+  }
+  push();
+  return lines;
+}
+
+/** A single line that fits the width, truncated with an ellipsis when it cannot. */
+function singleLine(text: string, size: number, width: number): string {
+  if (widthOf(text, size) <= width) return text;
+  let out = text;
+  while (out.length > 1 && widthOf(`${out}…`, size) > width) out = out.slice(0, -1);
+  return `${out.replace(/[\s.,;:—–-]+$/, "")}…`;
+}
+
+export type ProfileCardText = {
+  /** The display name. Decides whether a card is drawn at all. */
+  displayName: string;
+  /** The short handle, e.g. `@alice`. */
+  handle: string;
+  /** The bio, shown when it survives cleaning. */
+  bio: string;
+  /** The stats line, e.g. `12 articles · 340 followers`. Already formatted. */
+  stats: string;
+  /** The instance this profile lives on. */
+  site: string;
+};
+
+/** The initials the UI shows when a profile has no avatar (mirrors Avatar.svelte). */
+export function profileInitials(displayName: string): string {
+  return (
+    displayName
+      .trim()
+      .split(/\s+/)
+      .slice(0, 2)
+      .map((w) => w[0]?.toUpperCase() ?? "")
+      .join("") || "?"
+  );
+}
+
+/**
+ * A profile's share card as JPEG bytes, or null when the name cannot be drawn.
+ *
+ * Null is a real answer rather than an error: the bundled face covers Latin,
+ * Greek and Cyrillic, so a name written in Japanese, Korean or Arabic would
+ * render as an empty rectangle. The caller falls back to the instance's brand
+ * image, which says less but at least says something.
+ *
+ * The bio is dropped on the same test. It is context around the name, and a
+ * blank block is worse than no block. The handle, stats and site lines are
+ * generated ASCII and always drawn.
+ */
+export async function renderProfileCard(
+  text: ProfileCardText,
+  avatarBytes?: Uint8Array | null,
+): Promise<Uint8Array<ArrayBuffer> | null> {
+  const covered = await loadFont();
+  // A string this font can draw in full, or null. Whitespace is exempt: it is
+  // not a glyph anyone misses.
+  const renderable = (value: string) => {
+    const cleaned = clean(value);
+    if (!cleaned) return null;
+    for (const ch of cleaned) {
+      if (ch !== " " && !covered.has(ch.codePointAt(0)!)) return null;
+    }
+    return cleaned;
+  };
+
+  const displayName = renderable(text.displayName)?.slice(0, MAX_NAME_CHARS);
+  if (!displayName) return null;
+  const bio = renderable(text.bio)?.slice(0, MAX_BIO_CHARS);
+  const site = renderable(text.site);
+  const handle = clean(text.handle).slice(0, 64) || "@user";
+  const stats = clean(text.stats).slice(0, 64);
+
+  // The largest name size that fits two lines.
+  let nameLines: string[] = [];
+  let nameSize = NAME_SIZES[NAME_SIZES.length - 1];
+  for (const size of NAME_SIZES) {
+    const lines = wrap(displayName, size, TEXT_W);
+    if (lines.length <= MAX_NAME_LINES) {
+      nameLines = lines;
+      nameSize = size;
+      break;
+    }
+  }
+  if (nameLines.length === 0) {
+    nameLines = wrap(displayName, nameSize, TEXT_W).slice(0, MAX_NAME_LINES);
+    const last = nameLines.length - 1;
+    nameLines[last] = `${nameLines[last].replace(/[\s.,;:—–-]+$/, "")}…`;
+  }
+  const nameLineHeight = Math.round(nameSize * NAME_LINE_HEIGHT);
+
+  const handleLine = singleLine(handle, HANDLE_SIZE, TEXT_W);
+  const bioLines = bio ? wrap(bio, BIO_SIZE, TEXT_W).slice(0, MAX_BIO_LINES) : [];
+  if (bioLines.length === MAX_BIO_LINES) {
+    const last = bioLines.length - 1;
+    if (wrap(bio!, BIO_SIZE, TEXT_W).length > MAX_BIO_LINES) {
+      bioLines[last] = `${bioLines[last].replace(/[\s.,;:—–-]+$/, "")}…`;
+    }
+  }
+  const bioLineHeight = Math.round(BIO_SIZE * BIO_LINE_HEIGHT);
+
+  const GAP_NAME_HANDLE = 10;
+  const GAP_HANDLE_BIO = bioLines.length ? 16 : 0;
+  const GAP_BIO_STATS = 18;
+  const blockHeight =
+    nameLines.length * nameLineHeight +
+    GAP_NAME_HANDLE +
+    Math.round(HANDLE_SIZE * 1.2) +
+    GAP_HANDLE_BIO +
+    bioLines.length * bioLineHeight +
+    GAP_BIO_STATS +
+    Math.round(STATS_SIZE * 1.2);
+  const band = BAND_BOTTOM - BAND_TOP;
+  const blockTop = BAND_TOP + Math.max(0, (band - blockHeight) / 2);
+
+  const image = MagickImage.create();
+  image.read(new MagickColor(BACKGROUND), WIDTH, HEIGHT);
+
+  // The avatar first, so the text draws over nothing it needs.
+  const avatarY = Math.round(BAND_TOP + (band - AVATAR) / 2);
+  let avatarDrawn = false;
+  if (avatarBytes?.byteLength) {
+    try {
+      ImageMagick.read(avatarBytes, (avatar) => {
+        avatar.strip();
+        if (avatar.width <= 0 || avatar.height <= 0) throw new Error("Empty avatar.");
+        // Cover-crop to the square: scale so the short side lands on it, then
+        // cut the long side around the centre.
+        const scale = AVATAR / Math.min(avatar.width, avatar.height);
+        const w = Math.max(AVATAR, Math.round(avatar.width * scale));
+        const h = Math.max(AVATAR, Math.round(avatar.height * scale));
+        if (w !== avatar.width || h !== avatar.height) avatar.resize(w, h);
+        if (w !== AVATAR || h !== AVATAR) avatar.extent(AVATAR, AVATAR, Gravity.Center);
+        image.composite(avatar, new Point(AVATAR_X, avatarY));
+      });
+      avatarDrawn = true;
+    } catch {
+      // A corrupt or exotic avatar must not cost the caller their card — the
+      // initials fallback below covers it.
+    }
+  }
+
+  const draw = new Drawables();
+  // A short white rule, the card's only ornament — the same one the post card
+  // carries, so the two are recognisable as coming from the same place.
+  draw.fillColor(new MagickColor(NAME_COLOR)).rectangle(PAD, 74, PAD + 56, 80);
+
+  if (!avatarDrawn) {
+    draw
+      .fillColor(new MagickColor(AVATAR_FALLBACK_BG))
+      .roundRectangle(AVATAR_X, avatarY, AVATAR_X + AVATAR, avatarY + AVATAR, AVATAR_RADIUS, AVATAR_RADIUS);
+  }
+  draw.draw(image);
+
+  if (!avatarDrawn) {
+    // The initials sit centred in the fallback tile. Measured rather than
+    // gravity-placed: the tile's position on the canvas is known exactly.
+    const initials = profileInitials(displayName);
+    const initialSize = 84;
+    const iw = widthOf(initials, initialSize);
+    const ascent = ascentOf(initials || "M", initialSize);
+    const ix = Math.round(AVATAR_X + (AVATAR - iw) / 2);
+    const iy = Math.round(avatarY + AVATAR / 2 + ascent / 2 - 6);
+    const fg = new Drawables();
+    fg.font(FONT).fontPointSize(initialSize).fillColor(new MagickColor(NAME_COLOR)).text(ix, iy, initials);
+    fg.draw(image);
+  }
+
+  // The text column, stacked from the block top.
+  const ink = new Drawables();
+  ink.font(FONT);
+  let y = Math.round(blockTop + ascentOf(nameLines[0], nameSize));
+  ink.fontPointSize(nameSize).fillColor(new MagickColor(NAME_COLOR));
+  nameLines.forEach((line, i) => ink.text(TEXT_X, y + i * nameLineHeight, line));
+  y += (nameLines.length - 1) * nameLineHeight + GAP_NAME_HANDLE + Math.round(HANDLE_SIZE * 1.2);
+  ink.fontPointSize(HANDLE_SIZE).fillColor(new MagickColor(DIM_COLOR)).text(TEXT_X, y, handleLine);
+  if (bioLines.length) {
+    y += GAP_HANDLE_BIO;
+    ink.fontPointSize(BIO_SIZE).fillColor(new MagickColor(BIO_COLOR));
+    bioLines.forEach((line, i) => {
+      const baseline = y + ascentOf(line, BIO_SIZE) + i * bioLineHeight;
+      ink.text(TEXT_X, Math.round(baseline), line);
+    });
+    y += (bioLines.length - 1) * bioLineHeight + ascentOf(bioLines[bioLines.length - 1], BIO_SIZE);
+  }
+  y += GAP_BIO_STATS + Math.round(STATS_SIZE * 0.9);
+  ink.fontPointSize(STATS_SIZE).fillColor(new MagickColor(DIM_COLOR)).text(TEXT_X, Math.round(y), stats);
+
+  if (site) {
+    ink.fontPointSize(SITE_SIZE).fillColor(new MagickColor(DIM_COLOR)).text(PAD, SITE_BASELINE, site);
+  }
+  ink.draw(image);
+
+  image.quality = QUALITY;
+  let out: Uint8Array<ArrayBuffer> | null = null;
+  // Copied out of the callback: the buffer magick hands over is only valid for
+  // the duration of the call.
+  image.write(MagickFormat.Jpeg, (bytes) => {
+    out = new Uint8Array(bytes);
+  });
+  if (!out) throw new Error("Profile card could not be encoded.");
+  return out;
+}

--- a/apps/backend/src/lib/profileCard_test.ts
+++ b/apps/backend/src/lib/profileCard_test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { describe, expect, test } from "vitest";
+import { profileInitials, renderProfileCard } from "@/lib/profileCard.ts";
+
+// What is asserted here is the promise the card makes to a link-preview
+// scraper, not ImageMagick's behaviour: a JPEG of the documented size, small
+// enough for the platforms that consume it, and — the part that matters most —
+// nothing at all rather than a blank rectangle when the name cannot be set.
+//
+// The layout itself cannot be asserted on without comparing pixels, which would
+// fail on any harmless change to the design. What can be asserted is that no
+// input silently produces an empty card, which is the failure that would ship
+// unnoticed: an empty card is a valid JPEG of exactly the right dimensions.
+
+const TEXT = {
+  displayName: "Ada Lovelace",
+  handle: "@ada",
+  bio: "Mathematician writing about analytical engines and early computing.",
+  stats: "12 articles · 340 followers",
+  site: "blog.example.test",
+};
+
+/** Width and height read out of a JPEG's start-of-frame marker. */
+function jpegSize(bytes: Uint8Array): { width: number; height: number } | null {
+  for (let i = 2; i < bytes.length - 9;) {
+    if (bytes[i] !== 0xff) {
+      i++;
+      continue;
+    }
+    const marker = bytes[i + 1];
+    if (marker === 0xc0 || marker === 0xc1 || marker === 0xc2) {
+      return {
+        height: (bytes[i + 5] << 8) | bytes[i + 6],
+        width: (bytes[i + 7] << 8) | bytes[i + 8],
+      };
+    }
+    i += 2 + ((bytes[i + 2] << 8) | bytes[i + 3]);
+  }
+  return null;
+}
+
+test("a profile card is a JPEG at the size every platform documents", async () => {
+  const card = await renderProfileCard(TEXT);
+  expect(card, "no card was drawn").not.toBeNull();
+  // SOI + the first marker: what a scraper sniffs for.
+  expect([card![0], card![1], card![2]]).toEqual([0xff, 0xd8, 0xff]);
+  expect(jpegSize(card!)).toEqual({ width: 1200, height: 630 });
+  expect(card!.length, `card was ${card!.length} bytes`).toBeLessThan(600 * 1024);
+});
+
+test("a profile without a bio still gets a card", async () => {
+  const card = await renderProfileCard({ ...TEXT, bio: "" });
+  expect(card, "no card was drawn").not.toBeNull();
+  expect(jpegSize(card!)).toEqual({ width: 1200, height: 630 });
+});
+
+test("a corrupt avatar falls back to initials rather than failing the card", async () => {
+  const card = await renderProfileCard(TEXT, new Uint8Array([0, 1, 2, 3, 4]));
+  expect(card, "no card was drawn").not.toBeNull();
+  expect(jpegSize(card!)).toEqual({ width: 1200, height: 630 });
+});
+
+describe("a name the bundled face cannot set draws no card at all", () => {
+  test("a script with no glyphs", async () => {
+    expect(await renderProfileCard({ ...TEXT, displayName: "田中太郎" })).toBe(null);
+  });
+
+  test("a name that is only emoji", async () => {
+    expect(await renderProfileCard({ ...TEXT, displayName: "🚀✨🎉" })).toBe(null);
+  });
+});
+
+describe("what surrounds the name never decides whether there is a card", () => {
+  test("a bio the face cannot set still gets a card", async () => {
+    const card = await renderProfileCard({ ...TEXT, bio: "日本語の自己紹介文です" });
+    expect(card, "no card was drawn").not.toBeNull();
+  });
+
+  test("an emoji in the name costs the name nothing", async () => {
+    const card = await renderProfileCard({ ...TEXT, displayName: "🚀 Ada Lovelace" });
+    expect(card, "no card was drawn").not.toBeNull();
+    expect(jpegSize(card!)).toEqual({ width: 1200, height: 630 });
+  });
+});
+
+describe("no text runs off the card", () => {
+  test("a very long bio is bounded", async () => {
+    const card = await renderProfileCard({ ...TEXT, bio: "Writing about engines. ".repeat(40) });
+    expect(card).not.toBeNull();
+    expect(jpegSize(card!)).toEqual({ width: 1200, height: 630 });
+  });
+
+  test("a very long display name is bounded", async () => {
+    const card = await renderProfileCard({
+      ...TEXT,
+      displayName: "Alexandria Cassiopeia Maximiliana Worthington-Smythe the Third",
+    });
+    expect(card).not.toBeNull();
+    expect(jpegSize(card!)).toEqual({ width: 1200, height: 630 });
+  });
+});
+
+describe("profileInitials", () => {
+  test("takes the first letters of the first two words", () => {
+    expect(profileInitials("Ada Lovelace")).toBe("AL");
+    expect(profileInitials("  ada   ")).toBe("A");
+    expect(profileInitials("")).toBe("?");
+  });
+});

--- a/apps/backend/src/routes/og.ts
+++ b/apps/backend/src/routes/og.ts
@@ -4,10 +4,12 @@ import { notFound } from "@/lib/http.ts";
 import type { AppEnv } from "@/routes/types.ts";
 import { getOrigin } from "@/services/instanceSetup.ts";
 import * as ogCardService from "@/services/ogCard.ts";
+import * as profileCardService from "@/services/profileCard.ts";
 
 // Generated share images — what a link-preview scraper fetches as `og:image`
-// for a post that carries no picture of its own. See lib/ogCard.ts for what is
-// drawn and services/ogCard.ts for the caching.
+// for a post that carries no picture of its own, or for a profile page. See
+// lib/ogCard.ts and lib/profileCard.ts for what is drawn and
+// services/ogCard.ts / services/profileCard.ts for the caching.
 //
 // Its own prefix rather than a path under `/api/posts/`, and that is the point
 // of it: robots.txt disallows `/api/` wholesale, and a crawler path is a
@@ -42,6 +44,33 @@ ogRoutes.get("/posts/:file", async (c) => {
       // the post is retitled. Scrapers cache far longer than any header asks
       // anyway, which is why the URL the frontend emits carries the post's
       // `updatedAt` — a retitled post is a new URL for them to fetch.
+      "cache-control": "public, max-age=86400",
+      "x-content-type-options": "nosniff",
+    },
+  });
+});
+
+ogRoutes.get("/profiles/:file", async (c) => {
+  // Usernames are `[a-z0-9_]{3,30}` (see auth/auth.ts); anything else is not a
+  // profile card. The `.jpg` keeps scrapers sniffing an image extension.
+  const username = /^([a-z0-9_]{3,30})\.jpg$/.exec(c.req.param("file"))?.[1];
+  if (!username) throw notFound("Not found.");
+
+  // Built from the same public header a signed-out reader sees, so a card is
+  // no more reachable than the profile. Private accounts still get one: the
+  // card draws only the public header, never posts.
+  const card = await profileCardService.profileCard(username);
+  // No card could be drawn — a display name in a script the bundled face has
+  // no glyphs for. Hand the scraper the brand image rather than a 404, same
+  // as the post card above.
+  if (!card) return c.redirect(`${await getOrigin()}/og-image.png`, 302);
+
+  return new Response(card as BodyInit, {
+    headers: {
+      "content-type": "image/jpeg",
+      // A day, not `immutable`: what this draws changes when the profile is
+      // edited. The frontend's URL carries the profile's `updatedAt`, so an
+      // edited profile is a new URL for scrapers to fetch.
       "cache-control": "public, max-age=86400",
       "x-content-type-options": "nosniff",
     },

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -63,6 +63,10 @@ export function publicUser(
     isAdmin: u.isAdmin,
     isPrivate: u.isPrivate,
     createdAt: u.createdAt,
+    // When the profile last changed. Versions the profile's share card, so an
+    // edited profile is a new `og:image` URL for scrapers to fetch (see
+    // frontend lib/cover.ts `profileCardUrl`).
+    updatedAt: u.updatedAt,
     tags,
     links,
   };

--- a/apps/backend/src/services/profileCard.ts
+++ b/apps/backend/src/services/profileCard.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { config } from "@/config.ts";
+import * as followsRepo from "@/db/repositories/follows.ts";
+import * as postsRepo from "@/db/repositories/posts.ts";
+import * as usersRepo from "@/db/repositories/users.ts";
+import { notFound } from "@/lib/http.ts";
+import { renderProfileCard } from "@/lib/profileCard.ts";
+import { hashToken } from "@/lib/tokens.ts";
+import { getAppDomain } from "@/services/instanceSetup.ts";
+
+// On-disk caching for generated profile share cards. The drawing itself is in
+// lib/profileCard.ts, which explains why a card exists at all.
+//
+// Same shape as services/ogCard.ts, and for the same reason: a card is only
+// ever fetched by a link-preview scraper, once per profile per platform, so one
+// render amortised over the life of the profile is the whole cost.
+
+const AVATAR_PATH = /^\/api\/uploads\/([A-Za-z0-9-]+\.(?:png|jpe?g|webp|gif))$/;
+
+/**
+ * Where a card is cached.
+ *
+ * The hash is of everything drawn, so a renamed author, an edited bio or a
+ * swapped avatar writes a new file rather than serving a stale one. The
+ * superseded file is left behind — a few tens of kilobytes per edit, against
+ * the alternative of tracking which cards belong to which profile.
+ */
+function cachePath(username: string, digest: string): string {
+  return `${config.UPLOADS_DIR}/og-profiles/${username}-${digest.slice(0, 16)}.jpg`;
+}
+
+function plural(n: number, one: string, many: string): string {
+  return `${n} ${n === 1 ? one : many}`;
+}
+
+async function sha256Hex(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * The share card for a local profile, generated on first request and cached.
+ *
+ * Throws 404 when no such user exists (or the account is suspended), so a
+ * card is no more reachable than the profile. Returns null when no card can
+ * be drawn — a display name in a script the bundled face has no glyphs for —
+ * and the caller falls back to the instance's brand image.
+ *
+ * Private accounts still get a card: the header (name, bio, counts) renders
+ * for strangers deciding whether to request a follow, and the card draws only
+ * that same public header — never posts.
+ */
+export async function profileCard(username: string): Promise<Uint8Array<ArrayBuffer> | null> {
+  const user = await usersRepo.findByUsername(username);
+  if (!user || user.suspendedAt) throw notFound("User not found.");
+
+  const [counts, postCounts, site] = await Promise.all([
+    followsRepo.counts(user.id),
+    postsRepo.countsByAuthor(user.id),
+    getAppDomain(),
+  ]);
+
+  const text = {
+    displayName: user.displayName,
+    handle: `@${user.username}`,
+    bio: user.bio ?? "",
+    stats: `${plural(postCounts.published, "article", "articles")} · ${plural(counts.followers, "follower", "followers")}`,
+    site,
+  };
+
+  // A locally stored avatar is read off disk; anything else (no avatar, or a
+  // value that is not one of our upload paths) falls back to initials.
+  let avatar: Uint8Array<ArrayBuffer> | null = null;
+  const avatarFile = user.avatarUrl ? AVATAR_PATH.exec(user.avatarUrl)?.[1] : undefined;
+  if (avatarFile) {
+    try {
+      avatar = await Deno.readFile(`${config.UPLOADS_DIR}/${avatarFile}`);
+    } catch {
+      avatar = null;
+    }
+  }
+
+  const digest = await hashToken(
+    `${text.displayName}\n${text.handle}\n${text.bio}\n${text.stats}\n${text.site}\n${avatar ? await sha256Hex(avatar) : "-"}`,
+  );
+  const cached = cachePath(user.username, digest);
+  try {
+    return await Deno.readFile(cached);
+  } catch {
+    // Not built yet.
+  }
+
+  const jpeg = await renderProfileCard(text, avatar);
+  if (!jpeg) return null;
+
+  await Deno.mkdir(`${config.UPLOADS_DIR}/og-profiles`, { recursive: true });
+  // Written to a temporary file and renamed into place, so two scrapers
+  // arriving together can never serve each other a half-written image.
+  const tmp = `${cached}.${crypto.randomUUID()}.tmp`;
+  try {
+    await Deno.writeFile(tmp, jpeg);
+    await Deno.rename(tmp, cached);
+  } catch {
+    // A failed cache write costs a re-render next time; it must not cost the
+    // caller their card.
+    await Deno.remove(tmp).catch(() => {});
+  }
+  return jpeg;
+}

--- a/apps/frontend/src/lib/cover.ts
+++ b/apps/frontend/src/lib/cover.ts
@@ -95,3 +95,31 @@ export function postCardUrl(
   const version = Number.isFinite(changed) ? changed : 0;
   return `${origin}/api/og/posts/${post.id}.jpg?v=${version}`;
 }
+
+/**
+ * The generated share card for a profile, or undefined when there will not be one.
+ *
+ * The card is what a link-preview scraper gets for a profile page — the avatar,
+ * display name, handle, bio and a stats line, drawn by the backend (its
+ * lib/profileCard.ts). Before it existed, every profile shared as the same
+ * brand tile, so a shared author link said nothing about the author.
+ *
+ * Local profiles only. A remote `user@host` handle is another instance's to
+ * illustrate, and keeps the brand tile — which only the username pattern
+ * below can know, so that case is decided here rather than by the backend.
+ *
+ * The `v` parameter is the profile's own last-changed time. Scrapers cache a
+ * share image by URL and for far longer than any header asks, so without it an
+ * edited profile would keep showing its old name and bio on every platform
+ * that had already seen the link.
+ */
+export function profileCardUrl(
+  profile: { user: { username: string; updatedAt?: string; createdAt?: string } } | null | undefined,
+  origin: string,
+): string | undefined {
+  if (!profile) return undefined;
+  if (!/^[a-z0-9_]{3,30}$/.test(profile.user.username)) return undefined;
+  const changed = Date.parse(profile.user.updatedAt ?? profile.user.createdAt ?? "");
+  const version = Number.isFinite(changed) ? changed : 0;
+  return `${origin}/api/og/profiles/${profile.user.username}.jpg?v=${version}`;
+}

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -19,6 +19,9 @@ export type User = {
   // followers and following requires approval. Public by default.
   isPrivate: boolean;
   createdAt: string;
+  // When the profile last changed. Versions the profile's share card, so an
+  // edited profile is a new `og:image` URL for scrapers to fetch.
+  updatedAt: string;
   tags: Tag[];
   links: ProfileLink[];
   // Private account fields — present only on the signed-in user's own record

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -11,7 +11,7 @@
   import Nav from "$lib/components/Nav.svelte";
   import SideNav from "$lib/components/SideNav.svelte";
   import ConfirmDialog from "$lib/components/ui/ConfirmDialog.svelte";
-  import { absoluteBanner, postCardUrl } from "$lib/cover";
+  import { absoluteBanner, postCardUrl, profileCardUrl } from "$lib/cover";
   import { excerpt } from "$lib/format";
   import { rememberLocale } from "$lib/locale";
   import { blogPostingLd, breadcrumbLd, profilePageLd, serializeJsonLd, webSiteLd } from "$lib/seo";
@@ -109,6 +109,11 @@
     return description;
   });
   const ogType = $derived(post ? "article" : "website");
+  // A profile page's share image: the generated profile card (avatar, name,
+  // handle, bio, stats). Local profiles only — a remote `user@host` handle
+  // fails the username check in `profileCardUrl` and keeps the brand tile,
+  // since the card is the origin instance's to draw.
+  const profile = $derived($page.route.id === "/[handle]" ? ($page.data as { profile?: Profile }).profile : undefined);
   // A post's banner becomes its share image, falling back to the instance's
   // brand image. `bannerUrl` rather than `coverUrl`, so a post whose banner is
   // simply its first picture still gets a picture on the link card instead of
@@ -118,7 +123,9 @@
   // stored root-relative (`/api/uploads/…`) and a scraper would resolve that
   // against itself. An unparseable URL falls back rather than emitting a broken
   // og:image.
-  const shareImage = $derived(absoluteBanner(post?.bannerUrl, origin) ?? postCardUrl(post, origin) ?? ogImage);
+  const shareImage = $derived(
+    absoluteBanner(post?.bannerUrl, origin) ?? postCardUrl(post, origin) ?? profileCardUrl(profile, origin) ?? ogImage,
+  );
 
   // RSS auto-discovery: a reader pointed at a profile, an article or a
   // reading-list page finds the feed from this tag alone — which is how Feedly,
@@ -323,7 +330,7 @@
     <link rel="alternate" hreflang="x-default" href={canonical} />
   {/if}
   <!-- Screen readers reach a shared link through the card, not the page. -->
-  <meta property="og:image:alt" content={post?.title ?? appName} />
+  <meta property="og:image:alt" content={post?.title ?? profile?.user.displayName ?? appName} />
   {#if feedLink}
     <link rel="alternate" type="application/rss+xml" title={feedLink.title} href={feedLink.href} />
   {/if}


### PR DESCRIPTION
## Symptom

A shared profile link renders as the instance's generic brand tile — the same image as every page without its own picture. It says nothing about the author (no face, no name, no bio), where Substack-style profile cards carry exactly that.

## Root cause

Post pages already get a generated card (title/author/instance via `GET /api/og/posts/:id.jpg`, drawn in `lib/ogCard.ts`), but nothing equivalent existed for profiles: `+layout.svelte` fell through to the brand image on `/[handle]` pages because no profile-card URL was ever emitted.

## Fix

End-to-end profile cards in the same visual language as the post cards (1200x630, near-black ground, white accent rule, Inter SemiBold):

- **Renderer** (`backend lib/profileCard.ts`): avatar (cover-cropped photo, or initials tile mirroring `Avatar.svelte` when absent/corrupt) + display name + `@handle` + bio (3 lines) + `N articles · M followers` stats + instance domain. Undrawable display names return `null` → brand fallback, never a blank tile.
- **Service** (`backend services/profileCard.ts`): on-disk cache keyed by a hash of everything drawn; 404s for missing/suspended accounts. Private accounts still get a card — it draws only the public header, never posts.
- **Route** (`GET /api/og/profiles/:username.jpg`): same cache headers as the post card; already covered by the existing `Allow: /api/og/` robots rule and the Anubis `/api/` allow, so no infra change.
- **Frontend** (`cover.ts profileCardUrl` + layout): `og:image`/`twitter:image` point at the card on local profile pages (remote `user@host` handles keep the brand tile — the origin instance's to draw), `og:image:alt` falls back to the display name.
- **Versioning**: `usersRepo.update` now stamps `updatedAt` (previously write-only — nothing read it) and `publicUser` exposes it, so an edited profile is a new `?v=` URL for scrapers that cache by URL.

## Verified

- Backend: 305 tests pass (10 new in `profileCard_test.ts` — size/magic bytes, null-on-undrawable-name, bio-optional, corrupt-avatar fallback, truncation bounds); `oxlint`/`oxfmt` clean; `deno check` clean.
- Frontend: 34 tests pass; `oxlint`/`oxfmt` clean; `svelte-check` 0 errors.
- Rendered two sample cards and inspected them visually: initials fallback with Turkish glyphs (ğşıçöü) and a real photo avatar — both 1200x630, ~55KB (under WhatsApp's ~600KB ceiling).

## Not verified

- No live-scraper check (Telegram/WhatsApp/Twitter render) — needs a deployed instance; the JPEG magic bytes, dimensions and size budget are asserted in tests instead.

## Deploy notes

Plain `docker compose up -d` suffices. No migration (no schema change), no Caddy/Anubis change. First profile share renders on demand and caches under `UPLOADS_DIR/og-profiles/`.