### PR TITLE
feat(admin): roles and user detail on the users page

### DIFF
--- a/apps/backend/src/db/repositories/posts.ts
+++ b/apps/backend/src/db/repositories/posts.ts
@@ -736,6 +736,23 @@ export async function countLocalByAuthors(authorIds: string[]): Promise<Map<stri
   return totals;
 }
 
+// An author's latest local posts in any state, newest first — the context
+// behind a moderation decision on the admin user detail.
+export function listRecentByAuthor(authorId: string, limit = 5) {
+  return db
+    .select({
+      id: posts.id,
+      title: posts.title,
+      slug: posts.slug,
+      status: posts.status,
+      createdAt: posts.createdAt,
+    })
+    .from(posts)
+    .where(and(eq(posts.authorId, authorId), eq(posts.remote, false)))
+    .orderBy(desc(posts.createdAt))
+    .limit(limit);
+}
+
 // How many posts the author holds in each state, for the management page's tab
 // badges. One grouped scan rather than three counts.
 export async function countsByAuthor(authorId: string) {

--- a/apps/backend/src/db/repositories/reports.ts
+++ b/apps/backend/src/db/repositories/reports.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { aliasedTable, and, desc, eq, sql } from "drizzle-orm";
+import { aliasedTable, and, desc, eq, inArray, or, sql } from "drizzle-orm";
 import { db } from "@/db/client.ts";
 import { type NewReport, posts, reports, users } from "@/db/schema.ts";
 
@@ -80,6 +80,17 @@ function shape(r: Awaited<ReturnType<ReturnType<typeof baseQuery>["execute"]>>[n
 export async function list(status?: "open" | "resolved", limit = 200): Promise<ReportRow[]> {
   const q = baseQuery();
   const rows = await (status ? q.where(eq(reports.status, status)) : q).orderBy(desc(reports.createdAt)).limit(limit);
+  return rows.map(shape);
+}
+
+// Everything filed against one account: direct account reports plus reports on
+// their posts. Newest first — the context behind a suspend/delete decision.
+export async function listAgainstUser(userId: string, limit = 20): Promise<ReportRow[]> {
+  const authoredPosts = db.select({ id: posts.id }).from(posts).where(eq(posts.authorId, userId));
+  const rows = await baseQuery()
+    .where(or(eq(reports.userId, userId), and(eq(reports.subjectType, "post"), inArray(reports.postId, authoredPosts))))
+    .orderBy(desc(reports.createdAt))
+    .limit(limit);
   return rows.map(shape);
 }
 

--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -199,6 +199,23 @@ export async function setSuspended(id: string, at: Date | null) {
   return row;
 }
 
+// Grants or revokes the admin role. Returns the updated row.
+export async function setAdmin(id: string, isAdmin: boolean) {
+  const [row] = await db.update(users).set({ isAdmin }).where(eq(users.id, id)).returning();
+  return row;
+}
+
+// How many live admins exist — the demote guardrail (the last admin cannot be
+// removed). Deleted accounts cannot be admins (deletion refuses them), but the
+// filter keeps the count honest regardless.
+export async function countAdmins(): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(users)
+    .where(and(eq(users.isAdmin, true), sql`${users.deletedAt} is null`));
+  return row?.n ?? 0;
+}
+
 // Every account's id, email, and creation time — for the one-off email-lowercase
 // backfill (scripts/backfill_email_lowercase.ts), which canonicalises rows that
 // predate case-normalised registration. Oldest first, so a collision report is

--- a/apps/backend/src/queue/handlers.ts
+++ b/apps/backend/src/queue/handlers.ts
@@ -5,6 +5,8 @@ import {
   sendAccountReinstated,
   sendAccountRestored,
   sendAccountSuspended,
+  sendAdminGranted,
+  sendAdminRevoked,
   sendEmailVerification,
   sendPasswordChanged,
   sendPasswordReset,
@@ -153,5 +155,12 @@ export function registerJobHandlers() {
   );
   registerHandler("send_account_restored", ({ to, username, appName, origin }) =>
     sendAccountRestored(to, { username, appName, origin }),
+  );
+  // The admin role was granted or revoked; the affected account is told either way.
+  registerHandler("send_admin_granted", ({ to, username, appName, origin }) =>
+    sendAdminGranted(to, { username, appName, origin }),
+  );
+  registerHandler("send_admin_revoked", ({ to, username, appName, origin }) =>
+    sendAdminRevoked(to, { username, appName, origin }),
   );
 }

--- a/apps/backend/src/queue/queue.ts
+++ b/apps/backend/src/queue/queue.ts
@@ -32,7 +32,9 @@ export type JobName =
   | "send_account_erased"
   | "send_account_suspended"
   | "send_account_reinstated"
-  | "send_account_restored";
+  | "send_account_restored"
+  | "send_admin_granted"
+  | "send_admin_revoked";
 
 export type JobPayloads = {
   federate_post: { postId: string; action?: "create" | "update" };
@@ -61,6 +63,8 @@ export type JobPayloads = {
   send_account_suspended: { to: string; username: string; appName: string; origin: string };
   send_account_reinstated: { to: string; username: string; appName: string; origin: string };
   send_account_restored: { to: string; username: string; appName: string; origin: string };
+  send_admin_granted: { to: string; username: string; appName: string; origin: string };
+  send_admin_revoked: { to: string; username: string; appName: string; origin: string };
 };
 
 type Handler<N extends JobName> = (payload: JobPayloads[N]) => Promise<void>;

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -5,7 +5,7 @@ import { rotateSessionSecret, sessionSecretManaged } from "@/config.ts";
 import { badRequest } from "@/lib/http.ts";
 import { jsonBody } from "@/lib/validate.ts";
 import { requireAdmin } from "@/routes/middleware.ts";
-import { adminUserView, deletedUserView } from "@/routes/serializers.ts";
+import { adminUserDetailView, adminUserView, deletedUserView } from "@/routes/serializers.ts";
 import type { AppEnv } from "@/routes/types.ts";
 import * as anubis from "@/services/anubisProtection.ts";
 import { dnsRecords } from "@/services/dkim.ts";
@@ -344,6 +344,28 @@ adminRoutes.delete("/users/deleted/:id", async (c) => {
   requireAdmin(c);
   await moderation.purgeDeletedUser(c.req.param("id"));
   return c.json({ ok: true });
+});
+
+const roleSchema = z.object({
+  makeAdmin: z.boolean(),
+  password: z.string().min(1, "Your password is required."),
+});
+
+// Grant or revoke the admin role. The acting admin's own password is
+// re-verified — a stolen session alone must not mint new admins. Never self,
+// never the last admin.
+adminRoutes.post("/users/:id/role", jsonBody(roleSchema), async (c) => {
+  const admin = requireAdmin(c);
+  const { makeAdmin, password } = c.req.valid("json");
+  await moderation.setAdminRole(admin.id, c.req.param("id"), { makeAdmin, password });
+  return c.json({ ok: true });
+});
+
+// Full detail for one account: the table row plus counts, latest posts and
+// reports filed against the account or its posts.
+adminRoutes.get("/users/:id", async (c) => {
+  requireAdmin(c);
+  return c.json(adminUserDetailView(await moderation.getUserDetail(c.req.param("id"))));
 });
 
 // ── Posts ────────────────────────────────────────────────────────────────

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -1,6 +1,7 @@
 import type { CommentWithAuthor } from "@/db/repositories/comments.ts";
 import type { NotificationRow } from "@/db/repositories/notifications.ts";
 import type { PostWithAuthor } from "@/db/repositories/posts.ts";
+import type { ReportRow } from "@/db/repositories/reports.ts";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import type { Post, ProfileLink, ReadingList as ReadingListRow, RemoteActor, User, WebhookToken } from "@/db/schema.ts";
 import { bannerOf } from "@/lib/cover.ts";
@@ -97,6 +98,26 @@ export function adminUserView(u: User) {
     emailVerified: u.emailVerified,
     suspended: u.suspendedAt !== null,
     createdAt: u.createdAt,
+  };
+}
+
+// Full admin user detail: the table row plus post/follow counts, the latest
+// posts and the reports filed against the account or its posts. The reports
+// already carry the queue's display shape, so they pass through untouched.
+// Only ever returned to admins via the admin routes.
+export function adminUserDetailView(row: {
+  user: User;
+  postCounts: { draft: number; scheduled: number; published: number };
+  followCounts: { followers: number; following: number };
+  recentPosts: { id: string; title: string | null; slug: string | null; status: string; createdAt: Date }[];
+  reports: ReportRow[];
+}) {
+  return {
+    user: adminUserView(row.user),
+    postCounts: row.postCounts,
+    followCounts: row.followCounts,
+    recentPosts: row.recentPosts,
+    reports: row.reports,
   };
 }
 

--- a/apps/backend/src/services/accountNotices.ts
+++ b/apps/backend/src/services/accountNotices.ts
@@ -68,3 +68,21 @@ export async function notifyModeratorDeleted(email: string, username: string, ex
     console.error("accountNotices: failed to queue deletion notice (continuing):", err);
   }
 }
+
+/** Admin-granted notice after a moderator promotes the account. */
+export async function notifyAdminGranted(email: string, username: string): Promise<void> {
+  try {
+    queue.add("send_admin_granted", { to: email, username, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue admin-granted notice (continuing):", err);
+  }
+}
+
+/** Admin-revoked notice after a moderator demotes the account. */
+export async function notifyAdminRevoked(email: string, username: string): Promise<void> {
+  try {
+    queue.add("send_admin_revoked", { to: email, username, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue admin-revoked notice (continuing):", err);
+  }
+}

--- a/apps/backend/src/services/email.ts
+++ b/apps/backend/src/services/email.ts
@@ -454,3 +454,53 @@ export function accountRestoredEmail(vars: AccountNoticeVars): Omit<EmailMessage
 export function sendAccountRestored(to: string, vars: AccountNoticeVars): Promise<void> {
   return sendMail({ to, ...accountRestoredEmail(vars) });
 }
+
+/** Admin-granted notice: the account can now moderate the instance. */
+export function accountAdminGrantedEmail(vars: AccountNoticeVars): Omit<EmailMessage, "to"> {
+  return {
+    subject: `You are now an admin on ${vars.appName}`,
+    text: [
+      `Your account (@${vars.username}) on ${vars.appName} has been given the admin role.`,
+      "",
+      "You can now open /admin: moderate reports and accounts, manage defederation, and change instance settings. With that comes access to other people's private data (login emails) — treat it accordingly.",
+      "",
+      `— The ${vars.appName} team`,
+      `${vars.origin}/admin`,
+    ].join("\n"),
+    html: layout(
+      "You are now an admin",
+      `Your account (@${vars.username}) on ${vars.appName} has been given the admin role. You can now open the admin panel: moderate reports and accounts, manage defederation, and change instance settings. With that comes access to other people's private data (login emails) — treat it accordingly.`,
+      { label: "Open the admin panel", url: `${vars.origin}/admin` },
+    ),
+  };
+}
+
+/** Admin-granted notice. Queued off the request path (see queue/handlers.ts). */
+export function sendAdminGranted(to: string, vars: AccountNoticeVars): Promise<void> {
+  return sendMail({ to, ...accountAdminGrantedEmail(vars) });
+}
+
+/** Admin-revoked notice: back to a regular account, everything else unchanged. */
+export function accountAdminRevokedEmail(vars: AccountNoticeVars): Omit<EmailMessage, "to"> {
+  return {
+    subject: `Your ${vars.appName} admin role has been removed`,
+    text: [
+      `Your account (@${vars.username}) on ${vars.appName} is no longer an admin.`,
+      "",
+      "Everything else is unchanged — your profile, posts and lists are exactly as they were, and you can sign in as usual.",
+      "",
+      `— The ${vars.appName} team`,
+      vars.origin,
+    ].join("\n"),
+    html: layout(
+      "Your admin role has been removed",
+      `Your account (@${vars.username}) on ${vars.appName} is no longer an admin. Everything else is unchanged — your profile, posts and lists are exactly as they were, and you can sign in as usual.`,
+      { label: `Open ${vars.appName}`, url: vars.origin },
+    ),
+  };
+}
+
+/** Admin-revoked notice. Queued off the request path (see queue/handlers.ts). */
+export function sendAdminRevoked(to: string, vars: AccountNoticeVars): Promise<void> {
+  return sendMail({ to, ...accountAdminRevokedEmail(vars) });
+}

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -2,6 +2,7 @@ import bcrypt from "bcryptjs";
 import { config } from "@/config.ts";
 import * as accountsRepo from "@/db/repositories/accounts.ts";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
+import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
 import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
 import * as reportsRepo from "@/db/repositories/reports.ts";
@@ -14,6 +15,8 @@ import { hostMatchesDomain, normalizeDomain } from "@/lib/domain.ts";
 import { badRequest, forbidden, notFound, unauthorized } from "@/lib/http.ts";
 import { queue } from "@/queue/queue.ts";
 import {
+  notifyAdminGranted,
+  notifyAdminRevoked,
   notifyModeratorDeleted,
   notifyReinstated,
   notifyRestored,
@@ -110,7 +113,53 @@ export async function setSuspended(adminId: string, targetId: string, suspend: b
   }
 }
 
-// ── User deletion (admin, soft-delete with retention) ──────────────────────
+// ── Admin role (promote / demote) ──────────────────────────────────────────
+
+// Grants or revokes the admin role. A stolen admin session must not be enough
+// to mint new admins, so the acting admin's own password is re-verified — the
+// same bar as deletion, minus the username typing (the target is already
+// picked, and the action is reversible). Guards: never self, never the last
+// admin. The affected account is notified either way.
+export async function setAdminRole(
+  adminId: string,
+  targetId: string,
+  input: { makeAdmin: boolean; password: string },
+): Promise<void> {
+  const target = await usersRepo.findById(targetId);
+  if (!target || target.deletedAt) throw notFound("Account not found.");
+  if (target.id === adminId) throw forbidden("You can't change your own role.");
+  const hash = await accountsRepo.findCredentialHashByUserId(adminId);
+  if (!hash || !(await bcrypt.compare(input.password, hash))) {
+    throw unauthorized("Incorrect password.");
+  }
+  if (target.isAdmin === input.makeAdmin) return;
+  if (!input.makeAdmin && (await usersRepo.countAdmins()) <= 1) {
+    throw forbidden("You can't remove the last admin.");
+  }
+  await usersRepo.setAdmin(targetId, input.makeAdmin);
+  if (input.makeAdmin) {
+    await notifyAdminGranted(target.email, target.username);
+  } else {
+    await notifyAdminRevoked(target.email, target.username);
+  }
+}
+
+// ── User detail (admin) ────────────────────────────────────────────────────
+
+// Everything the admin user detail shows: the table row plus post/follow
+// counts, the latest posts, and every report filed against the account or its
+// posts — the context behind a suspend/delete decision.
+export async function getUserDetail(targetId: string) {
+  const user = await usersRepo.findById(targetId);
+  if (!user || user.deletedAt) throw notFound("Account not found.");
+  const [postCounts, followCounts, recentPosts, reports] = await Promise.all([
+    postsRepo.countsByAuthor(user.id),
+    followsRepo.counts(user.id),
+    postsRepo.listRecentByAuthor(user.id),
+    reportsRepo.listAgainstUser(user.id),
+  ]);
+  return { user, postCounts, followCounts, recentPosts, reports };
+}
 
 // How long a deleted account is kept restorable before the sweeper erases it
 // for good. The admin UI shows the exact expiry per account.

--- a/apps/backend/tests/integration/admin_roles_detail_test.ts
+++ b/apps/backend/tests/integration/admin_roles_detail_test.ts
@@ -1,0 +1,184 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Admin roles and the user detail endpoint.
+//
+// Covers promotion / demotion end to end against real Postgres: the password
+// re-verification, the guards (self, wrong password, deleted target), the
+// last-admin count the demote guardrail reads, the granted/revoked notices,
+// and the detail payload (counts, latest posts, reports against the account
+// and its posts).
+import bcrypt from "bcryptjs";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { db } from "@/db/client.ts";
+import * as reportsRepo from "@/db/repositories/reports.ts";
+import * as usersRepo from "@/db/repositories/users.ts";
+import { accounts } from "@/db/schema.ts";
+import { HttpError } from "@/lib/http.ts";
+import { registerHandler } from "@/queue/queue.ts";
+import { adminUserDetailView } from "@/routes/serializers.ts";
+import * as moderation from "@/services/moderation.ts";
+import { closeDb, follow, mkPost, mkUser, resetDb } from "./harness.ts";
+
+const ADMIN_PASSWORD = "correct-horse-battery-staple-12";
+
+async function mkCredential(userId: string, password: string) {
+  await db.insert(accounts).values({
+    userId,
+    accountId: userId,
+    providerId: "credential",
+    issuer: "local:credential",
+    password: await bcrypt.hash(password, 4),
+  });
+}
+
+type Notice = { to: string; username: string; appName: string; origin: string };
+
+const captured = new Map<string, Notice[]>();
+
+function notices(job: string): Notice[] {
+  return captured.get(job) ?? [];
+}
+
+async function flush() {
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  return new Error("expected rejection, but the call succeeded");
+}
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe("admin roles", () => {
+  let adminId: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    await resetDb();
+
+    for (const job of ["send_admin_granted", "send_admin_revoked"] as const) {
+      registerHandler(job, async (payload) => {
+        captured.set(job, [...(captured.get(job) ?? []), payload]);
+      });
+    }
+
+    adminId = (await mkUser("root", { isAdmin: true })).id;
+    await mkCredential(adminId, ADMIN_PASSWORD);
+    userId = (await mkUser("member")).id;
+  });
+
+  test("wrong password is rejected and the role is unchanged", async () => {
+    const err = await captureRejection(
+      moderation.setAdminRole(adminId, userId, { makeAdmin: true, password: "nope-nope-nope-nope" }),
+    );
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(401);
+    expect((await usersRepo.findById(userId))?.isAdmin).toBe(false);
+  });
+
+  test("an admin cannot change their own role", async () => {
+    const err = await captureRejection(
+      moderation.setAdminRole(adminId, adminId, { makeAdmin: false, password: ADMIN_PASSWORD }),
+    );
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(403);
+    expect((await usersRepo.findById(adminId))?.isAdmin).toBe(true);
+  });
+
+  test("promote grants the role and notifies the account", async () => {
+    await moderation.setAdminRole(adminId, userId, { makeAdmin: true, password: ADMIN_PASSWORD });
+    await flush();
+
+    expect((await usersRepo.findById(userId))?.isAdmin).toBe(true);
+    const [notice] = notices("send_admin_granted");
+    expect(notice?.to).toBe("member@example.test");
+    expect(notice?.username).toBe("member");
+  });
+
+  test("promoting an admin is a no-op (no second notice)", async () => {
+    await moderation.setAdminRole(adminId, userId, { makeAdmin: true, password: ADMIN_PASSWORD });
+    await flush();
+
+    expect(notices("send_admin_granted")).toHaveLength(1);
+  });
+
+  test("the admin count tracks promotions", async () => {
+    expect(await usersRepo.countAdmins()).toBe(2);
+  });
+
+  test("demote revokes the role and notifies the account", async () => {
+    await moderation.setAdminRole(adminId, userId, { makeAdmin: false, password: ADMIN_PASSWORD });
+    await flush();
+
+    expect((await usersRepo.findById(userId))?.isAdmin).toBe(false);
+    expect(await usersRepo.countAdmins()).toBe(1);
+    const [notice] = notices("send_admin_revoked");
+    expect(notice?.to).toBe("member@example.test");
+    expect(notice?.username).toBe("member");
+  });
+
+  test("role change on a deleted account 404s", async () => {
+    await usersRepo.setDeleted(userId, new Date(), adminId);
+    const err = await captureRejection(
+      moderation.setAdminRole(adminId, userId, { makeAdmin: true, password: ADMIN_PASSWORD }),
+    );
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(404);
+  });
+});
+
+describe("admin user detail", () => {
+  let subjectId: string;
+  let postId: string;
+
+  beforeAll(async () => {
+    await resetDb();
+
+    subjectId = (await mkUser("subject")).id;
+    const reporterId = (await mkUser("reporter")).id;
+    const fanId = (await mkUser("fan")).id;
+    postId = (await mkPost(subjectId, "subject-post")).id;
+
+    await follow(fanId, subjectId);
+    await reportsRepo.create({ reporterId, subjectType: "user", userId: subjectId, reason: "spam" });
+    await reportsRepo.create({ reporterId, subjectType: "post", postId, reason: "mislabeled" });
+  });
+
+  test("returns counts, latest posts and every report against the account", async () => {
+    const detail = await moderation.getUserDetail(subjectId);
+
+    expect(detail.user.id).toBe(subjectId);
+    expect(detail.postCounts.published).toBe(1);
+    expect(detail.followCounts.followers).toBe(1);
+    expect(detail.followCounts.following).toBe(0);
+    expect(detail.recentPosts.map((p) => p.id)).toContain(postId);
+    expect(detail.reports).toHaveLength(2);
+    expect(detail.reports.map((r) => r.reason).toSorted()).toEqual(["mislabeled", "spam"]);
+
+    // The serializer shapes the wire payload without dropping fields.
+    const view = adminUserDetailView(detail);
+    expect(view.user.username).toBe("subject");
+    expect(view.reports).toHaveLength(2);
+    expect(view.recentPosts[0].id).toBe(postId);
+  });
+
+  test("detail for a deleted or missing account 404s", async () => {
+    const goneId = (await mkUser("gone")).id;
+    await usersRepo.setDeleted(goneId, new Date(), subjectId);
+
+    const deletedErr = await captureRejection(moderation.getUserDetail(goneId));
+    expect(deletedErr).toBeInstanceOf(HttpError);
+    expect((deletedErr as HttpError).status).toBe(404);
+
+    const missingErr = await captureRejection(moderation.getUserDetail("00000000-0000-0000-0000-000000000000"));
+    expect(missingErr).toBeInstanceOf(HttpError);
+    expect((missingErr as HttpError).status).toBe(404);
+  });
+});

--- a/apps/frontend/src/lib/api/contract.ts
+++ b/apps/frontend/src/lib/api/contract.ts
@@ -29,6 +29,7 @@
 
 import type {
   AdminUser,
+  AdminUserDetail,
   Comment,
   CoverCredit,
   DeletedUser,
@@ -46,6 +47,7 @@ import type {
 } from "$lib/types";
 import type {
   adminUserView,
+  adminUserDetailView,
   commentView,
   deletedUserView,
   notificationView,
@@ -103,6 +105,12 @@ type _CoverCredit = Assert<Fits<NonNullable<Wire<typeof postWithAuthor>["coverCr
 type _User = Assert<Fits<Wire<typeof publicUser>, User>>;
 type _AdminUser = Assert<Fits<Wire<typeof adminUserView>, AdminUser>>;
 type _DeletedUser = Assert<Fits<Wire<typeof deletedUserView>, DeletedUser>>;
+// `reports` is omitted: the backend's ReportRow types status/subject as loose
+// strings while the frontend declares unions (the same looseness the reports
+// endpoint already lives with, and unasserted there too).
+type _AdminUserDetail = Assert<
+  Fits<Omit<Wire<typeof adminUserDetailView>, "reports">, Omit<AdminUserDetail, "reports">>
+>;
 
 type _Post = Assert<Fits<Wire<typeof postWithAuthor>, Post>>;
 type _PostAuthor = Assert<Fits<Wire<typeof postWithAuthor>["author"], PostAuthor>>;

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -1,6 +1,7 @@
 import type {
   AdminInstance,
   AdminUser,
+  AdminUserDetail,
   BlockedDomain,
   Comment,
   CoverCredit,
@@ -141,6 +142,12 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
       api.post<{ ok: true }>(`/admin/users/${id}/delete`, body),
     // Restore a deleted account within its retention window.
     restoreUser: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/restore`, {}),
+    // Full detail for one account: counts, latest posts and reports against it.
+    adminUserDetail: (id: string) => api.get<AdminUserDetail>(`/admin/users/${id}`),
+    // Grant or revoke the admin role. The acting admin's own password travels
+    // with the request — the server re-verifies it.
+    setUserRole: (id: string, body: { makeAdmin: boolean; password: string }) =>
+      api.post<{ ok: true }>(`/admin/users/${id}/role`, body),
     // Recently deleted accounts awaiting restore or expiry.
     deletedUsers: () => api.get<{ users: DeletedUser[] }>("/admin/users/deleted"),
     // Permanently erase a deleted account before its window ends.

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -6,11 +6,11 @@
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import type { AdminUser, DeletedUser } from "$lib/types";
+  import type { AdminUser, AdminUserDetail, DeletedUser } from "$lib/types";
   import { Dialog, Label } from "bits-ui";
 
-  // The signed-in admin's own id, so the row for self can hide the suspend /
-  // delete actions (the server also forbids them).
+  // The signed-in admin's own id, so the row for self can hide every action
+  // (the server also forbids them).
   let { selfId }: { selfId: string } = $props();
 
   let users = $state<AdminUser[]>([]);
@@ -41,6 +41,9 @@
       const res = await endpoints().adminUsers(query.trim() || undefined);
       users = res.users;
       total = res.total;
+      // Mutations may have changed what a detail shows; drop the cache so an
+      // expansion always refetches.
+      details = {};
     } catch (e) {
       error = e instanceof ApiError ? e.message : "Failed to load users.";
     } finally {
@@ -129,6 +132,67 @@
     }
   }
 
+  // Admin-role change: password re-verified server-side, like deletion minus
+  // the username typing (the target is already picked, and it is reversible).
+  let roleTarget = $state<AdminUser | null>(null);
+  let rolePassword = $state("");
+  let roleError = $state("");
+  let roleBusy = $state(false);
+
+  function openRole(u: AdminUser) {
+    roleTarget = u;
+    rolePassword = "";
+    roleError = "";
+  }
+
+  function onRoleOpenChange(open: boolean) {
+    if (!open) roleTarget = null;
+  }
+
+  const roleReady = $derived(roleTarget !== null && rolePassword.length > 0);
+
+  async function confirmRole() {
+    if (!roleTarget || !roleReady || roleBusy) return;
+    const makeAdmin = !roleTarget.isAdmin;
+    roleBusy = true;
+    roleError = "";
+    try {
+      await endpoints().setUserRole(roleTarget.id, { makeAdmin, password: rolePassword });
+      const id = roleTarget.id;
+      users = users.map((x) => (x.id === id ? { ...x, isAdmin: makeAdmin } : x));
+      roleTarget = null;
+    } catch (e) {
+      roleError = e instanceof ApiError ? e.message : "Role change failed.";
+    } finally {
+      roleBusy = false;
+    }
+  }
+
+  // Expandable per-account detail: counts, latest posts and reports against
+  // the account or its posts. Loaded lazily on expand and cached until the
+  // next table reload.
+  let expandedId = $state<string | null>(null);
+  let details = $state<Record<string, AdminUserDetail>>({});
+  let detailLoadingId = $state<string | null>(null);
+
+  async function toggleDetail(u: AdminUser) {
+    if (expandedId === u.id) {
+      expandedId = null;
+      return;
+    }
+    expandedId = u.id;
+    if (details[u.id] || detailLoadingId === u.id) return;
+    detailLoadingId = u.id;
+    try {
+      details[u.id] = await endpoints().adminUserDetail(u.id);
+    } catch (e) {
+      error = e instanceof ApiError ? e.message : "Failed to load account detail.";
+      expandedId = null;
+    } finally {
+      detailLoadingId = null;
+    }
+  }
+
   async function restoreDeleted(d: DeletedUser) {
     busyId = d.id;
     error = "";
@@ -206,45 +270,126 @@
   {:else}
     <ul class="flex flex-col divide-y divide-border">
       {#each users as u (u.id)}
-        <li class="flex items-center gap-3 py-3">
-          <Avatar name={u.displayName} src={u.avatarUrl ?? undefined} size={40} />
-          <div class="min-w-0 flex-1">
-            <div class="flex items-center gap-2">
-              <a href={`/@${u.username}`} class="truncate font-medium text-foreground hover:underline">
-                {u.displayName}
-              </a>
-              {#if u.isAdmin}
-                <span
-                  class="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-foreground"
-                >
-                  <Icon name="admin" size={12} /> Admin
-                </span>
-              {/if}
-              {#if u.suspended}
-                <span class="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
-                  Suspended
-                </span>
-              {/if}
+        <li class="py-3">
+          <div class="flex items-center gap-3">
+            <Button
+              variant="plain"
+              class="inline-flex size-7 shrink-0 items-center justify-center rounded-input text-muted-foreground hover:bg-muted"
+              onclick={() => toggleDetail(u)}
+              aria-expanded={expandedId === u.id}
+              aria-label={expandedId === u.id ? `Hide detail for @${u.username}` : `Show detail for @${u.username}`}
+            >
+              <Icon name="chevronDown" size={16} class={expandedId === u.id ? "rotate-180" : ""} />
+            </Button>
+            <Avatar name={u.displayName} src={u.avatarUrl ?? undefined} size={40} />
+            <div class="min-w-0 flex-1">
+              <div class="flex items-center gap-2">
+                <a href={`/@${u.username}`} class="truncate font-medium text-foreground hover:underline">
+                  {u.displayName}
+                </a>
+                {#if u.isAdmin}
+                  <span
+                    class="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-foreground"
+                  >
+                    <Icon name="admin" size={12} /> Admin
+                  </span>
+                {/if}
+                {#if u.suspended}
+                  <span class="rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive">
+                    Suspended
+                  </span>
+                {/if}
+              </div>
+              <p class="truncate text-xs text-muted-foreground">
+                @{u.username} · {u.email} · joined <Time iso={u.createdAt} kind="date" />
+              </p>
             </div>
-            <p class="truncate text-xs text-muted-foreground">
-              @{u.username} · {u.email} · joined <Time iso={u.createdAt} kind="date" />
-            </p>
+            {#if u.id !== selfId}
+              <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
+                {#if !u.isAdmin}
+                  <Button
+                    variant={u.suspended ? "outline" : "destructive"}
+                    size="sm"
+                    disabled={busyId === u.id}
+                    onclick={() => toggleSuspend(u)}
+                  >
+                    <Icon name={u.suspended ? "check" : "shieldOff"} size={15} />
+                    {u.suspended ? "Reinstate" : "Suspend"}
+                  </Button>
+                  <Button variant="outline" size="sm" disabled={busyId === u.id} onclick={() => openDelete(u)}>
+                    <Icon name="trash" size={15} />
+                    Delete
+                  </Button>
+                {/if}
+                <Button variant="outline" size="sm" disabled={busyId === u.id} onclick={() => openRole(u)}>
+                  <Icon name="admin" size={15} />
+                  {u.isAdmin ? "Remove admin" : "Make admin"}
+                </Button>
+              </div>
+            {/if}
           </div>
-          {#if u.id !== selfId && !u.isAdmin}
-            <div class="flex shrink-0 items-center gap-2">
-              <Button
-                variant={u.suspended ? "outline" : "destructive"}
-                size="sm"
-                disabled={busyId === u.id}
-                onclick={() => toggleSuspend(u)}
-              >
-                <Icon name={u.suspended ? "check" : "shieldOff"} size={15} />
-                {u.suspended ? "Reinstate" : "Suspend"}
-              </Button>
-              <Button variant="outline" size="sm" disabled={busyId === u.id} onclick={() => openDelete(u)}>
-                <Icon name="trash" size={15} />
-                Delete
-              </Button>
+          {#if expandedId === u.id}
+            <div class="mt-3 ml-10 rounded-card border border-border bg-background-alt p-4">
+              {#if detailLoadingId === u.id}
+                <p class="text-sm text-muted-foreground">Loading detail…</p>
+              {:else if details[u.id]}
+                {@const d = details[u.id]}
+                <div class="flex flex-wrap gap-x-5 gap-y-1 text-sm text-muted-foreground">
+                  <span><strong class="text-foreground">{d.postCounts.published}</strong> published</span>
+                  <span
+                    ><strong class="text-foreground">{d.postCounts.draft + d.postCounts.scheduled}</strong> drafts</span
+                  >
+                  <span><strong class="text-foreground">{d.followCounts.followers}</strong> followers</span>
+                  <span><strong class="text-foreground">{d.followCounts.following}</strong> following</span>
+                  <span>{d.user.emailVerified ? "Email verified" : "Email unverified"}</span>
+                </div>
+                <h4 class="mt-4 text-sm font-semibold text-foreground">Latest posts</h4>
+                {#if d.recentPosts.length === 0}
+                  <p class="mt-1 text-sm text-muted-foreground">No posts yet.</p>
+                {:else}
+                  <ul class="mt-1 flex flex-col gap-1">
+                    {#each d.recentPosts as p (p.id)}
+                      <li class="flex items-center gap-2 text-sm">
+                        <a href={`/posts/${p.id}`} class="truncate font-medium text-foreground hover:underline">
+                          {p.title ?? "Untitled"}
+                        </a>
+                        <span class="shrink-0 text-xs text-muted-foreground">
+                          {p.status} · <Time iso={p.createdAt} kind="date" />
+                        </span>
+                      </li>
+                    {/each}
+                  </ul>
+                {/if}
+                <h4 class="mt-4 text-sm font-semibold text-foreground">
+                  Reports {d.reports.length > 0 ? `(${d.reports.length})` : ""}
+                </h4>
+                {#if d.reports.length === 0}
+                  <p class="mt-1 text-sm text-muted-foreground">Nothing filed against this account.</p>
+                {:else}
+                  <ul class="mt-1 flex flex-col gap-2">
+                    {#each d.reports as r (r.id)}
+                      <li class="text-sm">
+                        <span
+                          class={r.status === "open"
+                            ? "rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive"
+                            : "rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground"}
+                        >
+                          {r.status}
+                        </span>
+                        <span class="text-foreground">
+                          {r.subjectType === "post" ? `Post “${r.postTitle ?? "untitled"}”` : "Account"}
+                        </span>
+                        <span class="text-muted-foreground">
+                          — {r.reason || "No reason given"} · by {r.reporter
+                            ? `@${r.reporter.username}`
+                            : "a deleted account"} ·
+                          <Time iso={r.createdAt} kind="date" />
+                        </span>
+                      </li>
+                    {/each}
+                  </ul>
+                {/if}
+              {/if}
             </div>
           {/if}
         </li>
@@ -364,6 +509,58 @@
         </Dialog.Close>
         <Button variant="destructive" disabled={!deleteReady || deleteBusy} onclick={confirmDelete}>
           {deleteBusy ? "Deleting…" : "Delete this account"}
+        </Button>
+      </div>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>
+
+<Dialog.Root open={roleTarget !== null} onOpenChange={onRoleOpenChange}>
+  <Dialog.Portal>
+    <Dialog.Overlay
+      class="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50"
+    />
+    <Dialog.Content
+      class="fixed top-1/2 left-1/2 z-50 w-full max-w-[94%] -translate-x-1/2 -translate-y-1/2 rounded-card border border-border bg-background p-6 shadow-popover sm:max-w-[440px]"
+    >
+      <Dialog.Title class="text-lg font-semibold tracking-tight text-foreground">
+        {roleTarget?.isAdmin
+          ? `Remove @${roleTarget?.username}'s admin role?`
+          : `Make @${roleTarget?.username} an admin?`}
+      </Dialog.Title>
+      <Dialog.Description class="mt-1 text-sm text-muted-foreground">
+        {#if roleTarget?.isAdmin}
+          They lose access to the admin panel immediately. Everything else stays as is. They will be notified by email.
+        {:else}
+          They gain the admin panel: reports, accounts, defederation and instance settings — including other people's
+          login emails. They will be notified by email.
+        {/if}
+      </Dialog.Description>
+
+      <div class="mt-5 flex flex-col gap-1.5">
+        <Label.Root for="role-password" class={labelClass}>Your password</Label.Root>
+        <input
+          id="role-password"
+          type="password"
+          bind:value={rolePassword}
+          autocomplete="current-password"
+          class={field}
+        />
+        {#if roleError}<p class="text-sm text-destructive">{roleError}</p>{/if}
+      </div>
+
+      <div class="mt-6 flex justify-end gap-2">
+        <Dialog.Close
+          class="inline-flex h-10 items-center justify-center rounded-input px-4 text-sm font-medium text-foreground hover:bg-muted active:scale-[0.98]"
+        >
+          Cancel
+        </Dialog.Close>
+        <Button
+          variant={roleTarget?.isAdmin ? "destructive" : "solid"}
+          disabled={!roleReady || roleBusy}
+          onclick={confirmRole}
+        >
+          {roleBusy ? "Saving…" : roleTarget?.isAdmin ? "Remove admin" : "Make admin"}
         </Button>
       </div>
     </Dialog.Content>

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -528,3 +528,13 @@ export type Report = {
   userUsername: string | null;
   userDisplayName: string | null;
 };
+
+// Full admin detail for one account: the table row plus post/follow counts,
+// the latest posts and the reports filed against the account or its posts.
+export type AdminUserDetail = {
+  user: AdminUser;
+  postCounts: { draft: number; scheduled: number; published: number };
+  followCounts: { followers: number; following: number };
+  recentPosts: { id: string; title: string | null; slug: string | null; status: string; createdAt: string }[];
+  reports: Report[];
+};

--- a/apps/frontend/src/routes/admin/+page.svelte
+++ b/apps/frontend/src/routes/admin/+page.svelte
@@ -65,7 +65,9 @@
   <Tabs.Content value="users" class="mt-6">
     <section class="rounded-card border border-border bg-background p-6">
       <h2 class="text-lg font-semibold tracking-tight text-foreground">Users</h2>
-      <p class="mt-1 text-sm text-muted-foreground">Every local account on this instance. Suspend to block sign-in.</p>
+      <p class="mt-1 text-sm text-muted-foreground">
+        Every local account on this instance. Expand a row for detail; suspend, delete, or change the admin role.
+      </p>
       <div class="mt-5">
         <AdminUsers selfId={data.user.id} />
       </div>


### PR DESCRIPTION
## Symptom

Two gaps on Admin → Users: (1) the only admin was the first user ever — no promote/demote existed anywhere, so team moderation was impossible without database writes; (2) suspend/delete decisions were made from a flat row with no context (no posts, no reports, no counts).

## Fix

**Backend** (`feat(admin): promote/demote admins and a user detail endpoint`)
- `POST /admin/users/:id/role { makeAdmin, password }`: password re-verified like deletion (minus username typing — reversible, target already picked). Refuses self-changes and removing the last admin (via a new `countAdmins`); affected account emailed either way (`send_admin_granted/revoked`).
- `GET /admin/users/:id`: table row + post/follow counts + latest 5 posts + every report against the account or its posts (new `listAgainstUser`, `listRecentByAuthor`). 404 on deleted/missing.
- Why password, not just a confirm: without it a stolen admin session could mint a persistent admin. Why no username typing: the destructive-case ceremony fits irreversible actions; role change is one click back.

**Frontend** (`feat(admin): role controls and expandable user detail …`)
- Make/Remove admin button per non-self row behind a password dialog; chevron expands inline detail (lazy-loaded, cached till reload) with counts, linked recent posts, and reports with status.

## Verified

- Backend `vitest run src/`: 307 passed; `oxlint`, `oxfmt --check` clean.
- New `admin_roles_detail_test.ts` (guards, notices, detail payload incl. both report kinds); needs Postgres + Deno — CI must confirm.
- Frontend `svelte-check` 0 errors (includes the new detail contract assertion), 34 tests passed, lint + format clean.
- `deno check` could not run here; CI covers it.

## Deploy notes

Plain `docker compose up -d`. No migration (role is a column update), no env changes. Note: the last-admin guardrail is belt-and-braces — with the self-change refusal it only bites under concurrent mutual demotion.