### PR TITLE
fix(frontend): accept LinkedIn company pages in profile links

### DIFF
--- a/apps/frontend/src/lib/components/ProfileLinksEditor.svelte
+++ b/apps/frontend/src/lib/components/ProfileLinksEditor.svelte
@@ -86,7 +86,7 @@
         </Select.Portal>
       </Select.Root>
 
-      {#if meta.input.kind === "handle"}
+      {#if meta.input.kind === "handle" || meta.input.kind === "linkedin"}
         <div class={inputWrapClass}>
           <span class="shrink-0 text-muted-foreground select-none">{inputPrefix(meta)}</span>
           <input

--- a/apps/frontend/src/lib/profileLinks.ts
+++ b/apps/frontend/src/lib/profileLinks.ts
@@ -28,6 +28,9 @@ export type LinkPlatform =
 //  - "url":    a full web address (Website, Other) — stored as typed.
 //  - "fedi":   a fediverse handle "@user@instance" → https://instance/@user.
 //  - "handle": a bare username appended to `base` → e.g. github.com/<user>.
+//  - "linkedin": a person (`in/username`) or an organization (`company/slug`,
+//    `school/slug`, `showcase/slug`) → the matching linkedin.com section. A
+//    bare username keeps meaning `in/username` for backwards compatibility.
 //  - "matrix": a Matrix id "@user:server" → https://matrix.to/#/@user:server.
 //  - "xmpp":   a JID "user@server" → xmpp:user@server.
 //  - "irc":    an IRC address "host/#channel" → ircs://host/#channel.
@@ -35,6 +38,7 @@ export type LinkInput =
   | { kind: "url" }
   | { kind: "fedi" }
   | { kind: "handle"; base: string }
+  | { kind: "linkedin" }
   | { kind: "matrix" }
   | { kind: "xmpp" }
   | { kind: "irc" };
@@ -138,8 +142,8 @@ export const PLATFORMS: PlatformMeta[] = [
     key: "linkedin",
     label: "LinkedIn",
     brand: BRAND.linkedin,
-    input: { kind: "handle", base: "https://www.linkedin.com/in/" },
-    placeholder: "username",
+    input: { kind: "linkedin" },
+    placeholder: "in/username or company/name",
   },
   {
     key: "letterboxd",
@@ -187,13 +191,48 @@ export function platformMeta(key: string): PlatformMeta {
   return BY_KEY.get(key) ?? PLATFORMS[PLATFORMS.length - 1];
 }
 
-// The "base.com/" prefix shown muted before a handle field (handle kind only).
+// The "base.com/" prefix shown muted before a handle field (handle kind only,
+// plus LinkedIn's shared "linkedin.com/" root covering in/company/school).
 export function inputPrefix(meta: PlatformMeta): string {
+  if (meta.input.kind === "linkedin") return "linkedin.com/";
   return meta.input.kind === "handle" ? meta.input.base.replace(/^https?:\/\//, "").replace(/^www\./, "") : "";
 }
 
 function stripAt(s: string): string {
   return s.replace(/^@+/, "");
+}
+
+// LinkedIn hosts people (/in/) and organizations (/company/, /school/,
+// /showcase/) under one picker row. Accepts a pasted full URL, a bare
+// "linkedin.com/…", a section path ("in/foo", "company/bar"), or — for
+// backwards compatibility with the old /in/-only field — a bare username.
+
+function linkedinToUrl(value: string): string | null {
+  // Be forgiving: a pasted full URL always works.
+  if (looksLikeUrl(value)) return normalizeWebUrl(value);
+  // A pasted address without the scheme ("linkedin.com/in/foo").
+  if (/^(www\.)?linkedin\.com\//i.test(value)) return normalizeWebUrl(`https://${value}`);
+
+  const path = stripAt(value).replace(/^\/+|\/+$/g, "");
+  if (!path) return null;
+  const m = path.match(/^(in|company|school|showcase)\/([^/\s]+)\/?$/i);
+  if (m) return `https://www.linkedin.com/${m[1].toLowerCase()}/${m[2]}`;
+  // No section: the legacy bare username means a person.
+  if (/^[^/\s]+$/.test(path)) return `https://www.linkedin.com/in/${path}`;
+  return null;
+}
+
+function linkedinToIdentifier(url: string): string | null {
+  let u: URL;
+  try {
+    u = new URL(url);
+  } catch {
+    return null;
+  }
+  if (!/^(www\.)?linkedin\.com$/i.test(u.hostname)) return null;
+  const m = u.pathname.match(/^\/(in|company|school|showcase)\/([^/]+)\/?$/i);
+  if (!m) return null;
+  return `${m[1].toLowerCase()}/${m[2]}`;
 }
 
 function looksLikeUrl(s: string): boolean {
@@ -238,6 +277,8 @@ export function identifierToUrl(platform: string, raw: string): string | null {
     return rest.includes(".") ? `ircs://${rest}` : null;
   }
 
+  if (meta.input.kind === "linkedin") return linkedinToUrl(value);
+
   // handle: bare username appended to the base.
   const handle = stripAt(value).replace(/^\/+|\/+$/g, "");
   if (!handle) return null;
@@ -265,6 +306,7 @@ export function urlToIdentifier(platform: string, url: string): string {
     const user = u.pathname.replace(/^\/@?/, "").replace(/\/$/, "");
     return user ? `@${user}@${u.host}` : url;
   }
+  if (meta.input.kind === "linkedin") return linkedinToIdentifier(url) ?? url;
   // handle: strip the base prefix; fall back to the trailing path segment.
   const bare = url.replace(meta.input.base, "");
   if (bare && bare !== url) return bare.replace(/\/$/, "");

--- a/apps/frontend/src/routes/settings/+page.svelte
+++ b/apps/frontend/src/routes/settings/+page.svelte
@@ -204,9 +204,11 @@
                   ? "address (user@server)"
                   : meta.input.kind === "irc"
                     ? "address (ircs://host/#channel)"
-                    : meta.input.kind === "handle"
-                      ? "username"
-                      : "web address";
+                    : meta.input.kind === "linkedin"
+                      ? "profile (in/username or company/name)"
+                      : meta.input.kind === "handle"
+                        ? "username"
+                        : "web address";
           error = `Enter a valid ${meta.label} ${what}.`;
           busy = false;
           return;


### PR DESCRIPTION
## Symptom
The LinkedIn profile-link row only supports people (`linkedin.com/in/`). There is no way to enter an organization page (`linkedin.com/company/…`).

## Root cause
In `apps/frontend/src/lib/profileLinks.ts` LinkedIn was a plain `handle` platform with base `https://www.linkedin.com/in/`. A pasted company URL round-tripped through `urlToIdentifier` as a confusing `company/slug` handle under a `linkedin.com/in/` prefix, and typing a bare `company/slug` saved to a broken `/in/company/slug` address.

## Fix
Give LinkedIn its own input kind covering people and organizations (`in/`, `company/`, `school/`, `showcase/`) under one picker row. The field prefix becomes the shared `linkedin.com/` root; a bare username still resolves to `/in/` so existing links keep working; full or schemeless pasted URLs pass through untouched. Editor prefix rendering and the settings validation message are updated to match. Chose one row over separate person/company rows to avoid cluttering the platform picker. Backend needs no change — it already accepts any https URL.

## Verified
- `pnpm svelte-check`: 0 errors, 0 warnings
- `pnpm lint`: clean
- `pnpm fmt:check`: clean
- Converter logic check: bare username → `/in/`, `company/acme` → `/company/acme`, full/schemeless URLs pass through, garbage rejected

## Deploy notes
None — frontend-only change, takes effect on a plain `docker compose up -d --build`.