### PR TITLE
feat(admin): email the account when a moderator deletes it

### DIFF
--- a/apps/backend/src/queue/handlers.ts
+++ b/apps/backend/src/queue/handlers.ts
@@ -1,5 +1,5 @@
 import { registerHandler } from "@/queue/queue.ts";
-import { sendEmailVerification, sendPasswordReset } from "@/services/email.ts";
+import { sendAccountDeleted, sendEmailVerification, sendPasswordReset } from "@/services/email.ts";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { federationRunning } from "@/services/federationState.ts";
 
@@ -123,4 +123,9 @@ export function registerJobHandlers() {
   // (and timing) doesn't depend on the mail server or whether an account exists.
   registerHandler("send_password_reset", ({ to, url }) => sendPasswordReset(to, url));
   registerHandler("send_email_verification", ({ to, url }) => sendEmailVerification(to, url));
+  // A moderated account's deletion notice: what happened, what it means, and
+  // until when restoration is possible.
+  registerHandler("send_account_deleted", ({ to, username, appName, origin, expiresAt }) =>
+    sendAccountDeleted(to, { username, appName, origin, expiresAt }),
+  );
 }

--- a/apps/backend/src/queue/queue.ts
+++ b/apps/backend/src/queue/queue.ts
@@ -26,7 +26,8 @@ export type JobName =
   | "send_recommend"
   | "send_unrecommend"
   | "send_password_reset"
-  | "send_email_verification";
+  | "send_email_verification"
+  | "send_account_deleted";
 
 export type JobPayloads = {
   federate_post: { postId: string; action?: "create" | "update" };
@@ -46,6 +47,9 @@ export type JobPayloads = {
   send_unrecommend: { userId: string; postId: string };
   send_password_reset: { to: string; url: string };
   send_email_verification: { to: string; url: string };
+  // A moderated account's deletion notice. `expiresAt` is an ISO instant (plain
+  // strings only — the payload crosses Redis as JSON).
+  send_account_deleted: { to: string; username: string; appName: string; origin: string; expiresAt: string };
 };
 
 type Handler<N extends JobName> = (payload: JobPayloads[N]) => Promise<void>;

--- a/apps/backend/src/services/email.ts
+++ b/apps/backend/src/services/email.ts
@@ -274,3 +274,44 @@ export function sendEmailVerification(to: string, url: string): Promise<void> {
     ),
   });
 }
+
+// ── Account deletion notice ────────────────────────────────────────────────
+// `expiresAt` is an ISO instant; only its calendar day is shown, so the reader
+// gets an unambiguous date rather than a timestamp in the server's zone.
+
+export type AccountDeletedVars = {
+  username: string;
+  appName: string;
+  origin: string;
+  expiresAt: string;
+};
+
+/** Pure content builder, kept separate from sending so the wording is reviewable. */
+export function accountDeletedEmail(vars: AccountDeletedVars): Omit<EmailMessage, "to"> {
+  const expiryDay = vars.expiresAt.slice(0, 10);
+  return {
+    subject: `Your ${vars.appName} account has been deleted`,
+    text: [
+      `Your account (@${vars.username}) on ${vars.appName} has been deleted by the instance moderation team.`,
+      "",
+      "What this means:",
+      "- You are signed out and cannot sign in.",
+      "- Your profile, posts and lists are no longer served.",
+      "",
+      `Your data is kept until ${expiryDay}. If you believe this is a mistake, contact the instance administrator before then to ask for your account to be restored. After that date your account and all of its data are permanently erased.`,
+      "",
+      `— The ${vars.appName} team`,
+      vars.origin,
+    ].join("\n"),
+    html: layout(
+      "Your account has been deleted",
+      `Your account (@${vars.username}) on ${vars.appName} has been deleted by the instance moderation team. You are signed out and cannot sign in, and your profile, posts and lists are no longer served. Your data is kept until ${expiryDay}: contact the instance administrator before then if you believe this is a mistake. After that date your account and all of its data are permanently erased.`,
+      { label: `Open ${vars.appName}`, url: vars.origin },
+    ),
+  };
+}
+
+/** Account-deletion notice. Queued off the request path (see queue/handlers.ts). */
+export function sendAccountDeleted(to: string, vars: AccountDeletedVars): Promise<void> {
+  return sendMail({ to, ...accountDeletedEmail(vars) });
+}

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -14,6 +14,7 @@ import { hostMatchesDomain, normalizeDomain } from "@/lib/domain.ts";
 import { badRequest, forbidden, notFound, unauthorized } from "@/lib/http.ts";
 import { queue } from "@/queue/queue.ts";
 import { federationRunning } from "@/services/federationState.ts";
+import { getAppName, getOrigin } from "@/services/instanceSetup.ts";
 
 // Business logic for moderation. Admin authorization is enforced at the route
 // layer (requireAdmin); these functions assume the caller is a moderator except
@@ -142,8 +143,24 @@ export async function deleteUser(
       console.error("deleteUser: federated Delete failed (continuing):", err);
     }
   }
