### PR TITLE
feat(auth): notify the login address on account lifecycle events

### DIFF
--- a/apps/backend/src/auth/auth.ts
+++ b/apps/backend/src/auth/auth.ts
@@ -9,6 +9,7 @@ import { db } from "@/db/client.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import { accounts, sessions, users, verifications } from "@/db/schema.ts";
 import { queue } from "@/queue/queue.ts";
+import { notifyPasswordChanged, notifySelfDeleted } from "@/services/accountNotices.ts";
 
 const BCRYPT_COST = 12;
 const SESSION_TTL_S = 60 * 60 * 24 * 30;
@@ -112,6 +113,28 @@ export const auth = betterAuth({
         before: async (user) => {
           const isFirst = (await usersRepo.countUsers()) === 0;
           return isFirst ? { data: { ...user, isAdmin: true, emailVerified: true } } : { data: user };
+        },
+      },
+      delete: {
+        // Self-service deletion receipt. The row is already gone; the hook
+        // carries the address. (Moderator deletion is a soft-delete and never
+        // reaches this hook — see services/moderation.ts.)
+        after: async (user) => {
+          if (typeof user.email === "string" && typeof user.username === "string") {
+            await notifySelfDeleted(user.email, user.username);
+          }
+        },
+      },
+    },
+    account: {
+      update: {
+        // Any update to a credential account is a password change (change or
+        // reset — the only writes this app makes to those rows), so the owner
+        // gets a security notice pointing at the reset flow.
+        after: async (account) => {
+          if (account.providerId === "credential" && typeof account.userId === "string") {
+            await notifyPasswordChanged(account.userId);
+          }
         },
       },
     },

--- a/apps/backend/src/queue/handlers.ts
+++ b/apps/backend/src/queue/handlers.ts
@@ -1,5 +1,14 @@
 import { registerHandler } from "@/queue/queue.ts";
-import { sendAccountDeleted, sendEmailVerification, sendPasswordReset } from "@/services/email.ts";
+import {
+  sendAccountDeleted,
+  sendAccountErased,
+  sendAccountReinstated,
+  sendAccountRestored,
+  sendAccountSuspended,
+  sendEmailVerification,
+  sendPasswordChanged,
+  sendPasswordReset,
+} from "@/services/email.ts";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { federationRunning } from "@/services/federationState.ts";
 
@@ -127,5 +136,22 @@ export function registerJobHandlers() {
   // until when restoration is possible.
   registerHandler("send_account_deleted", ({ to, username, appName, origin, expiresAt }) =>
     sendAccountDeleted(to, { username, appName, origin, expiresAt }),
+  );
+  // Account lifecycle notices: each states what changed and what to do if it
+  // wasn't the owner.
+  registerHandler("send_password_changed", ({ to, username, appName, origin }) =>
+    sendPasswordChanged(to, { username, appName, origin }),
+  );
+  registerHandler("send_account_erased", ({ to, username, appName, origin }) =>
+    sendAccountErased(to, { username, appName, origin }),
+  );
+  registerHandler("send_account_suspended", ({ to, username, appName, origin }) =>
+    sendAccountSuspended(to, { username, appName, origin }),
+  );
+  registerHandler("send_account_reinstated", ({ to, username, appName, origin }) =>
+    sendAccountReinstated(to, { username, appName, origin }),
+  );
+  registerHandler("send_account_restored", ({ to, username, appName, origin }) =>
+    sendAccountRestored(to, { username, appName, origin }),
   );
 }

--- a/apps/backend/src/queue/queue.ts
+++ b/apps/backend/src/queue/queue.ts
@@ -27,7 +27,12 @@ export type JobName =
   | "send_unrecommend"
   | "send_password_reset"
   | "send_email_verification"
