### PR TITLE
fix(frontend): let discovery rail scroll with page

### DIFF
--- a/apps/frontend/src/lib/components/Discover.svelte
+++ b/apps/frontend/src/lib/components/Discover.svelte
@@ -23,7 +23,7 @@
   const tags = $derived(data?.tags ?? []);
 </script>
 
-<aside class="flex flex-col gap-6 text-sm">
+<div class="flex flex-col gap-6 text-sm">
   {#if posts.length}
     <section>
       <h2 class="mb-3 flex items-center gap-2 text-base font-semibold text-foreground">
@@ -122,4 +122,4 @@
       </div>
     </section>
   {/if}
-</aside>
+</div>

--- a/apps/frontend/src/routes/+layout.svelte
+++ b/apps/frontend/src/routes/+layout.svelte
@@ -439,13 +439,10 @@
         </svelte:boundary>
       </main>
 
-      <!-- Right rail: discovery (home feed and profile pages only). Pinned like the
-           left rail; scrolls internally only when taller than the viewport. -->
-      <aside
-        class={showDiscover
-          ? "hidden xl:sticky xl:top-24 xl:block xl:max-h-[calc(100vh-7rem)] xl:self-start xl:overflow-y-auto"
-          : "hidden"}
-      >
+      <!-- Right rail: discovery (home feed and profile pages only). Scrolls with
+           the page — deliberately no max-height / internal scroll, so there is
+           never a nested scrollbar on short (e.g. 16:9 laptop) viewports. -->
+      <aside class={showDiscover ? "hidden min-w-0 xl:block" : "hidden"}>
         <Discover data={data.discover} />
       </aside>
     </div>


### PR DESCRIPTION
## Symptom
On standard 16:9 laptop viewports the right discovery rail (Trending / Who to follow / Topics) draws its own thin nested scrollbar next to the page scrollbar.

## Root cause
In `apps/frontend/src/routes/+layout.svelte` the rail was `xl:sticky … xl:max-h-[calc(100vh-7rem)] xl:overflow-y-auto`. At ~768px viewport height that cap is ~656px, while the three discovery sections together are taller, so the rail always overflowed into an internal scroll container.

## Fix
Render the rail as a plain static column (`hidden min-w-0 xl:block`) with no max-height and no internal scroll, so it scrolls naturally with the page like Medium's rail. Chose this over hiding the scrollbar with `no-scrollbar` because a hidden-but-present nested scroller still traps wheel focus. Also demotes Discover's inner `<aside>` to a `<div>` since the layout already provides the landmark.

## Verified
- `pnpm svelte-check`: 0 errors, 0 warnings
- `pnpm lint`: clean
- `pnpm fmt:check`: clean

## Deploy notes
None — frontend-only change, takes effect on a plain `docker compose up -d --build`.