### PR TITLE
feat(admin): safe user deletion with retention window and restore

### DIFF
--- a/apps/backend/drizzle/0036_user_soft_delete.sql
+++ b/apps/backend/drizzle/0036_user_soft_delete.sql
@@ -1,0 +1,14 @@
+-- Admin user deletion with a retention window. Additive and idempotent.
+-- `users.deleted_at` marks a soft-deleted account (null = live): the account
+-- cannot sign in, vanishes from every listing, profile and feed, and its row
+-- (posts, follows and all) is kept for the retention window so an admin can
+-- restore it (see services/moderation.ts DELETED_USER_RETENTION_DAYS).
+-- `users.deleted_by` records which moderator deleted it (null when unknown or
+-- when that moderator is gone). A sweeper hard-deletes rows past the window
+-- (see services/deletedUsers.ts).
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "deleted_at" timestamp with time zone;--> statement-breakpoint
+ALTER TABLE "users" ADD COLUMN IF NOT EXISTS "deleted_by" uuid;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "users" ADD CONSTRAINT "users_deleted_by_users_id_fk" FOREIGN KEY ("deleted_by") REFERENCES "users"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "users_deleted_at_idx" ON "users" ("deleted_at");

--- a/apps/backend/drizzle/meta/_journal.json
+++ b/apps/backend/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1788708046999,
       "tag": "0035_remote_comments",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1788800000000,
+      "tag": "0036_user_soft_delete",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/backend/src/auth/auth.ts
+++ b/apps/backend/src/auth/auth.ts
@@ -117,9 +117,10 @@ export const auth = betterAuth({
     },
     session: {
       create: {
-        // Block suspended accounts (runs after credential check, so no enumeration).
+        // Block suspended and deleted accounts (runs after credential check, so no enumeration).
         before: async (session) => {
           const user = await usersRepo.findById(session.userId);
+          if (user?.deletedAt) throw new APIError("FORBIDDEN", { message: "This account no longer exists." });
           if (user?.suspendedAt) throw new APIError("FORBIDDEN", { message: "This account has been suspended." });
           return { data: session };
         },

--- a/apps/backend/src/db/repositories/accounts.ts
+++ b/apps/backend/src/db/repositories/accounts.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { and, eq } from "drizzle-orm";
+import { db } from "@/db/client.ts";
+import { accounts } from "@/db/schema.ts";
+
+// All Better Auth credential access lives here. Only the bcrypt hash is ever
+// read — never written — and only to re-verify the acting admin's password
+// before a destructive moderation action (see services/moderation.ts).
+export async function findCredentialHashByUserId(userId: string): Promise<string | null> {
+  const row = await db.query.accounts.findFirst({
+    where: and(eq(accounts.userId, userId), eq(accounts.providerId, "credential")),
+  });
+  return row?.password ?? null;
+}

--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -284,6 +284,7 @@ const publishedLocally = () =>
     eq(posts.remote, false),
     eq(posts.status, "published"),
     sql`${users.suspendedAt} is null`,
+    sql`${users.deletedAt} is null`,
     eq(users.isPrivate, false),
   );
 
@@ -348,7 +349,7 @@ export function listRelated(postId: string, limit = 3) {
       // A private author's posts are visible only to approved followers; a
       // suggestion rail has no viewer context to check that against, so they are
       // left out entirely rather than teased and then 404'd.
-      .where(and(sql`${users.isPrivate} = false`, sql`${users.suspendedAt} is null`))
+      .where(and(sql`${users.isPrivate} = false`, sql`${users.suspendedAt} is null`, sql`${users.deletedAt} is null`))
       .orderBy(desc(shared.overlap), desc(posts.createdAt))
       .limit(limit)
   );
@@ -366,6 +367,7 @@ export function listRecentExcluding(postId: string, limit = 4) {
         eq(posts.remote, false),
         sql`${users.isPrivate} = false`,
         sql`${users.suspendedAt} is null`,
+        sql`${users.deletedAt} is null`,
       ),
     )
     .orderBy(desc(posts.createdAt))
@@ -379,13 +381,13 @@ export function listRecentExcluding(postId: string, limit = 4) {
 // one asks what the node holds, and a private author's article is as much this
 // node's output as anyone's — only the count leaves, never a title or a body.
 // Drafts and scheduled posts are not published and never counted; a suspended
-// author's work is withdrawn, so it is not counted either.
+// or deleted author's work is withdrawn, so it is not counted either.
 export async function countLocalPublished(): Promise<number> {
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(posts)
     .innerJoin(users, eq(posts.authorId, users.id))
-    .where(and(eq(posts.remote, false), isPublished, isNull(users.suspendedAt)));
+    .where(and(eq(posts.remote, false), isPublished, isNull(users.suspendedAt), isNull(users.deletedAt)));
   return row?.n ?? 0;
 }
 
@@ -403,7 +405,7 @@ export async function countSitemapEntries(): Promise<number> {
 // crawler following a byline. `lastmod` is their newest post, since that is what
 // actually changes the page.
 //
-// Excluded: suspended accounts, private accounts (their posts are only visible
+// Excluded: suspended and deleted accounts, private accounts (their posts are only visible
 // to approved followers, so the page is empty to a crawler), and anyone with
 // nothing published, whose profile would be a thin page.
 export function listSitemapProfiles() {
@@ -414,7 +416,7 @@ export function listSitemapProfiles() {
     })
     .from(users)
     .innerJoin(posts, and(eq(posts.authorId, users.id), eq(posts.status, "published"), eq(posts.remote, false)))
-    .where(and(sql`${users.suspendedAt} is null`, eq(users.isPrivate, false)))
+    .where(and(sql`${users.suspendedAt} is null`, sql`${users.deletedAt} is null`, eq(users.isPrivate, false)))
     .groupBy(users.username)
     .limit(10000);
 }
@@ -440,11 +442,12 @@ function beforeCursor(cursor: Cursor | null) {
 // to their author (see listDraftsByAuthor).
 export const isPublished = eq(posts.status, "published");
 
-// A locally-suspended author vanishes from every public listing — feeds,
-// trending, search, tags and their own profile — until an admin reinstates them
-// (nothing is deleted). Remote posts have no local author (`authorId is null`)
+// A locally-suspended or deleted author vanishes from every public listing —
+// feeds, trending, search, tags and their own profile — until an admin
+// reinstates them (a suspension deletes nothing; a deletion keeps the row for
+// the retention window). Remote posts have no local author (`authorId is null`)
 // and are unaffected. Relies on every listing left-joining `users` on authorId.
-export const notSuspended = sql`(${posts.authorId} is null or ${users.suspendedAt} is null)`;
+export const notSuspended = sql`(${posts.authorId} is null or (${users.suspendedAt} is null and ${users.deletedAt} is null))`;
 
 // Gates posts by a *private* local author to approved followers only (plus the
 // author themselves). Public authors and remote posts (authorId null) are
@@ -715,6 +718,22 @@ export function listPublishedByAuthor(authorId: string, cursor: Cursor | null, l
     .where(and(eq(posts.authorId, authorId), eq(posts.status, "published"), beforeCursor(cursor)))
     .orderBy(desc(posts.createdAt), desc(posts.id))
     .limit(limit + 1);
+}
+
+// How many local posts each of the given authors holds, for the admin
+// "recently deleted" list. One grouped scan rather than a count per row.
+export async function countLocalByAuthors(authorIds: string[]): Promise<Map<string, number>> {
+  if (authorIds.length === 0) return new Map();
+  const rows = await db
+    .select({ authorId: posts.authorId, n: count() })
+    .from(posts)
+    .where(and(eq(posts.remote, false), inArray(posts.authorId, authorIds)))
+    .groupBy(posts.authorId);
+  const totals = new Map<string, number>();
+  for (const row of rows) {
+    if (row.authorId) totals.set(row.authorId, row.n);
+  }
+  return totals;
 }
 
 // How many posts the author holds in each state, for the management page's tab

--- a/apps/backend/src/db/repositories/readingLists.ts
+++ b/apps/backend/src/db/repositories/readingLists.ts
@@ -94,7 +94,10 @@ export function listSitemapLists(): Promise<{ id: string; title: string; lastIte
     })
     .from(readingLists)
     .innerJoin(readingListItems, eq(readingListItems.listId, readingLists.id))
-    .innerJoin(users, and(eq(users.id, readingLists.userId), sql`${users.suspendedAt} is null`))
+    .innerJoin(
+      users,
+      and(eq(users.id, readingLists.userId), sql`${users.suspendedAt} is null`, sql`${users.deletedAt} is null`),
+    )
     .where(and(eq(readingLists.visibility, "public"), eq(readingLists.isReadLater, false)))
     .groupBy(readingLists.id)
     .limit(10000);

--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { and, desc, eq, gte, ilike, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, ilike, lt, ne, or, sql } from "drizzle-orm";
+import { alias } from "drizzle-orm/pg-core";
 import { db } from "@/db/client.ts";
 import { type ActorKeyPair, follows, type NewUser, sessions, users } from "@/db/schema.ts";
 
@@ -22,7 +23,13 @@ export function search(query: string, limit = 10) {
       avatarUrl: users.avatarUrl,
     })
     .from(users)
-    .where(and(sql`${users.suspendedAt} is null`, or(ilike(users.username, term), ilike(users.displayName, term))))
+    .where(
+      and(
+        sql`${users.suspendedAt} is null`,
+        sql`${users.deletedAt} is null`,
+        or(ilike(users.username, term), ilike(users.displayName, term)),
+      ),
+    )
     .orderBy(users.displayName)
     .limit(limit);
 }