-  | "send_account_deleted";
+  | "send_account_deleted"
+  | "send_password_changed"
+  | "send_account_erased"
+  | "send_account_suspended"
+  | "send_account_reinstated"
+  | "send_account_restored";
 
 export type JobPayloads = {
   federate_post: { postId: string; action?: "create" | "update" };
@@ -50,6 +55,12 @@ export type JobPayloads = {
   // A moderated account's deletion notice. `expiresAt` is an ISO instant (plain
   // strings only — the payload crosses Redis as JSON).
   send_account_deleted: { to: string; username: string; appName: string; origin: string; expiresAt: string };
+  // Account lifecycle notices. Plain strings only, same reason as above.
+  send_password_changed: { to: string; username: string; appName: string; origin: string };
+  send_account_erased: { to: string; username: string; appName: string; origin: string };
+  send_account_suspended: { to: string; username: string; appName: string; origin: string };
+  send_account_reinstated: { to: string; username: string; appName: string; origin: string };
+  send_account_restored: { to: string; username: string; appName: string; origin: string };
 };
 
 type Handler<N extends JobName> = (payload: JobPayloads[N]) => Promise<void>;

--- a/apps/backend/src/services/accountNotices.ts
+++ b/apps/backend/src/services/accountNotices.ts
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import * as usersRepo from "@/db/repositories/users.ts";
+import { queue } from "@/queue/queue.ts";
+import { getAppName, getOrigin } from "@/services/instanceSetup.ts";
+
+// Best-effort account lifecycle emails (password changes, suspensions,
+// deletions and their reversals). Every helper resolves the instance wording,
+// queues the notice off the request path, and swallows failures with a log —
+// a mail problem must never fail the operation the notice describes.
+
+async function instanceVars(): Promise<{ appName: string; origin: string }> {
+  const [appName, origin] = await Promise.all([getAppName(), getOrigin()]);
+  return { appName, origin };
+}
+
+/** Security notice after a credential password change (change or reset). */
+export async function notifyPasswordChanged(userId: string): Promise<void> {
+  try {
+    const user = await usersRepo.findById(userId);
+    if (!user) return;
+    queue.add("send_password_changed", { to: user.email, username: user.username, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue password-changed notice (continuing):", err);
+  }
+}
+
+/** Receipt after self-service account deletion (the row is already gone). */
+export async function notifySelfDeleted(email: string, username: string): Promise<void> {
+  try {
+    queue.add("send_account_erased", { to: email, username, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue self-deletion receipt (continuing):", err);
+  }
+}
+
+/** Suspension notice after a moderator suspends the account. */
+export async function notifySuspended(email: string, username: string): Promise<void> {
+  try {
+    queue.add("send_account_suspended", { to: email, username, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue suspension notice (continuing):", err);
+  }
+}
+
+/** Reinstatement notice after a moderator lifts the suspension. */
+export async function notifyReinstated(email: string, username: string): Promise<void> {
+  try {
+    queue.add("send_account_reinstated", { to: email, username, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue reinstatement notice (continuing):", err);
+  }
+}
+
+/** Restore notice after a moderator brings back a deleted account. */
+export async function notifyRestored(email: string, username: string): Promise<void> {
+  try {
+    queue.add("send_account_restored", { to: email, username, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue restore notice (continuing):", err);
+  }
+}
+
+/** Deletion notice after a moderator deletes the account. `expiresAt` is ISO. */
+export async function notifyModeratorDeleted(email: string, username: string, expiresAt: string): Promise<void> {
+  try {
+    queue.add("send_account_deleted", { to: email, username, expiresAt, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue deletion notice (continuing):", err);
+  }
+}

--- a/apps/backend/src/services/email.ts
+++ b/apps/backend/src/services/email.ts
@@ -315,3 +315,142 @@ export function accountDeletedEmail(vars: AccountDeletedVars): Omit<EmailMessage
 export function sendAccountDeleted(to: string, vars: AccountDeletedVars): Promise<void> {
   return sendMail({ to, ...accountDeletedEmail(vars) });
 }
+
+// ── Account security + status notices ──────────────────────────────────────
+// One short template per account lifecycle event. All are best-effort and sent
+// off the request path — a mail failure must never fail the operation itself.
+
+export type AccountNoticeVars = {
+  username: string;
+  appName: string;
+  origin: string;
+};
+
+/** Password-changed security notice. Points at the reset flow in case it wasn't them. */
+export function accountPasswordChangedEmail(vars: AccountNoticeVars): Omit<EmailMessage, "to"> {
+  return {
+    subject: `Your ${vars.appName} password was changed`,
+    text: [
+      `The password for your account (@${vars.username}) on ${vars.appName} was just changed.`,
+      "",
+      "If this was you, you can ignore this email. If it wasn't, reset your password immediately — your account may be compromised.",
+      `${vars.origin}/forgot-password`,
+      "",
+      `— The ${vars.appName} team`,
+    ].join("\n"),
+    html: layout(
+      "Your password was changed",
+      `The password for your account (@${vars.username}) on ${vars.appName} was just changed. If this was you, you can ignore this email. If it wasn't, reset your password immediately — your account may be compromised.`,
+      { label: "Reset password", url: `${vars.origin}/forgot-password` },
+    ),
+  };
+}
+
+/** Password-changed security notice. Queued off the request path (see queue/handlers.ts). */
+export function sendPasswordChanged(to: string, vars: AccountNoticeVars): Promise<void> {
+  return sendMail({ to, ...accountPasswordChangedEmail(vars) });
+}
+
+/** Self-deletion receipt: the account and all its data are gone immediately. */
+export function accountErasedEmail(vars: AccountNoticeVars): Omit<EmailMessage, "to"> {
+  return {
+    subject: `Your ${vars.appName} account has been permanently deleted`,
+    text: [
+      `Your account (@${vars.username}) on ${vars.appName} has been permanently deleted, as requested.`,
+      "",
+      "Your profile, posts, lists and all other data were removed with it. This cannot be undone.",
+      "",
+      `— The ${vars.appName} team`,
+      vars.origin,
+    ].join("\n"),
+    html: layout(
+      "Your account has been permanently deleted",
+      `Your account (@${vars.username}) on ${vars.appName} has been permanently deleted, as requested. Your profile, posts, lists and all other data were removed with it. This cannot be undone.`,
+      { label: `Open ${vars.appName}`, url: vars.origin },
+    ),
+  };
+}
+
+/** Self-deletion receipt. Queued off the request path (see queue/handlers.ts). */
+export function sendAccountErased(to: string, vars: AccountNoticeVars): Promise<void> {
+  return sendMail({ to, ...accountErasedEmail(vars) });
+}
+
+/** Suspension notice: signed out, content unserved, with an appeal prompt. */
+export function accountSuspendedEmail(vars: AccountNoticeVars): Omit<EmailMessage, "to"> {
+  return {
+    subject: `Your ${vars.appName} account has been suspended`,
+    text: [
+      `Your account (@${vars.username}) on ${vars.appName} has been suspended by the instance moderation team.`,
+      "",
+      "What this means:",
+      "- You cannot sign in until the suspension is lifted.",
+      "- Your profile, posts and lists are no longer served.",
+      "",
+      "If you believe this is a mistake, contact the instance administrator.",
+      "",
+      `— The ${vars.appName} team`,
+      vars.origin,
+    ].join("\n"),
+    html: layout(
+      "Your account has been suspended",
+      `Your account (@${vars.username}) on ${vars.appName} has been suspended by the instance moderation team. You cannot sign in until the suspension is lifted, and your profile, posts and lists are no longer served. If you believe this is a mistake, contact the instance administrator.`,
+      { label: `Open ${vars.appName}`, url: vars.origin },
+    ),
+  };
+}
+
+/** Suspension notice. Queued off the request path (see queue/handlers.ts). */
+export function sendAccountSuspended(to: string, vars: AccountNoticeVars): Promise<void> {
+  return sendMail({ to, ...accountSuspendedEmail(vars) });
+}
+
+/** Reinstatement notice: the suspension was lifted. */
+export function accountReinstatedEmail(vars: AccountNoticeVars): Omit<EmailMessage, "to"> {
+  return {
+    subject: `Your ${vars.appName} account has been reinstated`,
+    text: [
+      `Good news — your account (@${vars.username}) on ${vars.appName} has been reinstated.`,
+      "",
+      "You can sign in again, and your profile, posts and lists are served as before.",
+      "",
+      `— The ${vars.appName} team`,
+      `${vars.origin}/login`,
+    ].join("\n"),
+    html: layout(
+      "Your account has been reinstated",
+      `Good news — your account (@${vars.username}) on ${vars.appName} has been reinstated. You can sign in again, and your profile, posts and lists are served as before.`,
+      { label: "Sign in", url: `${vars.origin}/login` },
+    ),
+  };
+}
+
+/** Reinstatement notice. Queued off the request path (see queue/handlers.ts). */
+export function sendAccountReinstated(to: string, vars: AccountNoticeVars): Promise<void> {
+  return sendMail({ to, ...accountReinstatedEmail(vars) });
+}
+
+/** Restore notice: a moderator-deleted account is back. */
+export function accountRestoredEmail(vars: AccountNoticeVars): Omit<EmailMessage, "to"> {
+  return {
+    subject: `Your ${vars.appName} account has been restored`,
+    text: [
+      `Good news — your deleted account (@${vars.username}) on ${vars.appName} has been restored.`,
+      "",
+      "You can sign in again, and your profile, posts and lists are back as they were.",
+      "",
+      `— The ${vars.appName} team`,
+      `${vars.origin}/login`,
+    ].join("\n"),
+    html: layout(
+      "Your account has been restored",
+      `Good news — your deleted account (@${vars.username}) on ${vars.appName} has been restored. You can sign in again, and your profile, posts and lists are back as they were.`,
+      { label: "Sign in", url: `${vars.origin}/login` },
+    ),
+  };
+}
+
+/** Restore notice. Queued off the request path (see queue/handlers.ts). */
+export function sendAccountRestored(to: string, vars: AccountNoticeVars): Promise<void> {
+  return sendMail({ to, ...accountRestoredEmail(vars) });
+}

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -13,8 +13,13 @@ import type { BlockedDomain } from "@/db/schema.ts";
 import { hostMatchesDomain, normalizeDomain } from "@/lib/domain.ts";
 import { badRequest, forbidden, notFound, unauthorized } from "@/lib/http.ts";
 import { queue } from "@/queue/queue.ts";
+import {
+  notifyModeratorDeleted,
+  notifyReinstated,
+  notifyRestored,
+  notifySuspended,
+} from "@/services/accountNotices.ts";
 import { federationRunning } from "@/services/federationState.ts";
-import { getAppName, getOrigin } from "@/services/instanceSetup.ts";
 
 // Business logic for moderation. Admin authorization is enforced at the route
 // layer (requireAdmin); these functions assume the caller is a moderator except
@@ -97,7 +102,12 @@ export async function setSuspended(adminId: string, targetId: string, suspend: b
   if (target.isAdmin) throw forbidden("You can't suspend another admin.");
 
   await usersRepo.setSuspended(targetId, suspend ? new Date() : null);
-  if (suspend) await sessionsRepo.removeAllForUser(targetId);
+  if (suspend) {
+    await sessionsRepo.removeAllForUser(targetId);
+    await notifySuspended(target.email, target.username);
+  } else {
+    await notifyReinstated(target.email, target.username);
+  }
 }
 
 // ── User deletion (admin, soft-delete with retention) ──────────────────────
@@ -146,21 +156,8 @@ export async function deleteUser(
   const deletedAt = new Date();
   await usersRepo.setDeleted(targetId, deletedAt, adminId);
   await sessionsRepo.removeAllForUser(targetId);
-
   // Tell the account what happened and until when restoration is possible.
-  // Best-effort: a mail failure must never fail (or roll back) the deletion.
-  try {
-    const [appName, origin] = await Promise.all([getAppName(), getOrigin()]);
-    queue.add("send_account_deleted", {
-      to: target.email,
-      username: target.username,
-      appName,
-      origin,
-      expiresAt: deletionExpiresAt(deletedAt).toISOString(),
-    });
-  } catch (err) {
-    console.error("deleteUser: failed to queue deletion notice (continuing):", err);
-  }
+  await notifyModeratorDeleted(target.email, target.username, deletionExpiresAt(deletedAt).toISOString());
 }
 
 // Restores a deleted account within its retention window. The username and
@@ -170,6 +167,7 @@ export async function restoreUser(targetId: string): Promise<void> {
   const target = await usersRepo.findById(targetId);
   if (!target || !target.deletedAt) throw notFound("Deleted account not found.");
   await usersRepo.setDeleted(targetId, null, null);
+  await notifyRestored(target.email, target.username);
   queue.add("federate_actor_update", { userId: targetId });
 }
 

--- a/apps/backend/tests/integration/account_notices_test.ts
+++ b/apps/backend/tests/integration/account_notices_test.ts
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Account lifecycle emails: every operation that changes what an account can
+// do — password change, self-deletion, suspension, reinstatement, restore —
+// notifies its login address. The tests capture the queued jobs instead of
+// delivering them and assert on recipient and payload.
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import * as usersRepo from "@/db/repositories/users.ts";
+import { registerHandler } from "@/queue/queue.ts";
+import { notifyPasswordChanged, notifySelfDeleted } from "@/services/accountNotices.ts";
+import * as moderation from "@/services/moderation.ts";
+import { closeDb, mkUser, resetDb } from "./harness.ts";
+
+type Notice = { to: string; username: string; appName: string; origin: string; expiresAt?: string };
+
+const captured = new Map<string, Notice[]>();
+
+function notices(job: string): Notice[] {
+  return captured.get(job) ?? [];
+}
+
+// The queue delivers off the request path; flush before asserting.
+async function flush() {
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe("account notice emails", () => {
+  let adminId: string;
+  let userId: string;
+  let suspendeeId: string;
+  let restoreeId: string;
+
+  beforeAll(async () => {
+    await resetDb();
+
+    for (const job of [
+      "send_password_changed",
+      "send_account_erased",
+      "send_account_suspended",
+      "send_account_reinstated",
+      "send_account_restored",
+    ] as const) {
+      registerHandler(job, async (payload) => {
+        captured.set(job, [...(captured.get(job) ?? []), payload]);
+      });
+    }
+
+    adminId = (await mkUser("root", { isAdmin: true })).id;
+    userId = (await mkUser("notable")).id;
+    suspendeeId = (await mkUser("suspendee")).id;
+    restoreeId = (await mkUser("restoree")).id;
+  });
+
+  test("password change notifies the login address", async () => {
+    await notifyPasswordChanged(userId);
+    await flush();
+
+    const [notice] = notices("send_password_changed");
+    expect(notice?.to).toBe("notable@example.test");
+    expect(notice?.username).toBe("notable");
+    expect(notice?.appName).toBeTruthy();
+    expect(notice?.origin).toMatch(/^https?:\/\//);
+  });
+
+  test("password change for a gone account notifies nobody", async () => {
+    await notifyPasswordChanged("00000000-0000-0000-0000-000000000000");
+    await flush();
+
+    expect(notices("send_password_changed")).toHaveLength(1);
+  });
+
+  test("self-deletion sends a receipt to the former address", async () => {
+    await notifySelfDeleted("gone@example.test", "gone");
+    await flush();
+
+    const [notice] = notices("send_account_erased");
+    expect(notice?.to).toBe("gone@example.test");
+    expect(notice?.username).toBe("gone");
+  });
+
+  test("suspend and reinstate each notify the account", async () => {
+    await moderation.setSuspended(adminId, suspendeeId, true);
+    await flush();
+    const [suspended] = notices("send_account_suspended");
+    expect(suspended?.to).toBe("suspendee@example.test");
+    expect(suspended?.username).toBe("suspendee");
+
+    await moderation.setSuspended(adminId, suspendeeId, false);
+    await flush();
+    const [reinstated] = notices("send_account_reinstated");
+    expect(reinstated?.to).toBe("suspendee@example.test");
+    expect(reinstated?.username).toBe("suspendee");
+  });
+
+  test("restore notifies the account it is back", async () => {
+    await usersRepo.setDeleted(restoreeId, new Date(), adminId);
+    await moderation.restoreUser(restoreeId);
+    await flush();
+
+    const [restored] = notices("send_account_restored");
+    expect(restored?.to).toBe("restoree@example.test");
+    expect(restored?.username).toBe("restoree");
+  });
+});


### PR DESCRIPTION
## Symptom

Several operations change what an account can do without telling its owner: password changes (including via reset) sent nothing, self-deletion sent no receipt, and moderator suspend/reinstate/restore were silent — the account only discovered each by failing to sign in (or not at all, for a password change by an attacker).

## Fix

Every account lifecycle event now queues a short notice to the login address — what changed, what it means, and what to do if it wasn't them:

| Event | Trigger | Notice |
| --- | --- | --- |
| Password changed (change or reset) | `databaseHooks.account.update.after` on credential rows (the only writes to those rows) | Security notice pointing at `/forgot-password` |
| Self-deletion | `databaseHooks.user.delete.after` (moderator soft-delete never reaches it) | Permanent-deletion receipt |
| Suspend / reinstate | `moderation.setSuspended` | Effect + appeal prompt / sign-in link |
| Restore | `moderation.restoreUser` | Back-as-it-was + sign-in link |

Pattern matches the existing transactional email: pure builders + senders in `services/email.ts`, five new queue jobs with plain-string payloads, handlers in `queue/handlers.ts`, orchestration in the new `services/accountNotices.ts` (fail-open: a mail problem is logged, never fails the operation). No purge mail — the moderator-delete notice already names the permanent-erasure date.

## Verified

- Backend `vitest run src/`: 307 passed; `oxlint` and `oxfmt --check` clean.
- New `account_notices_test.ts` captures the queued jobs and asserts recipient/payload for all five (needs Postgres + Deno — CI must confirm).
- `deno check` could not run here; CI covers it. No frontend changes.

## Deploy notes

Plain `docker compose up -d`. No migration, no env changes. Uses the instance's existing email configuration (console transport logs in dev).