-  await usersRepo.setDeleted(targetId, new Date(), adminId);
+  const deletedAt = new Date();
+  await usersRepo.setDeleted(targetId, deletedAt, adminId);
   await sessionsRepo.removeAllForUser(targetId);
+
+  // Tell the account what happened and until when restoration is possible.
+  // Best-effort: a mail failure must never fail (or roll back) the deletion.
+  try {
+    const [appName, origin] = await Promise.all([getAppName(), getOrigin()]);
+    queue.add("send_account_deleted", {
+      to: target.email,
+      username: target.username,
+      appName,
+      origin,
+      expiresAt: deletionExpiresAt(deletedAt).toISOString(),
+    });
+  } catch (err) {
+    console.error("deleteUser: failed to queue deletion notice (continuing):", err);
+  }
 }
 
 // Restores a deleted account within its retention window. The username and

--- a/apps/backend/tests/integration/admin_delete_user_test.ts
+++ b/apps/backend/tests/integration/admin_delete_user_test.ts
@@ -15,6 +15,7 @@ import * as postsRepo from "@/db/repositories/posts.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import { accounts, sessions } from "@/db/schema.ts";
 import { HttpError } from "@/lib/http.ts";
+import { registerHandler } from "@/queue/queue.ts";
 import { sweep as sweepDeletedUsers } from "@/services/deletedUsers.ts";
 import * as moderation from "@/services/moderation.ts";
 import { closeDb, includesPost, mkPost, mkSession, mkUser, resetDb } from "./harness.ts";
@@ -66,8 +67,15 @@ describe("admin delete user", () => {
   let victimId: string;
   let victimPostId: string;
 
+  // Captures the queued deletion notices instead of delivering them.
+  const deletionNotices: { to: string; username: string; appName: string; origin: string; expiresAt: string }[] = [];
+
   beforeAll(async () => {
     await resetDb();
+
+    registerHandler("send_account_deleted", async (payload) => {
+      deletionNotices.push(payload);
+    });
 
     const admin = await mkUser(adminName, { isAdmin: true });
     adminId = admin.id;
@@ -138,6 +146,17 @@ describe("admin delete user", () => {
 
     // …and the account's posts vanish from public listings.
     expect(includesPost(await globalPosts(), victimPostId)).toBe(false);
+
+    // The account is told what happened, off the request path — flush the
+    // queue microtask before asserting.
+    await new Promise((r) => setTimeout(r, 10));
+    expect(deletionNotices).toHaveLength(1);
+    expect(deletionNotices[0].to).toBe("victim@example.test");
+    expect(deletionNotices[0].username).toBe("victim");
+    expect(deletionNotices[0].appName).toBeTruthy();
+    expect(deletionNotices[0].origin).toMatch(/^https?:\/\//);
+    const noticeExpiry = new Date(deletionNotices[0].expiresAt).getTime();
+    expect(noticeExpiry - (row?.deletedAt?.getTime() ?? 0)).toBe(moderation.DELETED_USER_RETENTION_DAYS * 86_400_000);
   });
 
   test("a deleted account shows up on the restore list with its metadata", async () => {

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -324,8 +324,8 @@
         Delete @{deleteTarget?.username}?
       </Dialog.Title>
       <Dialog.Description class="mt-1 text-sm text-muted-foreground">
-        This signs them out immediately and hides the account, its posts and its profile everywhere. The data is kept
-        for a limited time and can be restored from Recently deleted below.
+        This signs them out immediately and hides the account, its posts and its profile everywhere. They will be
+        notified by email. The data is kept for a limited time and can be restored from Recently deleted below.
       </Dialog.Description>
 
       <div class="mt-5 flex flex-col gap-4">


### PR DESCRIPTION
## Symptom

A moderated account finds out it was deleted only by failing to sign in — no explanation, no recourse path, no date.

## Fix

`moderation.deleteUser` now queues a `send_account_deleted` job to the account's login address after the soft-delete commits. The notice states what happened, the immediate effects (signed out, profile/posts/lists unserved), and the exact date until which the admin can still restore the account, with an appeal prompt. Follows the existing transactional-email pattern: pure content builder (`accountDeletedEmail`) + sender in `services/email.ts`, payload across Redis as plain strings, handler in `queue/handlers.ts`. Delivery is best-effort and off the request path — a mail failure is logged and never fails or rolls back the deletion. The delete dialog notes that the account will be notified.

Deliberately scoped out: no mail on restore (the account can see it is back) and none on purge (the delete notice already names the permanent-erasure date) — easy to add if wanted.

## Verified

- Backend `vitest run src/`: 307 passed; `oxlint` and `oxfmt --check` clean.
- Frontend `svelte-check` 0 errors, `vitest` 34 passed, lint + format clean.
- Integration suite extended (captures the queued job, asserts recipient/username/expiry); needs Postgres + Deno, so CI must confirm before merge.
- `deno check` could not run here (no Deno in this environment); CI covers it.

## Deploy notes

Plain `docker compose up -d`. No migration, no env changes. Uses the instance's existing email configuration — on the default console transport the notice prints to the backend log.