@@ -32,8 +39,8 @@ export function search(query: string, limit = 10) {
 // stay actionable; for a signed-out viewer it's just the most-followed accounts.
 export function suggested(viewerId: string | null, limit = 5) {
   const followerCount = sql<number>`count(${follows.followerId})::int`;
-  // Suspended accounts are never suggested (they can't be followed meaningfully).
-  const notSuspended = sql`${users.suspendedAt} is null`;
+  // Suspended and deleted accounts are never suggested (they can't be followed meaningfully).
+  const notSuspended = sql`${users.suspendedAt} is null and ${users.deletedAt} is null`;
   const exclude = viewerId
     ? and(
         notSuspended,
@@ -75,14 +82,20 @@ export function findByEmail(email: string) {
   return db.query.users.findFirst({ where: eq(users.email, email) });
 }
 
-// The oldest local account. Used as the signing identity for outbound fetches
+// The oldest live local account. Used as the signing identity for outbound fetches
 // (e.g. resolving remote actors on instances that require authorized fetch).
 export function firstUser() {
-  return db.query.users.findFirst({ orderBy: (u, { asc }) => asc(u.createdAt) });
+  return db.query.users.findFirst({
+    where: sql`${users.deletedAt} is null`,
+    orderBy: (u, { asc }) => asc(u.createdAt),
+  });
 }
 
 export async function countUsers(): Promise<number> {
-  const [row] = await db.select({ n: sql<number>`count(*)::int` }).from(users);
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(users)
+    .where(sql`${users.deletedAt} is null`);
   return row?.n ?? 0;
 }
 
@@ -123,16 +136,61 @@ export async function update(id: string, data: Partial<NewUser>) {
   return row;
 }
 
-// Local accounts for the admin user table: newest first, optional handle /
-// name substring filter. Returns full rows (the admin serializer picks fields).
+// Live local accounts for the admin user table: newest first, optional handle /
+// name substring filter. Deleted accounts are excluded — they have their own
+// restore list (listDeleted). Returns full rows (the admin serializer picks fields).
 export function listForAdmin(query = "", limit = 100) {
-  const where = query.trim()
+  const match = query.trim()
     ? (() => {
         const term = `%${query.replace(/[%_\\]/g, "\\$&")}%`;
         return or(ilike(users.username, term), ilike(users.displayName, term));
       })()
     : undefined;
-  return db.select().from(users).where(where).orderBy(desc(users.createdAt)).limit(limit);
+  return db
+    .select()
+    .from(users)
+    .where(and(sql`${users.deletedAt} is null`, match))
+    .orderBy(desc(users.createdAt))
+    .limit(limit);
+}
+
+// Recently deleted accounts, newest deletion first, with the deleting
+// moderator's username (null when unknown). The admin restore list — the
+// "backup" a deletion keeps for the retention window.
+export function listDeleted(limit = 100) {
+  const deleter = alias(users, "deleter");
+  return db
+    .select({ user: users, deletedByUsername: deleter.username })
+    .from(users)
+    .leftJoin(deleter, eq(users.deletedBy, deleter.id))
+    .where(sql`${users.deletedAt} is not null`)
+    .orderBy(desc(users.deletedAt))
+    .limit(limit);
+}
+
+// Ids of deleted accounts whose retention window ended before `cutoff` — the
+// expiry sweeper's claim list (see services/deletedUsers.ts).
+export function listExpiredDeletedIds(cutoff: Date, limit = 100) {
+  return db
+    .select({ id: users.id })
+    .from(users)
+    .where(and(sql`${users.deletedAt} is not null`, lt(users.deletedAt, cutoff)))
+    .orderBy(users.deletedAt)
+    .limit(limit);
+}
+
+// Marks (a Date + moderator) or unmarks (null) an account as deleted. Returns
+// the updated row.
+export async function setDeleted(id: string, at: Date | null, by: string | null) {
+  const [row] = await db.update(users).set({ deletedAt: at, deletedBy: by }).where(eq(users.id, id)).returning();
+  return row;
+}
+
+// Irreversibly removes the row. Cascades wipe the account's posts, follows and
+// the rest (see db/schema.ts); the sweeper and the admin "delete forever"
+// action are the only callers.
+export async function hardRemove(id: string) {
+  await db.delete(users).where(eq(users.id, id));
 }
 
 // Sets (a Date) or clears (null) the suspension marker. Returns the updated row.

--- a/apps/backend/src/db/schema.ts
+++ b/apps/backend/src/db/schema.ts
@@ -66,6 +66,17 @@ export const users = pgTable(
     // blocked from signing in and treated as signed out (see auth/auth.ts and
     // routes/middleware.ts).
     suspendedAt: timestamp("suspended_at", { withTimezone: true }),
+    // When an admin deleted this account (null = live). A deleted account is a
+    // suspended account taken further: it cannot sign in, is treated as signed
+    // out, and vanishes from every listing, profile, feed and federated actor
+    // lookup. The row — posts, follows and all — is kept for the retention
+    // window so the deletion can be reverted, then hard-deleted by a sweeper
+    // (see services/moderation.ts and services/deletedUsers.ts).
+    deletedAt: timestamp("deleted_at", { withTimezone: true }),
+    // Which moderator deleted the account (null when unknown, or when that
+    // moderator's own account is gone). Shown in the admin "recently deleted"
+    // list; never a public surface.
+    deletedBy: uuid("deleted_by").references((): AnyPgColumn => users.id, { onDelete: "set null" }),
     actorKeyPair: jsonb("actor_key_pair").$type<ActorKeyPair | null>(),
     createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),

--- a/apps/backend/src/federation/mod.ts
+++ b/apps/backend/src/federation/mod.ts
@@ -133,7 +133,9 @@ function createFederationInstance(): Federation<ContextData> {
 function setupActor(f: Federation<ContextData>) {
   f.setActorDispatcher("/users/{identifier}", async (ctx, identifier) => {
     const user = await usersRepo.findByUsername(identifier);
-    if (!user) return null;
+    // A deleted account reads as gone (its Delete was already federated at
+    // delete time), so remote instances tombstone rather than refetch it.
+    if (!user || user.deletedAt) return null;
     const keys = await ctx.getActorKeyPairs(identifier);
     const tags = await tagsRepo.tagsForUser(user.id);
     return await buildPerson(ctx, identifier, user, tags, keys);
@@ -166,7 +168,7 @@ function setupActor(f: Federation<ContextData>) {
 function setupFollowers(f: Federation<ContextData>) {
   f.setFollowersDispatcher("/users/{identifier}/followers", async (ctx, identifier) => {
     const user = await usersRepo.findByUsername(identifier);
-    if (!user) return null;
+    if (!user || user.deletedAt) return null;
     const [locals, remotes] = await Promise.all([
       followsRepo.localFollowerUsernames(user.id),
       followsRepo.remoteFollowerActors(user.id),

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -4,6 +4,7 @@ import { config } from "@/config.ts";
 import { runMigrations } from "@/db/migrate.ts";
 import { startJobWorker } from "@/queue/queue.ts";
 import { reconcileAnubisInBackground } from "@/services/anubisProtection.ts";
+import { startDeletedUserSweeper } from "@/services/deletedUsers.ts";
 import { seedFederationOrigin, seedFederationRunning } from "@/services/federationState.ts";
 import { getFederationEnabled, getOrigin } from "@/services/instanceSetup.ts";
 import { backfillSlugs } from "@/services/postSlugs.ts";
@@ -46,10 +47,14 @@ async function main() {
   startUploadGcSweeper();
 
   // Prune cached remote actors (and their posts) that are stale and no longer
-  // referenced by any local follow/mute/block/recommendation/notification edge,
+  // referenced by any local follow/mute/block/recommendation edge,
   // so a hostile instance can't grow the remote tables without bound by serving
   // many distinct actors. Safe to run on every node — see services/remoteCacheGc.ts.
   startRemoteCacheGcSweeper();
+
+  // Erase soft-deleted accounts once their retention window ends. Same
+  // database-backed pattern as the sweepers above — see services/deletedUsers.ts.
+  startDeletedUserSweeper();
 
   // `onListen` overrides Deno's own "Listening on http://0.0.0.0:8000/" banner,
   // which otherwise prints alongside ours and announces the same thing twice —

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -5,7 +5,7 @@ import { rotateSessionSecret, sessionSecretManaged } from "@/config.ts";
 import { badRequest } from "@/lib/http.ts";
 import { jsonBody } from "@/lib/validate.ts";
 import { requireAdmin } from "@/routes/middleware.ts";
-import { adminUserView } from "@/routes/serializers.ts";
+import { adminUserView, deletedUserView } from "@/routes/serializers.ts";
 import type { AppEnv } from "@/routes/types.ts";
 import * as anubis from "@/services/anubisProtection.ts";
 import { dnsRecords } from "@/services/dkim.ts";
@@ -306,6 +306,43 @@ const suspendSchema = z.object({ suspend: z.boolean() });
 adminRoutes.post("/users/:id/suspend", jsonBody(suspendSchema, "Expected { suspend: boolean }."), async (c) => {
   const admin = requireAdmin(c);
   await moderation.setSuspended(admin.id, c.req.param("id"), c.req.valid("json").suspend);
+  return c.json({ ok: true });
+});
+
+const deleteUserSchema = z.object({
+  username: z.string().trim().min(1, "Type the account's username to confirm."),
+  password: z.string().min(1, "Your password is required."),
+});
+
+// Delete a local account (soft-delete with a retention window). GitHub-style:
+// the admin must type the account's exact username and re-enter their own
+// password — a stolen session alone cannot wipe accounts.
+adminRoutes.post("/users/:id/delete", jsonBody(deleteUserSchema), async (c) => {
+  const admin = requireAdmin(c);
+  const { username, password } = c.req.valid("json");
+  await moderation.deleteUser(admin.id, c.req.param("id"), { username, password });
+  return c.json({ ok: true });
+});
+
+// Restore a deleted account within its retention window.
+adminRoutes.post("/users/:id/restore", async (c) => {
+  requireAdmin(c);
+  await moderation.restoreUser(c.req.param("id"));
+  return c.json({ ok: true });
+});
+
+// Recently deleted accounts awaiting restore or expiry, newest deletion first.
+adminRoutes.get("/users/deleted", async (c) => {
+  requireAdmin(c);
+  const rows = await moderation.listDeletedUsers();
+  return c.json({ users: rows.map(deletedUserView) });
+});
+
+// Permanently erase a deleted account before its window ends (frees the handle
+// immediately; cannot be undone).
+adminRoutes.delete("/users/deleted/:id", async (c) => {
+  requireAdmin(c);
+  await moderation.purgeDeletedUser(c.req.param("id"));
   return c.json({ ok: true });
 });
 

--- a/apps/backend/src/routes/middleware.ts
+++ b/apps/backend/src/routes/middleware.ts
@@ -7,13 +7,13 @@ import type { AppEnv } from "@/routes/types.ts";
 
 // Resolves the Better Auth session → full user row on every request (null if
 // none). Loading the row (not just the session's user) keeps the whole `User`
-// shape — isAdmin, isPrivate, suspendedAt, actorKeyPair — available downstream.
+// shape — isAdmin, isPrivate, suspendedAt, deletedAt, actorKeyPair — available downstream.
 export const sessionMiddleware = createMiddleware<AppEnv>(async (c, next) => {
   const session = await auth.api.getSession({ headers: c.req.raw.headers });
   const user = session ? await usersRepo.findById(session.user.id) : null;
-  // A suspended account is treated as signed out at once, regardless of the
-  // session cookie cache (its sign-in is also blocked in auth/auth.ts).
-  c.set("user", user && !user.suspendedAt ? user : null);
+  // A suspended or deleted account is treated as signed out at once, regardless
+  // of the session cookie cache (its sign-in is also blocked in auth/auth.ts).
+  c.set("user", user && !user.suspendedAt && !user.deletedAt ? user : null);
   await next();
 });
 

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -100,6 +100,28 @@ export function adminUserView(u: User) {
   };
 }
 
+// A recently deleted account for the admin restore list: identity plus who
+// deleted it, how many posts are kept, and when the retention window ends
+// (computed by the service). Only ever returned to admins via the admin routes.
+export function deletedUserView(row: {
+  user: User;
+  deletedByUsername: string | null;
+  postCount: number;
+  expiresAt: Date;
+}) {
+  return {
+    id: row.user.id,
+    username: row.user.username,
+    displayName: row.user.displayName,
+    avatarUrl: row.user.avatarUrl,
+    email: row.user.email,
+    postCount: row.postCount,
+    deletedBy: row.deletedByUsername,
+    deletedAt: row.user.deletedAt ?? new Date(),
+    expiresAt: row.expiresAt,
+  };
+}
+
 // Coalesces the two possible author sources into one uniform shape. For remote
 // authors `username` is the full `user@host` handle, so the frontend's
 // `/@${author.username}` links resolve straight back to the remote profile.

--- a/apps/backend/src/routes/serializers_test.ts
+++ b/apps/backend/src/routes/serializers_test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { expect, test } from "vitest";
 import type { User } from "@/db/schema.ts";
-import { publicUser, webhookTokenView } from "@/routes/serializers.ts";
+import { deletedUserView, publicUser, webhookTokenView } from "@/routes/serializers.ts";
 
 // The serializers decide what leaves the server. These tests pin the parts that
 // are privacy decisions rather than plumbing.
@@ -21,6 +21,8 @@ const user = {
   isPrivate: true,
   emailVerified: false,
   suspendedAt: null,
+  deletedAt: null,
+  deletedBy: null,
   actorKeyPair: null,
   displayUsername: "ada",
   createdAt: new Date(),
@@ -66,4 +68,24 @@ test("webhookTokenView: never returns the token hash", () => {
   // The owning account is implied by the session; echoing it back is noise.
   expect("userId" in out).toBe(false);
   expect(out.label).toBe("Sanity");
+});
+
+test("deletedUserView: carries the restore metadata and no credentials", () => {
+  const deletedAt = new Date("2026-08-01T00:00:00.000Z");
+  const expiresAt = new Date("2026-08-31T00:00:00.000Z");
+  const out = deletedUserView({
+    user: { ...user, deletedAt, deletedBy: "admin-id" },
+    deletedByUsername: "root",
+    postCount: 7,
+    expiresAt,
+  }) as Record<string, unknown>;
+
+  expect(out.id).toBe("u1");
+  expect(out.username).toBe("ada");
+  expect(out.postCount).toBe(7);
+  expect(out.deletedBy).toBe("root");
+  expect(out.deletedAt).toEqual(deletedAt);
+  expect(out.expiresAt).toEqual(expiresAt);
+  expect("passwordHash" in out).toBe(false);
+  expect("actorKeyPair" in out).toBe(false);
 });

--- a/apps/backend/src/services/deletedUsers.ts
+++ b/apps/backend/src/services/deletedUsers.ts
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { purgeExpiredDeletedUsers } from "@/services/moderation.ts";
+
+// Hard-deletes soft-deleted accounts once their retention window ends.
+//
+// Database-backed and timer-driven like the scheduled-post sweeper
+// (services/scheduledPosts.ts): the job queue is one-shot and, without Redis,
+// not durable, while expiry must simply happen every day forever. The sweep is
+// idempotent — purging an already-purged account is a no-op — so it is safe to
+// run on every backend process without coordination.
+
+// Daily. The retention window absorbs sweep latency, so a tighter loop would
+// buy nothing for a scan that returns no rows almost every time.
+const SWEEP_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+// Most a single sweep will purge. A cap only matters after long downtime, when
+// a backlog of expiries comes due at once; the rest follow on later sweeps
+// rather than one pass holding locks on hundreds of cascades.
+const SWEEP_BATCH = 100;
+
+let started = false;
+
+/** Start the deleted-account expiry sweeper. Call once at boot. */
+export function startDeletedUserSweeper(): void {
+  if (started) return;
+  started = true;
+  void sweep();
+  setInterval(() => void sweep(), SWEEP_INTERVAL_MS);
+  console.log("✔ Deleted-account sweeper started.");
+}
+
+/**
+ * One pass. Exported for the tests, which drive it directly rather than
+ * waiting on a timer. Failures are logged and dropped — expired rows are still
+ * expired, so the next sweep sees them again.
+ */
+export async function sweep(): Promise<number> {
+  try {
+    const purged = await purgeExpiredDeletedUsers(new Date(), SWEEP_BATCH);
+    if (purged > 0) console.log(`deleted-users: purged ${purged} expired deleted account(s).`);
+    return purged;
+  } catch (err) {
+    console.error("deleted-users: expiry sweep failed:", err);
+    return 0;
+  }
+}

--- a/apps/backend/src/services/follows.ts
+++ b/apps/backend/src/services/follows.ts
@@ -86,7 +86,7 @@ export async function removeFollower(userId: string, identifier: string) {
 // already follows them.
 export async function profile(username: string, viewerId: string | null) {
   const user = await usersRepo.findByUsername(username);
-  if (!user) throw notFound("User not found.");
+  if (!user || user.deletedAt) throw notFound("User not found.");
   // A block (either direction) makes the two users invisible to each other, so
   // the blocked profile reads as not-found rather than rendering the header,
   // counts and bio. Unblocking is done from the Connections settings, not here.
@@ -118,7 +118,7 @@ async function canViewPrivate(user: { id: string; isPrivate: boolean }, viewerId
 // accounts), as a flat, uniform actor list.
 export async function followersOf(username: string, viewerId: string | null = null) {
   const user = await usersRepo.findByUsername(username);
-  if (!user) throw notFound("User not found.");
+  if (!user || user.deletedAt) throw notFound("User not found.");
   // A locked private profile hides its follower list from non-followers.
   if (!(await canViewPrivate(user, viewerId))) return [];
   const [local, remote] = await Promise.all([
@@ -130,7 +130,7 @@ export async function followersOf(username: string, viewerId: string | null = nu
 
 export async function followingOf(username: string, viewerId: string | null = null) {
   const user = await usersRepo.findByUsername(username);
-  if (!user) throw notFound("User not found.");
+  if (!user || user.deletedAt) throw notFound("User not found.");
   // A locked private profile hides its following list from non-followers.
   if (!(await canViewPrivate(user, viewerId))) return [];
   const [local, remote] = await Promise.all([

--- a/apps/backend/src/services/indexNow.ts
+++ b/apps/backend/src/services/indexNow.ts
@@ -65,7 +65,7 @@ export async function submitPost(postId: string): Promise<void> {
   if (!row.post.authorId) return;
 
   const author = await usersRepo.findById(row.post.authorId);
-  if (!author || author.suspendedAt || author.isPrivate) return;
+  if (!author || author.suspendedAt || author.deletedAt || author.isPrivate) return;
 
   await submit([`${site}${postPath(row.post, author.username)}`], site, seo.indexNowKey);
 }

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -1,4 +1,6 @@
+import bcrypt from "bcryptjs";
 import { config } from "@/config.ts";
+import * as accountsRepo from "@/db/repositories/accounts.ts";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
@@ -9,7 +11,9 @@ import * as sessionsRepo from "@/db/repositories/sessions.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import type { BlockedDomain } from "@/db/schema.ts";
 import { hostMatchesDomain, normalizeDomain } from "@/lib/domain.ts";
-import { badRequest, forbidden, notFound } from "@/lib/http.ts";
+import { badRequest, forbidden, notFound, unauthorized } from "@/lib/http.ts";
+import { queue } from "@/queue/queue.ts";
+import { federationRunning } from "@/services/federationState.ts";
 
 // Business logic for moderation. Admin authorization is enforced at the route
 // layer (requireAdmin); these functions assume the caller is a moderator except
@@ -93,6 +97,104 @@ export async function setSuspended(adminId: string, targetId: string, suspend: b
 
   await usersRepo.setSuspended(targetId, suspend ? new Date() : null);
   if (suspend) await sessionsRepo.removeAllForUser(targetId);
+}
+
+// ── User deletion (admin, soft-delete with retention) ──────────────────────
+
+// How long a deleted account is kept restorable before the sweeper erases it
+// for good. The admin UI shows the exact expiry per account.
+export const DELETED_USER_RETENTION_DAYS = 30;
+
+export function deletionExpiresAt(deletedAt: Date): Date {
+  return new Date(deletedAt.getTime() + DELETED_USER_RETENTION_DAYS * 86_400_000);
+}
+
+// Deletes a local account. GitHub-style safety: the caller must supply the
+// target's exact username plus the acting admin's own password, re-verified
+// against the credential hash (a stolen admin session alone cannot wipe
+// accounts). Like self-deletion, this federates Delete(actor) first, then
+// soft-deletes: the row — posts, follows and all — is kept for the retention
+// window so the deletion can be reverted, while the account itself cannot sign
+// in and vanishes from every listing, profile, feed and actor lookup.
+// Admins cannot delete themselves or other admins.
+export async function deleteUser(
+  adminId: string,
+  targetId: string,
+  input: { username: string; password: string },
+): Promise<void> {
+  const target = await usersRepo.findById(targetId);
+  if (!target || target.deletedAt) throw notFound("Account not found.");
+  if (target.id === adminId) throw forbidden("You can't delete your own account.");
+  if (target.isAdmin) throw forbidden("You can't delete another admin.");
+  if (input.username.trim() !== target.username) {
+    throw badRequest("The typed username does not match this account.");
+  }
+  const hash = await accountsRepo.findCredentialHashByUserId(adminId);
+  if (!hash || !(await bcrypt.compare(input.password, hash))) {
+    throw unauthorized("Incorrect password.");
+  }
+
+  if (federationRunning()) {
+    try {
+      const { sendActorDelete } = await import("@/federation/outbound.ts");
+      await sendActorDelete(target.id);
+    } catch (err) {
+      console.error("deleteUser: federated Delete failed (continuing):", err);
+    }
+  }
+  await usersRepo.setDeleted(targetId, new Date(), adminId);
+  await sessionsRepo.removeAllForUser(targetId);
+}
+
+// Restores a deleted account within its retention window. The username and
+// email were never freed (the row was kept), so restoration cannot conflict.
+// Queues an actor update so instances that cached the Delete can refetch.
+export async function restoreUser(targetId: string): Promise<void> {
+  const target = await usersRepo.findById(targetId);
+  if (!target || !target.deletedAt) throw notFound("Deleted account not found.");
+  await usersRepo.setDeleted(targetId, null, null);
+  queue.add("federate_actor_update", { userId: targetId });
+}
+
+// Recently deleted accounts with the deleting moderator's username, each
+// account's kept post count, and when its retention window ends — the admin
+// restore list.
+export async function listDeletedUsers(): Promise<
+  {
+    user: NonNullable<Awaited<ReturnType<typeof usersRepo.findById>>>;
+    deletedByUsername: string | null;
+    postCount: number;
+    expiresAt: Date;
+  }[]
+> {
+  const rows = await usersRepo.listDeleted();
+  const counts = await postsRepo.countLocalByAuthors(rows.map((r) => r.user.id));
+  return rows.map((r) => ({
+    ...r,
+    postCount: counts.get(r.user.id) ?? 0,
+    // `deletedAt` is non-null: listDeleted only returns deleted accounts.
+    expiresAt: deletionExpiresAt(r.user.deletedAt!),
+  }));
+}
+
+// Permanently erases a deleted account before its window ends. The Delete was
+// already federated at delete time; this drops the row (cascades wipe the
+// account's posts, follows and the rest) so the handle is freed immediately.
+export async function purgeDeletedUser(targetId: string): Promise<void> {
+  const target = await usersRepo.findById(targetId);
+  if (!target || !target.deletedAt) throw notFound("Deleted account not found.");
+  await usersRepo.hardRemove(targetId);
+}
+
+// Hard-deletes every account whose retention window ended before now. Returns
+// how many were purged. Driven by the expiry sweeper (services/deletedUsers.ts).
+export async function purgeExpiredDeletedUsers(now = new Date(), limit = 100): Promise<number> {
+  const cutoff = new Date(now.getTime() - DELETED_USER_RETENTION_DAYS * 86_400_000);
+  const expired = await usersRepo.listExpiredDeletedIds(cutoff, limit);
+  for (const { id } of expired) {
+    await usersRepo.hardRemove(id);
+  }
+  return expired.length;
 }
 
 // ── Posts (admin) ──────────────────────────────────────────────────────────

--- a/apps/backend/src/services/profileCard.ts
+++ b/apps/backend/src/services/profileCard.ts
@@ -47,7 +47,7 @@ async function sha256Hex(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
 /**
  * The share card for a local profile, generated on first request and cached.
  *
- * Throws 404 when no such user exists (or the account is suspended), so a
+ * Throws 404 when no such user exists (or the account is suspended or deleted), so a
  * card is no more reachable than the profile. Returns null when no card can
  * be drawn — a display name in a script the bundled face has no glyphs for —
  * and the caller falls back to the instance's brand image.
@@ -58,7 +58,7 @@ async function sha256Hex(bytes: Uint8Array<ArrayBuffer>): Promise<string> {
  */
 export async function profileCard(username: string): Promise<Uint8Array<ArrayBuffer> | null> {
   const user = await usersRepo.findByUsername(username);
-  if (!user || user.suspendedAt) throw notFound("User not found.");
+  if (!user || user.suspendedAt || user.deletedAt) throw notFound("User not found.");
 
   const [counts, postCounts, site] = await Promise.all([
     followsRepo.counts(user.id),

--- a/apps/backend/src/services/webhooks.ts
+++ b/apps/backend/src/services/webhooks.ts
@@ -84,6 +84,7 @@ async function authorForToken(presented: string): Promise<User> {
   // reachable in a race. Treat it as a bad credential, not a server error.
   if (!user) throw unauthorized("Invalid webhook credentials.");
   if (user.suspendedAt) throw forbidden("This account is suspended.");
+  if (user.deletedAt) throw forbidden("This account no longer exists.");
 
   // Best-effort: the owner reads this to spot a token they forgot about, so it
   // must never delay or fail a publish.
@@ -108,6 +109,9 @@ async function configuredAuthor(): Promise<User> {
   }
   if (user.suspendedAt) {
     throw new HttpError(503, "The ingestion author account is suspended.");
+  }
+  if (user.deletedAt) {
+    throw new HttpError(503, "The ingestion author account no longer exists.");
   }
   return user;
 }

--- a/apps/backend/tests/integration/admin_delete_user_test.ts
+++ b/apps/backend/tests/integration/admin_delete_user_test.ts
@@ -1,0 +1,210 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Admin user deletion: soft-delete with a retention window.
+//
+// Covers the moderation service end to end against real Postgres: the
+// GitHub-style confirmation (the exact username plus the acting admin's own
+// password), the guards (self / other admins / already deleted), the effects
+// (the row is kept but invisible, sessions are cleared, the restore list
+// carries the account), restore, early purge, and expiry purge.
+import bcrypt from "bcryptjs";
+import { eq } from "drizzle-orm";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { db } from "@/db/client.ts";
+import * as postsRepo from "@/db/repositories/posts.ts";
+import * as usersRepo from "@/db/repositories/users.ts";
+import { accounts, sessions } from "@/db/schema.ts";
+import { HttpError } from "@/lib/http.ts";
+import { sweep as sweepDeletedUsers } from "@/services/deletedUsers.ts";
+import * as moderation from "@/services/moderation.ts";
+import { closeDb, includesPost, mkPost, mkSession, mkUser, resetDb } from "./harness.ts";
+
+const ADMIN_PASSWORD = "correct-horse-battery-staple-12";
+
+// A Better Auth credential row for the admin, carrying a real bcrypt hash so
+// the password re-verification runs for real (cost 4 keeps the suite fast;
+// compare accepts any cost).
+async function mkCredential(userId: string, password: string) {
+  await db.insert(accounts).values({
+    userId,
+    accountId: userId,
+    providerId: "credential",
+    issuer: "local:credential",
+    password: await bcrypt.hash(password, 4),
+  });
+}
+
+async function sessionCount(userId: string): Promise<number> {
+  return (await db.select().from(sessions).where(eq(sessions.userId, userId))).length;
+}
+
+type Rows = readonly { post: { id: string } }[];
+
+async function globalPosts(): Promise<Rows> {
+  return postsRepo.listGlobal(null, null);
+}
+
+// Runs the promise to settlement, returning whatever it threw (or a sentinel
+// when it unexpectedly succeeded) so each test asserts on the status itself.
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  return new Error("expected rejection, but the call succeeded");
+}
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe("admin delete user", () => {
+  const adminName = "root";
+  let adminId: string;
+  let fellowAdminId: string;
+  let victimId: string;
+  let victimPostId: string;
+
+  beforeAll(async () => {
+    await resetDb();
+
+    const admin = await mkUser(adminName, { isAdmin: true });
+    adminId = admin.id;
+    await mkCredential(adminId, ADMIN_PASSWORD);
+
+    const fellow = await mkUser("fellow", { isAdmin: true });
+    fellowAdminId = fellow.id;
+    await mkCredential(fellowAdminId, ADMIN_PASSWORD);
+
+    const victim = await mkUser("victim");
+    victimId = victim.id;
+    const post = await mkPost(victimId, "victim-post");
+    victimPostId = post.id;
+    await mkSession(victimId, new Date());
+  });
+
+  test("wrong username is rejected and nothing changes", async () => {
+    const err = await captureRejection(
+      moderation.deleteUser(adminId, victimId, { username: "someone-else", password: ADMIN_PASSWORD }),
+    );
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(400);
+    expect((await usersRepo.findById(victimId))?.deletedAt).toBeNull();
+  });
+
+  test("wrong password is rejected and nothing changes", async () => {
+    const err = await captureRejection(
+      moderation.deleteUser(adminId, victimId, { username: "victim", password: "nope-nope-nope-nope" }),
+    );
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(401);
+    expect((await usersRepo.findById(victimId))?.deletedAt).toBeNull();
+  });
+
+  test("an admin cannot delete their own account", async () => {
+    const err = await captureRejection(
+      moderation.deleteUser(adminId, adminId, { username: adminName, password: ADMIN_PASSWORD }),
+    );
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(403);
+  });
+
+  test("an admin cannot delete another admin", async () => {
+    const err = await captureRejection(
+      moderation.deleteUser(adminId, fellowAdminId, { username: "fellow", password: ADMIN_PASSWORD }),
+    );
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(403);
+  });
+
+  test("delete keeps the row but hides the account everywhere", async () => {
+    await moderation.deleteUser(adminId, victimId, { username: "victim", password: ADMIN_PASSWORD });
+
+    const row = await usersRepo.findById(victimId);
+    expect(row?.deletedAt).toBeInstanceOf(Date);
+    expect(row?.deletedBy).toBe(adminId);
+
+    // Signed out: sessions are cleared.
+    expect(await sessionCount(victimId)).toBe(0);
+
+    // Vanishes from the admin table, the header count and search…
+    expect((await usersRepo.listForAdmin()).some((u) => u.id === victimId)).toBe(false);
+    expect((await usersRepo.listForAdmin("victim")).some((u) => u.id === victimId)).toBe(false);
+    expect((await usersRepo.search("victim")).some((u) => u.id === victimId)).toBe(false);
+    expect((await usersRepo.suggested(adminId)).some((u) => u.id === victimId)).toBe(false);
+    const total = await usersRepo.countUsers();
+    expect(total).toBe(2);
+
+    // …and the account's posts vanish from public listings.
+    expect(includesPost(await globalPosts(), victimPostId)).toBe(false);
+  });
+
+  test("a deleted account shows up on the restore list with its metadata", async () => {
+    const deleted = await moderation.listDeletedUsers();
+    expect(deleted).toHaveLength(1);
+    expect(deleted[0].user.id).toBe(victimId);
+    expect(deleted[0].deletedByUsername).toBe(adminName);
+    expect(deleted[0].postCount).toBe(1);
+    expect(deleted[0].user.deletedAt).toBeInstanceOf(Date);
+    expect(deleted[0].expiresAt.getTime() - deleted[0].user.deletedAt!.getTime()).toBe(
+      moderation.DELETED_USER_RETENTION_DAYS * 86_400_000,
+    );
+  });
+
+  test("deleting an already-deleted account 404s", async () => {
+    const err = await captureRejection(
+      moderation.deleteUser(adminId, victimId, { username: "victim", password: ADMIN_PASSWORD }),
+    );
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(404);
+  });
+
+  test("restoring a live account 404s", async () => {
+    const err = await captureRejection(moderation.restoreUser(adminId));
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(404);
+  });
+
+  test("restore brings the account fully back", async () => {
+    await moderation.restoreUser(victimId);
+
+    const row = await usersRepo.findById(victimId);
+    expect(row?.deletedAt).toBeNull();
+    expect(row?.deletedBy).toBeNull();
+
+    expect((await usersRepo.listForAdmin()).some((u) => u.id === victimId)).toBe(true);
+    expect(await moderation.listDeletedUsers()).toHaveLength(0);
+    expect(includesPost(await globalPosts(), victimPostId)).toBe(true);
+  });
+
+  test("purging a live account 404s", async () => {
+    const err = await captureRejection(moderation.purgeDeletedUser(victimId));
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(404);
+  });
+
+  test("purge erases the row and cascades its posts", async () => {
+    await moderation.deleteUser(adminId, victimId, { username: "victim", password: ADMIN_PASSWORD });
+    await moderation.purgeDeletedUser(victimId);
+
+    expect(await usersRepo.findById(victimId)).toBeUndefined();
+    expect(await postsRepo.findById(victimPostId)).toBeNull();
+    expect(await moderation.listDeletedUsers()).toHaveLength(0);
+  });
+
+  test("expiry purge only takes accounts past the retention window", async () => {
+    const oldTimer = await mkUser("oldtimer");
+    const fresh = await mkUser("fresh");
+    const ancient = new Date(Date.now() - (moderation.DELETED_USER_RETENTION_DAYS + 1) * 86_400_000);
+    await usersRepo.setDeleted(oldTimer.id, ancient, adminId);
+    await usersRepo.setDeleted(fresh.id, new Date(), adminId);
+
+    expect(await moderation.purgeExpiredDeletedUsers()).toBe(1);
+    expect(await usersRepo.findById(oldTimer.id)).toBeUndefined();
+    expect((await usersRepo.findById(fresh.id))?.deletedAt).toBeInstanceOf(Date);
+
+    // The sweeper service surfaces the same pass without throwing.
+    await expect(sweepDeletedUsers()).resolves.toBe(0);
+  });
+});

--- a/apps/backend/tests/integration/harness.ts
+++ b/apps/backend/tests/integration/harness.ts
@@ -52,7 +52,7 @@ export async function closeDb(): Promise<void> {
 // Deliberately terse: a visibility test should read as a sentence about who
 // can see what, not as twenty lines of insert boilerplate.
 
-export type UserOpts = { isPrivate?: boolean; suspended?: boolean };
+export type UserOpts = { isPrivate?: boolean; suspended?: boolean; isAdmin?: boolean; deleted?: boolean };
 
 export async function mkUser(username: string, opts: UserOpts = {}) {
   const [row] = await db
@@ -63,7 +63,9 @@ export async function mkUser(username: string, opts: UserOpts = {}) {
       passwordHash: "not-a-real-hash",
       displayName: username,
       isPrivate: opts.isPrivate ?? false,
+      isAdmin: opts.isAdmin ?? false,
       suspendedAt: opts.suspended ? new Date() : null,
+      deletedAt: opts.deleted ? new Date() : null,
     })
     .returning();
   return row;

--- a/apps/frontend/src/lib/api/contract.ts
+++ b/apps/frontend/src/lib/api/contract.ts
@@ -31,6 +31,7 @@ import type {
   AdminUser,
   Comment,
   CoverCredit,
+  DeletedUser,
   Notification,
   Post,
   PostAuthor,
@@ -46,6 +47,7 @@ import type {
 import type {
   adminUserView,
   commentView,
+  deletedUserView,
   notificationView,
   postWithAuthor,
   profileLinkView,
@@ -100,6 +102,7 @@ type _CoverCredit = Assert<Fits<NonNullable<Wire<typeof postWithAuthor>["coverCr
 
 type _User = Assert<Fits<Wire<typeof publicUser>, User>>;
 type _AdminUser = Assert<Fits<Wire<typeof adminUserView>, AdminUser>>;
+type _DeletedUser = Assert<Fits<Wire<typeof deletedUserView>, DeletedUser>>;
 
 type _Post = Assert<Fits<Wire<typeof postWithAuthor>, Post>>;
 type _PostAuthor = Assert<Fits<Wire<typeof postWithAuthor>["author"], PostAuthor>>;

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -5,6 +5,7 @@ import type {
   Comment,
   CoverCredit,
   DashboardSummary,
+  DeletedUser,
   DkimGenerateResult,
   EmailDnsResult,
   EmailInput,
@@ -134,6 +135,16 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     adminUsers: (q?: string) =>
       api.get<{ users: AdminUser[]; total: number }>(`/admin/users${q ? `?q=${encodeURIComponent(q)}` : ""}`),
     suspendUser: (id: string, suspend: boolean) => api.post<{ ok: true }>(`/admin/users/${id}/suspend`, { suspend }),
+    // Delete a local account. GitHub-style: the exact username plus the acting
+    // admin's own password travel with the request — the server re-verifies both.
+    deleteUser: (id: string, body: { username: string; password: string }) =>
+      api.post<{ ok: true }>(`/admin/users/${id}/delete`, body),
+    // Restore a deleted account within its retention window.
+    restoreUser: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/restore`, {}),
+    // Recently deleted accounts awaiting restore or expiry.
+    deletedUsers: () => api.get<{ users: DeletedUser[] }>("/admin/users/deleted"),
+    // Permanently erase a deleted account before its window ends.
+    purgeDeletedUser: (id: string) => api.del<{ ok: true }>(`/admin/users/deleted/${id}`),
     adminRemovePost: (id: string) => api.del<{ ok: true }>(`/admin/posts/${id}`),
     adminReports: (status?: "open" | "resolved") =>
       api.get<{ reports: Report[]; openCount: number }>(`/admin/reports${status ? `?status=${status}` : ""}`),

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -6,10 +6,11 @@
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import type { AdminUser } from "$lib/types";
+  import type { AdminUser, DeletedUser } from "$lib/types";
+  import { Dialog, Label } from "bits-ui";
 
-  // The signed-in admin's own id, so the row for self can hide the suspend
-  // action (the server also forbids it).
+  // The signed-in admin's own id, so the row for self can hide the suspend /
+  // delete actions (the server also forbids them).
   let { selfId }: { selfId: string } = $props();
 
   let users = $state<AdminUser[]>([]);
@@ -18,6 +19,20 @@
   let error = $state("");
   let query = $state("");
   let busyId = $state<string | null>(null);
+
+  // Recently deleted accounts: the retention window's restore list.
+  let deleted = $state<DeletedUser[]>([]);
+  let deletedLoading = $state(true);
+  let deletedError = $state("");
+
+  // GitHub-style delete confirmation: type the account's username and re-enter
+  // the admin's own password. Both travel with the request; the server
+  // re-verifies them before anything is deleted.
+  let deleteTarget = $state<AdminUser | null>(null);
+  let deleteUsername = $state("");
+  let deletePassword = $state("");
+  let deleteError = $state("");
+  let deleteBusy = $state(false);
 
   async function load() {
     loading = true;
@@ -33,8 +48,21 @@
     }
   }
 
+  async function loadDeleted() {
+    deletedLoading = true;
+    deletedError = "";
+    try {
+      deleted = (await endpoints().deletedUsers()).users;
+    } catch (e) {
+      deletedError = e instanceof ApiError ? e.message : "Failed to load deleted accounts.";
+    } finally {
+      deletedLoading = false;
+    }
+  }
+
   $effect(() => {
     load();
+    loadDeleted();
   });
 
   let searchTimer: ReturnType<typeof setTimeout>;
@@ -66,6 +94,83 @@
       busyId = null;
     }
   }
+
+  function openDelete(u: AdminUser) {
+    deleteTarget = u;
+    deleteUsername = "";
+    deletePassword = "";
+    deleteError = "";
+  }
+
+  function onDeleteOpenChange(open: boolean) {
+    if (!open) deleteTarget = null;
+  }
+
+  const deleteReady = $derived(
+    deleteTarget !== null && deleteUsername.trim() === deleteTarget.username && deletePassword.length > 0,
+  );
+
+  async function confirmDelete() {
+    if (!deleteTarget || !deleteReady || deleteBusy) return;
+    deleteBusy = true;
+    deleteError = "";
+    try {
+      await endpoints().deleteUser(deleteTarget.id, {
+        username: deleteUsername.trim(),
+        password: deletePassword,
+      });
+      users = users.filter((x) => x.id !== deleteTarget!.id);
+      deleteTarget = null;
+      await loadDeleted();
+    } catch (e) {
+      deleteError = e instanceof ApiError ? e.message : "Delete failed.";
+    } finally {
+      deleteBusy = false;
+    }
+  }
+
+  async function restoreDeleted(d: DeletedUser) {
+    busyId = d.id;
+    error = "";
+    try {
+      await endpoints().restoreUser(d.id);
+      deleted = deleted.filter((x) => x.id !== d.id);
+      await load();
+    } catch (e) {
+      error = e instanceof ApiError ? e.message : "Restore failed.";
+    } finally {
+      busyId = null;
+    }
+  }
+
+  async function purgeDeleted(d: DeletedUser) {
+    const ok = await confirm({
+      title: `Erase @${d.username} forever?`,
+      description:
+        "The account, its posts and all of its data will be permanently erased immediately. This cannot be undone.",
+      confirmText: "Erase forever",
+      destructive: true,
+    });
+    if (!ok) return;
+    busyId = d.id;
+    try {
+      await endpoints().purgeDeletedUser(d.id);
+      deleted = deleted.filter((x) => x.id !== d.id);
+    } catch (e) {
+      deletedError = e instanceof ApiError ? e.message : "Erase failed.";
+    } finally {
+      busyId = null;
+    }
+  }
+
+  // Whole days until the retention window ends, for the "expires in N days" label.
+  function daysLeft(iso: string): number {
+    return Math.max(0, Math.ceil((new Date(iso).getTime() - Date.now()) / 86_400_000));
+  }
+
+  const field =
+    "rounded-input border border-input bg-background shadow-btn px-3.5 py-2.5 text-sm outline-hidden placeholder:text-muted-foreground focus:border-foreground";
+  const labelClass = "text-sm font-medium leading-none";
 </script>
 
 <div class="flex flex-col gap-4">
@@ -126,18 +231,141 @@
             </p>
           </div>
           {#if u.id !== selfId && !u.isAdmin}
-            <Button
-              variant={u.suspended ? "outline" : "destructive"}
-              size="sm"
-              disabled={busyId === u.id}
-              onclick={() => toggleSuspend(u)}
-            >
-              <Icon name={u.suspended ? "check" : "shieldOff"} size={15} />
-              {u.suspended ? "Reinstate" : "Suspend"}
-            </Button>
+            <div class="flex shrink-0 items-center gap-2">
+              <Button
+                variant={u.suspended ? "outline" : "destructive"}
+                size="sm"
+                disabled={busyId === u.id}
+                onclick={() => toggleSuspend(u)}
+              >
+                <Icon name={u.suspended ? "check" : "shieldOff"} size={15} />
+                {u.suspended ? "Reinstate" : "Suspend"}
+              </Button>
+              <Button variant="outline" size="sm" disabled={busyId === u.id} onclick={() => openDelete(u)}>
+                <Icon name="trash" size={15} />
+                Delete
+              </Button>
+            </div>
           {/if}
         </li>
       {/each}
     </ul>
   {/if}
+
+  <div class="mt-4 border-t border-border pt-4">
+    <div class="flex items-center gap-2 text-sm text-muted-foreground">
+      <Icon name="clock" size={16} />
+      {#if deletedLoading}
+        <span>Loading recently deleted…</span>
+      {:else}
+        <span>
+          Recently deleted{deleted.length > 0 ? ` (${deleted.length})` : ""} — restorable until the retention window ends
+        </span>
+      {/if}
+    </div>
+
+    {#if deletedError}<p class="mt-2 text-sm text-destructive">{deletedError}</p>{/if}
+
+    {#if !deletedLoading}
+      {#if deleted.length === 0}
+        <p class="py-4 text-center text-sm text-muted-foreground">No deleted accounts.</p>
+      {:else}
+        <ul class="flex flex-col divide-y divide-border">
+          {#each deleted as d (d.id)}
+            <li class="flex items-center gap-3 py-3">
+              <Avatar name={d.displayName} src={d.avatarUrl ?? undefined} size={40} />
+              <div class="min-w-0 flex-1">
+                <div class="flex items-center gap-2">
+                  <span class="truncate font-medium text-foreground">{d.displayName}</span>
+                  <span class="rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+                    Deleted
+                  </span>
+                </div>
+                <p class="truncate text-xs text-muted-foreground">
+                  @{d.username} · {d.email} · {d.postCount}
+                  {d.postCount === 1 ? "post" : "posts"} kept
+                </p>
+                <p class="mt-0.5 flex items-center gap-1 text-xs text-muted-foreground">
+                  <Icon name="clock" size={12} />
+                  Deleted <Time iso={d.deletedAt} kind="date" />{d.deletedBy ? ` by @${d.deletedBy}` : ""} · erased <Time
+                    iso={d.expiresAt}
+                    kind="date"
+                  /> ({daysLeft(d.expiresAt)}
+                  {daysLeft(d.expiresAt) === 1 ? "day" : "days"} left)
+                </p>
+              </div>
+              <div class="flex shrink-0 items-center gap-2">
+                <Button variant="outline" size="sm" disabled={busyId === d.id} onclick={() => restoreDeleted(d)}>
+                  <Icon name="check" size={15} />
+                  Restore
+                </Button>
+                <Button variant="destructive" size="sm" disabled={busyId === d.id} onclick={() => purgeDeleted(d)}>
+                  <Icon name="trash" size={15} />
+                  Erase
+                </Button>
+              </div>
+            </li>
+          {/each}
+        </ul>
+      {/if}
+    {/if}
+  </div>
 </div>
+
+<Dialog.Root open={deleteTarget !== null} onOpenChange={onDeleteOpenChange}>
+  <Dialog.Portal>
+    <Dialog.Overlay
+      class="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50"
+    />
+    <Dialog.Content
+      class="fixed top-1/2 left-1/2 z-50 w-full max-w-[94%] -translate-x-1/2 -translate-y-1/2 rounded-card border border-border bg-background p-6 shadow-popover sm:max-w-[440px]"
+    >
+      <Dialog.Title class="text-lg font-semibold tracking-tight text-foreground">
+        Delete @{deleteTarget?.username}?
+      </Dialog.Title>
+      <Dialog.Description class="mt-1 text-sm text-muted-foreground">
+        This signs them out immediately and hides the account, its posts and its profile everywhere. The data is kept
+        for a limited time and can be restored from Recently deleted below.
+      </Dialog.Description>
+
+      <div class="mt-5 flex flex-col gap-4">
+        <div class="flex flex-col gap-1.5">
+          <Label.Root for="delete-username" class={labelClass}>
+            Type <strong class="text-foreground">{deleteTarget?.username}</strong> to confirm
+          </Label.Root>
+          <input
+            id="delete-username"
+            bind:value={deleteUsername}
+            placeholder={deleteTarget?.username ?? ""}
+            autocomplete="off"
+            autocapitalize="off"
+            spellcheck={false}
+            class={field}
+          />
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <Label.Root for="delete-password" class={labelClass}>Your password</Label.Root>
+          <input
+            id="delete-password"
+            type="password"
+            bind:value={deletePassword}
+            autocomplete="current-password"
+            class={field}
+          />
+        </div>
+        {#if deleteError}<p class="text-sm text-destructive">{deleteError}</p>{/if}
+      </div>
+
+      <div class="mt-6 flex justify-end gap-2">
+        <Dialog.Close
+          class="inline-flex h-10 items-center justify-center rounded-input px-4 text-sm font-medium text-foreground hover:bg-muted active:scale-[0.98]"
+        >
+          Cancel
+        </Dialog.Close>
+        <Button variant="destructive" disabled={!deleteReady || deleteBusy} onclick={confirmDelete}>
+          {deleteBusy ? "Deleting…" : "Delete this account"}
+        </Button>
+      </div>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -496,6 +496,21 @@ export type AdminUser = {
 // A defederated domain (admin only). Blocking a domain also blocks its subdomains.
 export type BlockedDomain = { domain: string; reason: string; createdAt: string };
 
+// A recently deleted account awaiting restore or expiry (admin only).
+// `deletedBy` is the deleting moderator's username (null when unknown);
+// `expiresAt` is when the retention window ends and the row is erased for good.
+export type DeletedUser = {
+  id: string;
+  username: string;
+  displayName: string;
+  avatarUrl: string | null;
+  email: string;
+  postCount: number;
+  deletedBy: string | null;
+  deletedAt: string;
+  expiresAt: string;
+};
+
 // A report in the moderation queue, enriched with light subject/reporter info.
 export type Report = {
   id: string;


### PR DESCRIPTION
## Symptom

Admins could only suspend accounts. There was no way to remove an account from the admin UI at all — the only path was a manual database delete, which is irreversible and bypasses federation.

## Root cause

No deletion primitive existed: no endpoint, no retention, no restore. A hard delete would also cascade away posts, follows and reports with no way back.

## Fix

Deletion is now a **soft-delete with a 30-day retention window**, in two commits:

**Backend** (`feat(admin): soft-delete users …`)
- Migration `0036_user_soft_delete`: `users.deleted_at` + `users.deleted_by` (FK set null).
- `POST /admin/users/:id/delete` requires the account's **exact username + the acting admin's own password** (bcrypt re-verified against the credential hash, generic 401 on mismatch). Guards: not self, not another admin, not already deleted. Federates `Delete(actor)` first (same path as self-deletion), then marks deleted + clears sessions.
- `POST /admin/users/:id/restore`, `GET /admin/users/deleted` (deleter name, kept post count, exact expiry), `DELETE /admin/users/deleted/:id` (early purge, frees the handle).
- Deleted accounts cannot sign in, read as signed out, and vanish from listings, profiles, feeds, search, sitemap, reading-list sitemap, share cards, webhook ingestion, IndexNow and federated actor/followers lookups — the same places suspension is enforced.
- Daily expiry sweeper (`services/deletedUsers.ts`, wired in `main.ts`) hard-deletes rows past the window. Usernames/emails stay reserved until purge, so restore can never conflict.
- New integration suite `admin_delete_user_test.ts` (confirmation, guards, invisibility, restore, purge, expiry) + a `deletedUserView` serializer test.

**Frontend** (`feat(admin): delete and restore controls …`)
- Per-account Delete button behind a GitHub-style dialog (type username + admin password, button enables only when both match), a Recently deleted section with deleter/expiry/post-count, Restore, and Erase-forever behind a confirm.

Why soft-delete instead of a backup snapshot + hard delete: restore is a single UPDATE with perfect fidelity (posts, follows, likes all survive), no snapshot/restore skew, and no window where the handle can be re-registered by someone else.

## Verified

- Backend: `vitest run src/` 307 passed; `oxlint` clean; `oxfmt --check` clean. (`deno check` could not run here — no Deno in this environment; CI covers it.)
- Frontend: `svelte-check` 0 errors (includes the backend↔frontend contract assertion for the new payload), `vitest` 34 passed, oxlint + oxfmt clean.
- **Not run here**: the new integration suite and the migration need Postgres + Deno, unavailable in this environment — CI must confirm them before merge.

## Deploy notes

Plain `docker compose up -d` applies migration 0036 on boot (additive, idempotent). No env or config changes. Follow-up worth tracking: a deleted/suspended author's *scheduled* posts still publish on the scheduler tick (pre-existing gap, unchanged by this PR); direct permalinks to a deleted author's posts behave like suspension (hidden from listings/profile, still resolvable by direct link).