### PR TITLE
feat(admin): filters and email verification control on the users page

### DIFF
--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { and, desc, eq, gte, ilike, lt, ne, or, sql } from "drizzle-orm";
+import { and, desc, eq, gte, ilike, lt, ne, or, type SQL, sql } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { db } from "@/db/client.ts";
 import { type ActorKeyPair, follows, type NewUser, sessions, users } from "@/db/schema.ts";
@@ -136,20 +136,34 @@ export async function update(id: string, data: Partial<NewUser>) {
   return row;
 }
 
+// Filter dimensions for the admin user table. Each is tri-state: true shows
+// only matching accounts, false only the rest, undefined leaves it unfiltered.
+export type AdminUserFilter = {
+  suspended?: boolean;
+  admin?: boolean;
+  verified?: boolean;
+};
+
 // Live local accounts for the admin user table: newest first, optional handle /
-// name substring filter. Deleted accounts are excluded — they have their own
-// restore list (listDeleted). Returns full rows (the admin serializer picks fields).
-export function listForAdmin(query = "", limit = 100) {
-  const match = query.trim()
-    ? (() => {
-        const term = `%${query.replace(/[%_\\]/g, "\\$&")}%`;
-        return or(ilike(users.username, term), ilike(users.displayName, term));
-      })()
-    : undefined;
+// name substring filter plus the triage filters. Deleted accounts are excluded
+// — they have their own restore list (listDeleted). Returns full rows (the
+// admin serializer picks fields).
+export function listForAdmin(query = "", filter: AdminUserFilter = {}, limit = 100) {
+  const conditions: (SQL | undefined)[] = [sql`${users.deletedAt} is null`];
+  if (query.trim()) {
+    const term = `%${query.replace(/[%_\\]/g, "\\$&")}%`;
+    conditions.push(or(ilike(users.username, term), ilike(users.displayName, term)));
+  }
+  if (filter.suspended !== undefined) {
+    conditions.push(filter.suspended ? sql`${users.suspendedAt} is not null` : sql`${users.suspendedAt} is null`);
+  }
+  if (filter.admin !== undefined) conditions.push(eq(users.isAdmin, filter.admin));
+  if (filter.verified !== undefined) conditions.push(eq(users.emailVerified, filter.verified));
+  // `and()` drops undefined operands, so unset dimensions stay unfiltered.
   return db
     .select()
     .from(users)
-    .where(and(sql`${users.deletedAt} is null`, match))
+    .where(and(...conditions))
     .orderBy(desc(users.createdAt))
     .limit(limit);
 }

--- a/apps/backend/src/queue/handlers.ts
+++ b/apps/backend/src/queue/handlers.ts
@@ -5,6 +5,7 @@ import {
   sendAccountReinstated,
   sendAccountRestored,
   sendAccountSuspended,
+  sendAccountVerified,
   sendAdminGranted,
   sendAdminRevoked,
   sendEmailVerification,
@@ -162,5 +163,9 @@ export function registerJobHandlers() {
   );
   registerHandler("send_admin_revoked", ({ to, username, appName, origin }) =>
     sendAdminRevoked(to, { username, appName, origin }),
+  );
+  // An admin manually verified the address, unblocking sign-in.
+  registerHandler("send_account_verified", ({ to, username, appName, origin }) =>
+    sendAccountVerified(to, { username, appName, origin }),
   );
 }

--- a/apps/backend/src/queue/queue.ts
+++ b/apps/backend/src/queue/queue.ts
@@ -34,7 +34,8 @@ export type JobName =
   | "send_account_reinstated"
   | "send_account_restored"
   | "send_admin_granted"
-  | "send_admin_revoked";
+  | "send_admin_revoked"
+  | "send_account_verified";
 
 export type JobPayloads = {
   federate_post: { postId: string; action?: "create" | "update" };
@@ -65,6 +66,7 @@ export type JobPayloads = {
   send_account_restored: { to: string; username: string; appName: string; origin: string };
   send_admin_granted: { to: string; username: string; appName: string; origin: string };
   send_admin_revoked: { to: string; username: string; appName: string; origin: string };
+  send_account_verified: { to: string; username: string; appName: string; origin: string };
 };
 
 type Handler<N extends JobName> = (payload: JobPayloads[N]) => Promise<void>;

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -292,11 +292,26 @@ adminRoutes.post("/email/test", jsonBody(emailTestSchema), async (c) => {
 
 // ── Users ──────────────────────────────────────────────────────────────────
 
-// The admin user table, with an optional handle / name filter (?q=).
+// Parses an optional `true`/`false` query flag; anything else leaves the
+// dimension unfiltered.
+function flag(v: string | undefined): boolean | undefined {
+  return v === "true" ? true : v === "false" ? false : undefined;
+}
+
+// The admin user table, with an optional handle / name filter (?q=) and
+// triage filters (?suspended=&admin=&verified=true|false).
 // `total` is the unfiltered local-account count for the header.
 adminRoutes.get("/users", async (c) => {
   requireAdmin(c);
-  const [rows, total] = await Promise.all([moderation.listUsers(c.req.query("q") ?? ""), moderation.countUsers()]);
+  const filter = {
+    suspended: flag(c.req.query("suspended")),
+    admin: flag(c.req.query("admin")),
+    verified: flag(c.req.query("verified")),
+  };
+  const [rows, total] = await Promise.all([
+    moderation.listUsers(c.req.query("q") ?? "", filter),
+    moderation.countUsers(),
+  ]);
   return c.json({ users: rows.map(adminUserView), total });
 });
 
@@ -366,6 +381,21 @@ adminRoutes.post("/users/:id/role", jsonBody(roleSchema), async (c) => {
 adminRoutes.get("/users/:id", async (c) => {
   requireAdmin(c);
   return c.json(adminUserDetailView(await moderation.getUserDetail(c.req.param("id"))));
+});
+
+// Resend the verification email to an unverified account.
+adminRoutes.post("/users/:id/verification-email", async (c) => {
+  requireAdmin(c);
+  await moderation.resendVerification(c.req.param("id"));
+  return c.json({ ok: true });
+});
+
+// Manually mark an account's email verified — the escape hatch for when
+// instance mail was misconfigured and the link can never arrive.
+adminRoutes.post("/users/:id/verify", async (c) => {
+  requireAdmin(c);
+  await moderation.verifyEmail(c.req.param("id"));
+  return c.json({ ok: true });
 });
 
 // ── Posts ────────────────────────────────────────────────────────────────

--- a/apps/backend/src/services/accountNotices.ts
+++ b/apps/backend/src/services/accountNotices.ts
@@ -86,3 +86,12 @@ export async function notifyAdminRevoked(email: string, username: string): Promi
     console.error("accountNotices: failed to queue admin-revoked notice (continuing):", err);
   }
 }
+
+/** Verified notice after an admin manually confirms the address. */
+export async function notifyVerified(email: string, username: string): Promise<void> {
+  try {
+    queue.add("send_account_verified", { to: email, username, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue verified notice (continuing):", err);
+  }
+}

--- a/apps/backend/src/services/email.ts
+++ b/apps/backend/src/services/email.ts
@@ -504,3 +504,28 @@ export function accountAdminRevokedEmail(vars: AccountNoticeVars): Omit<EmailMes
 export function sendAdminRevoked(to: string, vars: AccountNoticeVars): Promise<void> {
   return sendMail({ to, ...accountAdminRevokedEmail(vars) });
 }
+
+/** Verified notice: an admin confirmed the address, so sign-in is unblocked. */
+export function accountVerifiedEmail(vars: AccountNoticeVars): Omit<EmailMessage, "to"> {
+  return {
+    subject: `Your ${vars.appName} email has been verified`,
+    text: [
+      `An admin on ${vars.appName} has verified the email address on your account (@${vars.username}).`,
+      "",
+      "You can sign in now — no further action needed.",
+      "",
+      `— The ${vars.appName} team`,
+      `${vars.origin}/login`,
+    ].join("\n"),
+    html: layout(
+      "Your email has been verified",
+      `An admin on ${vars.appName} has verified the email address on your account (@${vars.username}). You can sign in now — no further action needed.`,
+      { label: "Sign in", url: `${vars.origin}/login` },
+    ),
+  };
+}
+
+/** Verified notice. Queued off the request path (see queue/handlers.ts). */
+export function sendAccountVerified(to: string, vars: AccountNoticeVars): Promise<void> {
+  return sendMail({ to, ...accountVerifiedEmail(vars) });
+}

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -10,6 +10,7 @@ import type { ReportRow } from "@/db/repositories/reports.ts";
 import * as sessionsRepo from "@/db/repositories/sessions.ts";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import * as usersRepo from "@/db/repositories/users.ts";
+import type { AdminUserFilter } from "@/db/repositories/users.ts";
 import type { BlockedDomain } from "@/db/schema.ts";
 import { hostMatchesDomain, normalizeDomain } from "@/lib/domain.ts";
 import { badRequest, forbidden, notFound, unauthorized } from "@/lib/http.ts";
@@ -21,6 +22,7 @@ import {
   notifyReinstated,
   notifyRestored,
   notifySuspended,
+  notifyVerified,
 } from "@/services/accountNotices.ts";
 import { federationRunning } from "@/services/federationState.ts";
 
@@ -84,8 +86,11 @@ export async function resolveReport(adminId: string, reportId: string, resolutio
 
 // ── Users (admin) ──────────────────────────────────────────────────────────
 
-export function listUsers(query = ""): Promise<Awaited<ReturnType<typeof usersRepo.listForAdmin>>> {
-  return usersRepo.listForAdmin(query);
+export function listUsers(
+  query = "",
+  filter: AdminUserFilter = {},
+): Promise<Awaited<ReturnType<typeof usersRepo.listForAdmin>>> {
+  return usersRepo.listForAdmin(query, filter);
 }
 
 // Total local accounts, unfiltered — the admin user table's header count.
@@ -259,6 +264,34 @@ export async function purgeExpiredDeletedUsers(now = new Date(), limit = 100): P
     await usersRepo.hardRemove(id);
   }
   return expired.length;
+}
+
+// ── Email verification (admin) ───────────────────────────────────────────
+
+// Manually marks an account's email verified — the escape hatch for when
+// instance mail was misconfigured and the user can never receive the link.
+// Idempotent; the account is notified it can sign in.
+export async function verifyEmail(targetId: string): Promise<void> {
+  const target = await usersRepo.findById(targetId);
+  if (!target || target.deletedAt) throw notFound("Account not found.");
+  if (target.emailVerified) return;
+  await usersRepo.update(targetId, { emailVerified: true });
+  await notifyVerified(target.email, target.username);
+}
+
+// Resends the verification email to an unverified account. Goes through
+// Better Auth's own endpoint so token format and expiry stay in one place;
+// already-verified is a caller error, not a silent no-op.
+export async function resendVerification(targetId: string): Promise<void> {
+  const target = await usersRepo.findById(targetId);
+  if (!target || target.deletedAt) throw notFound("Account not found.");
+  if (target.emailVerified) throw badRequest("This account's email is already verified.");
+  try {
+    const { auth } = await import("@/auth/auth.ts");
+    await auth.api.sendVerificationEmail({ body: { email: target.email }, headers: new Headers() });
+  } catch (err) {
+    throw badRequest(err instanceof Error ? err.message : "Could not send the verification email.");
+  }
 }
 
 // ── Posts (admin) ──────────────────────────────────────────────────────────

--- a/apps/backend/tests/integration/admin_filters_verify_test.ts
+++ b/apps/backend/tests/integration/admin_filters_verify_test.ts
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// Admin user filters and email verification control.
+//
+// Covers the triage filters (suspended / admin / verified, alone, combined and
+// with a search query), manual verification (idempotent, notified) and the
+// verification resend (sent, refused when already verified). The resend goes
+// through Better Auth's own endpoint; the test captures the queued mail job.
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import * as usersRepo from "@/db/repositories/users.ts";
+import { HttpError } from "@/lib/http.ts";
+import { registerHandler } from "@/queue/queue.ts";
+import * as moderation from "@/services/moderation.ts";
+import { closeDb, mkUser, resetDb } from "./harness.ts";
+
+// The verification mail carries `{ to, url }` instead of the account payload,
+// so everything but the recipient is optional here.
+type Notice = { to: string; username?: string; appName?: string; origin?: string };
+
+const captured = new Map<string, Notice[]>();
+
+function notices(job: string): Notice[] {
+  return captured.get(job) ?? [];
+}
+
+async function flush() {
+  await new Promise((r) => setTimeout(r, 10));
+}
+
+async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
+  try {
+    await promise;
+  } catch (err) {
+    return err;
+  }
+  return new Error("expected rejection, but the call succeeded");
+}
+
+function usernames(rows: readonly { username: string }[]): string[] {
+  return rows.map((r) => r.username).toSorted();
+}
+
+afterAll(async () => {
+  await closeDb();
+});
+
+describe("admin user filters", () => {
+  beforeAll(async () => {
+    await resetDb();
+
+    await mkUser("alpha");
+    await mkUser("beta", { suspended: true });
+    await mkUser("gamma", { isAdmin: true });
+    const delta = await mkUser("delta");
+    await usersRepo.update(delta.id, { emailVerified: true });
+  });
+
+  test("no filter lists everyone live", async () => {
+    expect(usernames(await moderation.listUsers())).toEqual(["alpha", "beta", "delta", "gamma"]);
+  });
+
+  test("suspended filter splits both ways", async () => {
+    expect(usernames(await moderation.listUsers("", { suspended: true }))).toEqual(["beta"]);
+    expect(usernames(await moderation.listUsers("", { suspended: false }))).toEqual(["alpha", "delta", "gamma"]);
+  });
+
+  test("admin filter splits both ways", async () => {
+    expect(usernames(await moderation.listUsers("", { admin: true }))).toEqual(["gamma"]);
+    expect(usernames(await moderation.listUsers("", { admin: false }))).toEqual(["alpha", "beta", "delta"]);
+  });
+
+  test("verified filter splits both ways", async () => {
+    expect(usernames(await moderation.listUsers("", { verified: true }))).toEqual(["delta"]);
+    expect(usernames(await moderation.listUsers("", { verified: false }))).toEqual(["alpha", "beta", "gamma"]);
+  });
+
+  test("filters combine with each other and with the search query", async () => {
+    expect(usernames(await moderation.listUsers("", { admin: false, verified: false }))).toEqual(["alpha", "beta"]);
+    expect(usernames(await moderation.listUsers("a", { verified: false }))).toEqual(["alpha", "beta", "gamma"]);
+    expect(usernames(await moderation.listUsers("amm", { admin: true }))).toEqual(["gamma"]);
+  });
+});
+
+describe("admin email verification control", () => {
+  let unverifiedId: string;
+
+  beforeAll(async () => {
+    await resetDb();
+
+    for (const job of ["send_account_verified", "send_email_verification"] as const) {
+      registerHandler(job, async (payload) => {
+        captured.set(job, [...(captured.get(job) ?? []), payload]);
+      });
+    }
+
+    unverifiedId = (await mkUser("pending")).id;
+  });
+
+  test("manual verify marks the address and notifies the account", async () => {
+    await moderation.verifyEmail(unverifiedId);
+    await flush();
+
+    expect((await usersRepo.findById(unverifiedId))?.emailVerified).toBe(true);
+    const [notice] = notices("send_account_verified");
+    expect(notice?.to).toBe("pending@example.test");
+    expect(notice?.username).toBe("pending");
+  });
+
+  test("manual verify is idempotent (no second notice)", async () => {
+    await moderation.verifyEmail(unverifiedId);
+    await flush();
+
+    expect(notices("send_account_verified")).toHaveLength(1);
+  });
+
+  test("resend delivers a fresh verification email", async () => {
+    const freshId = (await mkUser("fresh")).id;
+    await moderation.resendVerification(freshId);
+    await flush();
+
+    const [notice] = notices("send_email_verification");
+    expect(notice?.to).toBe("fresh@example.test");
+  });
+
+  test("resend refuses an already-verified address", async () => {
+    const err = await captureRejection(moderation.resendVerification(unverifiedId));
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(400);
+  });
+
+  test("verify and resend on a missing account 404", async () => {
+    const missing = "00000000-0000-0000-0000-000000000000";
+    const verifyErr = await captureRejection(moderation.verifyEmail(missing));
+    expect((verifyErr as HttpError).status).toBe(404);
+    const resendErr = await captureRejection(moderation.resendVerification(missing));
+    expect((resendErr as HttpError).status).toBe(404);
+  });
+
+  test("verify on a deleted account 404s", async () => {
+    const goneId = (await mkUser("gone2")).id;
+    await usersRepo.setDeleted(goneId, new Date(), unverifiedId);
+    const err = await captureRejection(moderation.verifyEmail(goneId));
+    expect(err).toBeInstanceOf(HttpError);
+    expect((err as HttpError).status).toBe(404);
+  });
+});

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -133,8 +133,15 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     checkPort25: () => api.get<{ ok: boolean; detail: string }>("/admin/email/port25"),
 
     // admin moderation
-    adminUsers: (q?: string) =>
-      api.get<{ users: AdminUser[]; total: number }>(`/admin/users${q ? `?q=${encodeURIComponent(q)}` : ""}`),
+    adminUsers: (q?: string, filters?: { suspendedOnly?: boolean; adminsOnly?: boolean; unverifiedOnly?: boolean }) => {
+      const params = new URLSearchParams();
+      if (q) params.set("q", q);
+      if (filters?.suspendedOnly) params.set("suspended", "true");
+      if (filters?.adminsOnly) params.set("admin", "true");
+      if (filters?.unverifiedOnly) params.set("verified", "false");
+      const qs = params.toString();
+      return api.get<{ users: AdminUser[]; total: number }>(`/admin/users${qs ? `?${qs}` : ""}`);
+    },
     suspendUser: (id: string, suspend: boolean) => api.post<{ ok: true }>(`/admin/users/${id}/suspend`, { suspend }),
     // Delete a local account. GitHub-style: the exact username plus the acting
     // admin's own password travel with the request — the server re-verifies both.
@@ -144,6 +151,9 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     restoreUser: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/restore`, {}),
     // Full detail for one account: counts, latest posts and reports against it.
     adminUserDetail: (id: string) => api.get<AdminUserDetail>(`/admin/users/${id}`),
+    // Resend the verification email, or manually mark the address verified.
+    resendVerification: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/verification-email`, {}),
+    verifyEmail: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/verify`, {}),
     // Grant or revoke the admin role. The acting admin's own password travels
     // with the request — the server re-verifies it.
     setUserRole: (id: string, body: { makeAdmin: boolean; password: string }) =>

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -20,6 +20,11 @@
   let query = $state("");
   let busyId = $state<string | null>(null);
 
+  // Triage filters: each shows only matching accounts while on.
+  let fSuspended = $state(false);
+  let fAdmins = $state(false);
+  let fUnverified = $state(false);
+
   // Recently deleted accounts: the retention window's restore list.
   let deleted = $state<DeletedUser[]>([]);
   let deletedLoading = $state(true);
@@ -38,12 +43,17 @@
     loading = true;
     error = "";
     try {
-      const res = await endpoints().adminUsers(query.trim() || undefined);
+      const res = await endpoints().adminUsers(query.trim() || undefined, {
+        suspendedOnly: fSuspended || undefined,
+        adminsOnly: fAdmins || undefined,
+        unverifiedOnly: fUnverified || undefined,
+      });
       users = res.users;
       total = res.total;
       // Mutations may have changed what a detail shows; drop the cache so an
       // expansion always refetches.
       details = {};
+      detailNotice = "";
     } catch (e) {
       error = e instanceof ApiError ? e.message : "Failed to load users.";
     } finally {
@@ -181,6 +191,7 @@
       return;
     }
     expandedId = u.id;
+    detailNotice = "";
     if (details[u.id] || detailLoadingId === u.id) return;
     detailLoadingId = u.id;
     try {
@@ -190,6 +201,47 @@
       expandedId = null;
     } finally {
       detailLoadingId = null;
+    }
+  }
+
+  // Verification actions live in the expanded detail, next to the state they
+  // act on. Resending just sends mail; marking verified overrides a security
+  // gate, so it gets a confirmation dialog.
+  let verifyBusyId = $state<string | null>(null);
+  let detailNotice = $state("");
+
+  async function resendVerification(u: AdminUser) {
+    verifyBusyId = u.id;
+    detailNotice = "";
+    try {
+      await endpoints().resendVerification(u.id);
+      detailNotice = "Verification email sent.";
+    } catch (e) {
+      detailNotice = e instanceof ApiError ? e.message : "Sending failed.";
+    } finally {
+      verifyBusyId = null;
+    }
+  }
+
+  async function markVerified(u: AdminUser) {
+    const ok = await confirm({
+      title: `Mark @${u.username}'s email verified?`,
+      description:
+        "They will be able to sign in without clicking a link. Use this when instance mail was broken — not to skip ownership proof lightly.",
+      confirmText: "Mark verified",
+    });
+    if (!ok) return;
+    verifyBusyId = u.id;
+    detailNotice = "";
+    try {
+      await endpoints().verifyEmail(u.id);
+      users = users.map((x) => (x.id === u.id ? { ...x, emailVerified: true } : x));
+      if (details[u.id]) details[u.id] = { ...details[u.id], user: { ...details[u.id].user, emailVerified: true } };
+      detailNotice = "Email marked verified.";
+    } catch (e) {
+      detailNotice = e instanceof ApiError ? e.message : "Action failed.";
+    } finally {
+      verifyBusyId = null;
     }
   }
 
@@ -242,7 +294,7 @@
     <Icon name="users" size={16} />
     {#if loading}
       <span>Loading accounts…</span>
-    {:else if query.trim()}
+    {:else if query.trim() || fSuspended || fAdmins || fUnverified}
       <span>{users.length} of {total} {total === 1 ? "account" : "accounts"}</span>
     {:else}
       <span>{total} {total === 1 ? "account" : "accounts"} total</span>
@@ -259,6 +311,42 @@
       placeholder="Search by handle or name"
       class="w-full rounded-input border border-input bg-background py-2.5 pr-3.5 pl-9 text-sm shadow-btn outline-hidden placeholder:text-muted-foreground focus:border-foreground"
     />
+  </div>
+
+  <div class="flex flex-wrap gap-2" role="group" aria-label="Filter accounts">
+    <Button
+      variant={fSuspended ? "solid" : "outline"}
+      size="sm"
+      aria-pressed={fSuspended}
+      onclick={() => {
+        fSuspended = !fSuspended;
+        load();
+      }}
+    >
+      Suspended
+    </Button>
+    <Button
+      variant={fAdmins ? "solid" : "outline"}
+      size="sm"
+      aria-pressed={fAdmins}
+      onclick={() => {
+        fAdmins = !fAdmins;
+        load();
+      }}
+    >
+      Admins
+    </Button>
+    <Button
+      variant={fUnverified ? "solid" : "outline"}
+      size="sm"
+      aria-pressed={fUnverified}
+      onclick={() => {
+        fUnverified = !fUnverified;
+        load();
+      }}
+    >
+      Unverified
+    </Button>
   </div>
 
   {#if error}<p class="text-sm text-destructive">{error}</p>{/if}
@@ -341,8 +429,31 @@
                   >
                   <span><strong class="text-foreground">{d.followCounts.followers}</strong> followers</span>
                   <span><strong class="text-foreground">{d.followCounts.following}</strong> following</span>
-                  <span>{d.user.emailVerified ? "Email verified" : "Email unverified"}</span>
+                  <span class="inline-flex flex-wrap items-center gap-2">
+                    <span>{d.user.emailVerified ? "Email verified" : "Email unverified"}</span>
+                    {#if !d.user.emailVerified}
+                      <Button
+                        variant="outline"
+                        size="xs"
+                        disabled={verifyBusyId === u.id}
+                        onclick={() => resendVerification(u)}
+                      >
+                        <Icon name="mail" size={13} />
+                        Resend email
+                      </Button>
+                      <Button
+                        variant="outline"
+                        size="xs"
+                        disabled={verifyBusyId === u.id}
+                        onclick={() => markVerified(u)}
+                      >
+                        <Icon name="check" size={13} />
+                        Mark verified
+                      </Button>
+                    {/if}
+                  </span>
                 </div>
+                {#if detailNotice}<p class="mt-1 text-xs text-muted-foreground">{detailNotice}</p>{/if}
                 <h4 class="mt-4 text-sm font-semibold text-foreground">Latest posts</h4>
                 {#if d.recentPosts.length === 0}
                   <p class="mt-1 text-sm text-muted-foreground">No posts yet.</p>


### PR DESCRIPTION
## Symptom

Two triage gaps on Admin → Users: (1) the table only searched — finding all suspended accounts, listing admins, or spotting unverified addresses meant eyeballing the whole table; (2) the verified state was display-only, leaving admins helpless when instance mail was misconfigured and a user could never receive the link.

## Fix

**Backend** (`feat(admin): user table filters and email verification control`)
- `GET /admin/users` takes `?suspended=`, `?admin=`, `?verified=` (each true/false/absent) next to `?q=`; the header total stays unfiltered.
- `POST /users/:id/verification-email` resends through Better Auth's own endpoint, so token format/expiry stay in one place; 400 when already verified.
- `POST /users/:id/verify` manually marks verified — idempotent, and notified with a sign-in-unblocked email like every other lifecycle event.

**Frontend** (`feat(admin): filter chips and verify actions …`)
- Suspended / Admins / Unverified toggle chips; header switches to filtered-of-total while any is on.
- Expanded detail hosts Resend email and Mark verified (confirm dialog) next to the verified state, with inline feedback and immediate cache updates.

## Verified

- Backend `vitest run src/`: 307 passed; `oxlint`, `oxfmt --check` clean.
- New `admin_filters_verify_test.ts` (each filter both ways, combos with search, verify idempotence + notice, resend delivery + refusals, 404s); needs Postgres + Deno — CI must confirm.
- Frontend `svelte-check` 0 errors, 34 tests passed, lint + format clean. No contract change (no serializer touched).
- `deno check` could not run here; CI covers it.

## Deploy notes

Plain `docker compose up -d`. No migration, no env changes.