### PR TITLE
feat(admin): let admins edit user details including login email

### DIFF
--- a/apps/backend/src/db/repositories/accounts.ts
+++ b/apps/backend/src/db/repositories/accounts.ts
@@ -12,3 +12,12 @@ export async function findCredentialHashByUserId(userId: string): Promise<string
   });
   return row?.password ?? null;
 }
+
+// Keeps the credential account's identifier in sync when an admin changes the
+// login email (users.email is the sign-in lookup, but accountId mirrors it).
+export async function setCredentialAccountId(userId: string, email: string): Promise<void> {
+  await db
+    .update(accounts)
+    .set({ accountId: email })
+    .where(and(eq(accounts.userId, userId), eq(accounts.providerId, "credential")));
+}

--- a/apps/backend/src/queue/handlers.ts
+++ b/apps/backend/src/queue/handlers.ts
@@ -1,6 +1,7 @@
 import { registerHandler } from "@/queue/queue.ts";
 import {
   sendAccountDeleted,
+  sendAccountEmailChanged,
   sendAccountErased,
   sendAccountReinstated,
   sendAccountRestored,
@@ -167,5 +168,11 @@ export function registerJobHandlers() {
   // An admin manually verified the address, unblocking sign-in.
   registerHandler("send_account_verified", ({ to, username, appName, origin }) =>
     sendAccountVerified(to, { username, appName, origin }),
+  );
+  // An admin changed the login email: the previous address is told what
+  // happened and where to turn if it wasn't the owner. The verification link
+  // to the new address goes through the standard verification job.
+  registerHandler("send_account_email_changed", ({ to, username, appName, origin, newEmail }) =>
+    sendAccountEmailChanged(to, { username, appName, origin, newEmail }),
   );
 }

--- a/apps/backend/src/queue/queue.ts
+++ b/apps/backend/src/queue/queue.ts
@@ -35,7 +35,8 @@ export type JobName =
   | "send_account_restored"
   | "send_admin_granted"
   | "send_admin_revoked"
-  | "send_account_verified";
+  | "send_account_verified"
+  | "send_account_email_changed";
 
 export type JobPayloads = {
   federate_post: { postId: string; action?: "create" | "update" };
@@ -67,6 +68,7 @@ export type JobPayloads = {
   send_admin_granted: { to: string; username: string; appName: string; origin: string };
   send_admin_revoked: { to: string; username: string; appName: string; origin: string };
   send_account_verified: { to: string; username: string; appName: string; origin: string };
+  send_account_email_changed: { to: string; username: string; appName: string; origin: string; newEmail: string };
 };
 
 type Handler<N extends JobName> = (payload: JobPayloads[N]) => Promise<void>;

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -383,6 +383,35 @@ adminRoutes.get("/users/:id", async (c) => {
   return c.json(adminUserDetailView(await moderation.getUserDetail(c.req.param("id"))));
 });
 
+// Edit another account's profile + login email. Every field optional: the
+// admin form patches only what was touched. Profile validation lives in
+// services/users.ts (via moderation.updateUserDetails); the login email has
+// its own flow — it is stored unverified, a verification link goes to the new
+// address, and a security notice goes to the previous address.
+const adminUpdateUserSchema = z.object({
+  displayName: z.string().optional(),
+  bio: z.string().optional(),
+  publicEmail: z.string().optional(),
+  customSection: z.string().optional(),
+  tags: z.array(z.string()).optional(),
+  links: z
+    .array(
+      z.object({
+        platform: z.string().optional(),
+        url: z.string().optional(),
+        label: z.string().optional(),
+      }),
+    )
+    .optional(),
+  email: z.string().optional(),
+});
+
+adminRoutes.patch("/users/:id", jsonBody(adminUpdateUserSchema), async (c) => {
+  requireAdmin(c);
+  const user = await moderation.updateUserDetails(c.req.param("id"), c.req.valid("json"));
+  return c.json({ user: adminUserView(user) });
+});
+
 // Resend the verification email to an unverified account.
 adminRoutes.post("/users/:id/verification-email", async (c) => {
   requireAdmin(c);

--- a/apps/backend/src/routes/serializers.ts
+++ b/apps/backend/src/routes/serializers.ts
@@ -85,13 +85,17 @@ export function privateUser(u: User, tags: TagSummary[] = [], links: LinkSummary
 }
 
 // Admin user-table row: identity plus the moderation-relevant private fields
-// (login email, verification + suspension state). Only ever returned to admins
-// via the admin routes — never on any public surface.
+// (login email, verification + suspension state) and the editable profile
+// fields. Only ever returned to admins via the admin routes — never on any
+// public surface.
 export function adminUserView(u: User) {
   return {
     id: u.id,
     username: u.username,
     displayName: u.displayName,
+    bio: u.bio,
+    publicEmail: u.publicEmail,
+    customSection: u.customSection,
     avatarUrl: u.avatarUrl,
     isAdmin: u.isAdmin,
     email: u.email,
@@ -102,15 +106,18 @@ export function adminUserView(u: User) {
 }
 
 // Full admin user detail: the table row plus post/follow counts, the latest
-// posts and the reports filed against the account or its posts. The reports
-// already carry the queue's display shape, so they pass through untouched.
-// Only ever returned to admins via the admin routes.
+// posts, the profile tags/links for the edit form, and the reports filed
+// against the account or its posts. The reports already carry the queue's
+// display shape, so they pass through untouched. Only ever returned to admins
+// via the admin routes.
 export function adminUserDetailView(row: {
   user: User;
   postCounts: { draft: number; scheduled: number; published: number };
   followCounts: { followers: number; following: number };
   recentPosts: { id: string; title: string | null; slug: string | null; status: string; createdAt: Date }[];
   reports: ReportRow[];
+  tags?: TagSummary[];
+  links?: LinkSummary[];
 }) {
   return {
     user: adminUserView(row.user),
@@ -118,6 +125,8 @@ export function adminUserDetailView(row: {
     followCounts: row.followCounts,
     recentPosts: row.recentPosts,
     reports: row.reports,
+    tags: row.tags ?? [],
+    links: row.links ?? [],
   };
 }
 

--- a/apps/backend/src/services/accountNotices.ts
+++ b/apps/backend/src/services/accountNotices.ts
@@ -95,3 +95,12 @@ export async function notifyVerified(email: string, username: string): Promise<v
     console.error("accountNotices: failed to queue verified notice (continuing):", err);
   }
 }
+
+/** Login-email-changed notice to the previous address. Best-effort. */
+export async function notifyEmailChanged(oldEmail: string, username: string, newEmail: string): Promise<void> {
+  try {
+    queue.add("send_account_email_changed", { to: oldEmail, username, newEmail, ...(await instanceVars()) });
+  } catch (err) {
+    console.error("accountNotices: failed to queue email-changed notice (continuing):", err);
+  }
+}

--- a/apps/backend/src/services/email.ts
+++ b/apps/backend/src/services/email.ts
@@ -529,3 +529,32 @@ export function accountVerifiedEmail(vars: AccountNoticeVars): Omit<EmailMessage
 export function sendAccountVerified(to: string, vars: AccountNoticeVars): Promise<void> {
   return sendMail({ to, ...accountVerifiedEmail(vars) });
 }
+
+export type AccountEmailChangedVars = AccountNoticeVars & { newEmail: string };
+
+/** Login-email-changed notice to the previous address. Pure content builder. */
+export function accountEmailChangedEmail(vars: AccountEmailChangedVars): Omit<EmailMessage, "to"> {
+  return {
+    subject: `Your ${vars.appName} email was changed`,
+    text: [
+      `The login email for your account (@${vars.username}) on ${vars.appName} was changed by an admin to ${vars.newEmail}.`,
+      "",
+      "Your old address can no longer sign in. A verification link was sent to the new address — the change is complete once it is confirmed.",
+      "",
+      "If this wasn't you, contact the instance administrator immediately — your account may be compromised.",
+      "",
+      `— The ${vars.appName} team`,
+      vars.origin,
+    ].join("\n"),
+    html: layout(
+      "Your email was changed",
+      `The login email for your account (@${vars.username}) on ${vars.appName} was changed by an admin to ${vars.newEmail}. Your old address can no longer sign in. A verification link was sent to the new address — the change is complete once it is confirmed. If this wasn't you, contact the instance administrator immediately — your account may be compromised.`,
+      { label: `Open ${vars.appName}`, url: vars.origin },
+    ),
+  };
+}
+
+/** Login-email-changed notice to the previous address. Queued off the request path. */
+export function sendAccountEmailChanged(to: string, vars: AccountEmailChangedVars): Promise<void> {
+  return sendMail({ to, ...accountEmailChangedEmail(vars) });
+}

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -4,10 +4,12 @@ import * as accountsRepo from "@/db/repositories/accounts.ts";
 import * as blockedDomainsRepo from "@/db/repositories/blockedDomains.ts";
 import * as followsRepo from "@/db/repositories/follows.ts";
 import * as postsRepo from "@/db/repositories/posts.ts";
+import * as linksRepo from "@/db/repositories/profileLinks.ts";
 import * as remoteActorsRepo from "@/db/repositories/remoteActors.ts";
 import * as reportsRepo from "@/db/repositories/reports.ts";
 import type { ReportRow } from "@/db/repositories/reports.ts";
 import * as sessionsRepo from "@/db/repositories/sessions.ts";
+import * as tagsRepo from "@/db/repositories/tags.ts";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import * as usersRepo from "@/db/repositories/users.ts";
 import type { AdminUserFilter } from "@/db/repositories/users.ts";
@@ -18,6 +20,7 @@ import { queue } from "@/queue/queue.ts";
 import {
   notifyAdminGranted,
   notifyAdminRevoked,
+  notifyEmailChanged,
   notifyModeratorDeleted,
   notifyReinstated,
   notifyRestored,
@@ -25,6 +28,8 @@ import {
   notifyVerified,
 } from "@/services/accountNotices.ts";
 import { federationRunning } from "@/services/federationState.ts";
+import type { ProfileLinkInput } from "@/services/users.ts";
+import * as usersService from "@/services/users.ts";
 
 // Business logic for moderation. Admin authorization is enforced at the route
 // layer (requireAdmin); these functions assume the caller is a moderator except
@@ -152,8 +157,9 @@ export async function setAdminRole(
 // ── User detail (admin) ────────────────────────────────────────────────────
 
 // Everything the admin user detail shows: the table row plus post/follow
-// counts, the latest posts, and every report filed against the account or its
-// posts — the context behind a suspend/delete decision.
+// counts, the latest posts, the profile tags/links backing the edit form, and
+// every report filed against the account or its posts — the context behind a
+// suspend/delete decision.
 export async function getUserDetail(targetId: string) {
   const user = await usersRepo.findById(targetId);
   if (!user || user.deletedAt) throw notFound("Account not found.");
@@ -163,7 +169,16 @@ export async function getUserDetail(targetId: string) {
     postsRepo.listRecentByAuthor(user.id),
     reportsRepo.listAgainstUser(user.id),
   ]);
-  return { user, postCounts, followCounts, recentPosts, reports };
+  const [tags, linkRows] = await Promise.all([tagsRepo.tagsForUser(user.id), linksRepo.listForUser(user.id)]);
+  return {
+    user,
+    postCounts,
+    followCounts,
+    recentPosts,
+    reports,
+    tags,
+    links: linkRows.map((l) => ({ platform: l.platform, url: l.url, label: l.label })),
+  };
 }
 
 // How long a deleted account is kept restorable before the sweeper erases it
@@ -292,6 +307,71 @@ export async function resendVerification(targetId: string): Promise<void> {
   } catch (err) {
     throw badRequest(err instanceof Error ? err.message : "Could not send the verification email.");
   }
+}
+
+// ── User details (admin edit) ────────────────────────────────────────────
+
+export type AdminUpdateUserInput = {
+  displayName?: string;
+  bio?: string;
+  publicEmail?: string;
+  customSection?: string;
+  tags?: string[];
+  links?: ProfileLinkInput[];
+  email?: string;
+};
+
+// Edits another account's profile + login email. Profile fields reuse the
+// user's own update path (services/users.ts) so validation, tag/link caps and
+// federation stay in one place; the login email has its own flow: it is
+// normalized, checked for uniqueness, stored unverified, and the owner must
+// prove the new address via the standard verification link while the previous
+// address gets a security notice. Best-effort mail never fails the edit
+// itself, except the verification send, which the admin can retry via the
+// existing resend endpoint.
+export async function updateUserDetails(targetId: string, input: AdminUpdateUserInput) {
+  const target = await usersRepo.findById(targetId);
+  if (!target || target.deletedAt) throw notFound("Account not found.");
+
+  const { email, ...profileInput } = input;
+  if (Object.keys(profileInput).length > 0) {
+    await usersService.updateProfile(targetId, profileInput);
+  }
+
+  if (email !== undefined) {
+    const normalized = email.trim().toLowerCase();
+    if (!normalized) throw badRequest("Enter a valid email address.");
+    if (normalized.length > 254) throw badRequest("Email must be 254 characters or fewer.");
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized)) {
+      throw badRequest("Enter a valid email address.");
+    }
+    // Case-only canonicalisation needs no verification round-trip.
+    if (normalized !== target.email) {
+      if (normalized === target.email.toLowerCase()) {
+        await usersRepo.update(targetId, { email: normalized });
+        await accountsRepo.setCredentialAccountId(targetId, normalized);
+      } else {
+        const existing = await usersRepo.findByEmail(normalized);
+        if (existing && existing.id !== targetId) throw badRequest("That email is already in use.");
+        const oldEmail = (await usersRepo.findById(targetId))?.email ?? target.email;
+        await usersRepo.update(targetId, { email: normalized, emailVerified: false });
+        await accountsRepo.setCredentialAccountId(targetId, normalized);
+        await notifyEmailChanged(oldEmail, target.username, normalized);
+        try {
+          const { auth } = await import("@/auth/auth.ts");
+          await auth.api.sendVerificationEmail({ body: { email: normalized }, headers: new Headers() });
+        } catch (err) {
+          throw badRequest(
+            `Email updated, but the verification email could not be sent: ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+    }
+  }
+
+  const updated = await usersRepo.findById(targetId);
+  if (!updated) throw notFound("Account not found.");
+  return updated;
 }
 
 // ── Posts (admin) ──────────────────────────────────────────────────────────

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -151,6 +151,22 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     restoreUser: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/restore`, {}),
     // Full detail for one account: counts, latest posts and reports against it.
     adminUserDetail: (id: string) => api.get<AdminUserDetail>(`/admin/users/${id}`),
+    // Edit another account's profile + login email. Every field optional; only
+    // the keys present are patched. Changing the login email stores it
+    // unverified, sends a verification link to the new address and a security
+    // notice to the previous one.
+    updateUserAsAdmin: (
+      id: string,
+      body: {
+        displayName?: string;
+        bio?: string;
+        publicEmail?: string;
+        customSection?: string;
+        tags?: string[];
+        links?: { platform: string; url: string; label: string }[];
+        email?: string;
+      },
+    ) => api.patch<{ user: AdminUser }>(`/admin/users/${id}`, body),
     // Resend the verification email, or manually mark the address verified.
     resendVerification: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/verification-email`, {}),
     verifyEmail: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/verify`, {}),

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -1,12 +1,17 @@
 <!-- SPDX-License-Identifier: AGPL-3.0-or-later -->
 <script lang="ts">
   import { endpoints, ApiError } from "$lib/api";
+  import CustomSectionEditor from "$lib/components/CustomSectionEditor.svelte";
   import Icon from "$lib/components/Icon.svelte";
+  import ProfileLinksEditor from "$lib/components/ProfileLinksEditor.svelte";
+  import TagInput from "$lib/components/TagInput.svelte";
   import Time from "$lib/components/Time.svelte";
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
-  import type { AdminUser, AdminUserDetail, DeletedUser } from "$lib/types";
+  import { identifierToUrl, platformMeta, urlToIdentifier } from "$lib/profileLinks";
+  import { MAX_PROFILE_TAGS } from "$lib/tags";
+  import type { AdminUser, AdminUserDetail, DeletedUser, ProfileLink } from "$lib/types";
   import { Dialog, Label } from "bits-ui";
 
   // The signed-in admin's own id, so the row for self can hide every action
@@ -245,6 +250,170 @@
     }
   }
 
+  // Admin edit: patch another account's profile + login email. Seeded from the
+  // expanded detail when present (it carries tags/links), otherwise from the
+  // table row. Links are edited as identifiers and converted back to canonical
+  // URLs on save, mirroring the Settings form.
+  const MAX_CUSTOM_SECTION_LEN = 20_000;
+  let editTarget = $state<AdminUser | null>(null);
+  let editDisplayName = $state("");
+  let editBio = $state("");
+  let editEmail = $state("");
+  let editPublicEmail = $state("");
+  let editCustomSection = $state("");
+  let editTags = $state<string[]>([]);
+  let editLinks = $state<ProfileLink[]>([]);
+  let editInitial = $state("");
+  let editError = $state("");
+  let editBusy = $state(false);
+
+  async function openEdit(u: AdminUser) {
+    editTarget = u;
+    editError = "";
+    editBusy = false;
+    if (!details[u.id] && detailLoadingId !== u.id) {
+      detailLoadingId = u.id;
+      try {
+        details[u.id] = await endpoints().adminUserDetail(u.id);
+      } catch (e) {
+        editError = e instanceof ApiError ? e.message : "Failed to load account detail.";
+      } finally {
+        detailLoadingId = null;
+      }
+    }
+    const d = details[u.id];
+    const row = d?.user ?? u;
+    editDisplayName = row.displayName;
+    editBio = row.bio ?? "";
+    editEmail = row.email;
+    editPublicEmail = row.publicEmail ?? "";
+    editCustomSection = row.customSection ?? "";
+    editTags = d?.tags?.map((t) => t.name) ?? [];
+    editLinks = (d?.links ?? []).map((l) => ({
+      platform: l.platform,
+      url: urlToIdentifier(l.platform, l.url),
+      label: l.label,
+    }));
+    editInitial = JSON.stringify({
+      displayName: editDisplayName,
+      bio: editBio,
+      email: editEmail,
+      publicEmail: editPublicEmail,
+      customSection: editCustomSection,
+      tags: editTags,
+      links: editLinks,
+    });
+  }
+
+  function onEditOpenChange(open: boolean) {
+    if (!open) editTarget = null;
+  }
+
+  const editDirty = $derived(
+    editTarget !== null &&
+      JSON.stringify({
+        displayName: editDisplayName,
+        bio: editBio,
+        email: editEmail,
+        publicEmail: editPublicEmail,
+        customSection: editCustomSection,
+        tags: editTags,
+        links: editLinks,
+      }) !== editInitial,
+  );
+
+  async function saveEdit() {
+    if (!editTarget || editBusy) return;
+    editError = "";
+    const displayName = editDisplayName.trim();
+    if (displayName.length < 1 || displayName.length > 60) {
+      editError = "Display name must be 1–60 characters.";
+      return;
+    }
+    if (editBio.length > 500) {
+      editError = "Bio must be 500 characters or fewer.";
+      return;
+    }
+    const email = editEmail.trim();
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      editError = "Enter a valid login email address.";
+      return;
+    }
+    if (email.length > 254) {
+      editError = "Email must be 254 characters or fewer.";
+      return;
+    }
+    const publicEmail = editPublicEmail.trim();
+    if (publicEmail && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(publicEmail)) {
+      editError = "Enter a valid public email address, or leave it blank.";
+      return;
+    }
+    if (editCustomSection.trim().length > MAX_CUSTOM_SECTION_LEN) {
+      editError = `Custom section must be ${MAX_CUSTOM_SECTION_LEN.toLocaleString("en-US")} characters or fewer.`;
+      return;
+    }
+    const links = [];
+    for (const l of editLinks) {
+      if (!l.url.trim()) continue;
+      const url = identifierToUrl(l.platform, l.url);
+      if (!url) {
+        const meta = platformMeta(l.platform);
+        editError = `Enter a valid ${meta.label} address.`;
+        return;
+      }
+      links.push({ platform: l.platform, url, label: l.label.trim() });
+    }
+    const initial = JSON.parse(editInitial);
+    const body: {
+      displayName?: string;
+      bio?: string;
+      publicEmail?: string;
+      customSection?: string;
+      tags?: string[];
+      links?: { platform: string; url: string; label: string }[];
+      email?: string;
+    } = {};
+    if (displayName !== initial.displayName) body.displayName = displayName;
+    if (editBio !== initial.bio) body.bio = editBio;
+    if (email !== initial.email) body.email = email;
+    if (publicEmail !== initial.publicEmail) body.publicEmail = publicEmail;
+    if (editCustomSection !== initial.customSection) body.customSection = editCustomSection;
+    if (JSON.stringify(editTags) !== JSON.stringify(initial.tags)) body.tags = editTags;
+    if (JSON.stringify(editLinks) !== JSON.stringify(initial.links)) body.links = links;
+    // Links with only blank rows removed still count as a change when the row
+    // set differs; cover the case where the comparison above missed it because
+    // blank rows were skipped during conversion.
+    if (body.links === undefined && JSON.stringify(links) !== JSON.stringify(initial.links)) body.links = links;
+    if (Object.keys(body).length === 0) {
+      editTarget = null;
+      return;
+    }
+    const target = editTarget;
+    const emailChanged = body.email !== undefined && body.email.trim() !== initial.email;
+    editBusy = true;
+    try {
+      const { user } = await endpoints().updateUserAsAdmin(target.id, body);
+      users = users.map((x) => (x.id === target.id ? { ...x, ...user } : x));
+      if (details[target.id]) {
+        details[target.id] = {
+          ...details[target.id],
+          user: { ...details[target.id].user, ...user },
+          tags: body.tags !== undefined ? body.tags.map((t) => ({ slug: t, name: t })) : details[target.id].tags,
+          links: body.links !== undefined ? body.links : details[target.id].links,
+        };
+      }
+      editTarget = null;
+      detailNotice = emailChanged
+        ? "Saved. Login email updated — a verification link was sent to the new address and the previous address was notified."
+        : "Saved.";
+      if (expandedId !== target.id) expandedId = target.id;
+    } catch (e) {
+      editError = e instanceof ApiError ? e.message : "Save failed.";
+    } finally {
+      editBusy = false;
+    }
+  }
+
   async function restoreDeleted(d: DeletedUser) {
     busyId = d.id;
     error = "";
@@ -409,6 +578,10 @@
                     Delete
                   </Button>
                 {/if}
+                <Button variant="outline" size="sm" disabled={busyId === u.id} onclick={() => openEdit(u)}>
+                  <Icon name="edit" size={15} />
+                  Edit
+                </Button>
                 <Button variant="outline" size="sm" disabled={busyId === u.id} onclick={() => openRole(u)}>
                   <Icon name="admin" size={15} />
                   {u.isAdmin ? "Remove admin" : "Make admin"}
@@ -672,6 +845,95 @@
           onclick={confirmRole}
         >
           {roleBusy ? "Saving…" : roleTarget?.isAdmin ? "Remove admin" : "Make admin"}
+        </Button>
+      </div>
+    </Dialog.Content>
+  </Dialog.Portal>
+</Dialog.Root>
+
+<Dialog.Root open={editTarget !== null} onOpenChange={onEditOpenChange}>
+  <Dialog.Portal>
+    <Dialog.Overlay
+      class="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50"
+    />
+    <Dialog.Content
+      class="fixed top-1/2 left-1/2 z-50 max-h-[90vh] w-full max-w-[94%] -translate-x-1/2 -translate-y-1/2 overflow-y-auto rounded-card border border-border bg-background p-6 shadow-popover sm:max-w-[560px]"
+    >
+      <Dialog.Title class="text-lg font-semibold tracking-tight text-foreground">
+        Edit @{editTarget?.username}
+      </Dialog.Title>
+      <Dialog.Description class="mt-1 text-sm text-muted-foreground">
+        Change how this account appears and which login email it uses. Changing the login email stores it unverified — a
+        verification link goes to the new address and a security notice goes to the previous one.
+      </Dialog.Description>
+
+      <div class="mt-5 flex flex-col gap-4">
+        <div class="flex flex-col gap-1.5">
+          <Label.Root for="edit-displayName" class={labelClass}>Display name</Label.Root>
+          <input id="edit-displayName" bind:value={editDisplayName} maxlength={60} class={field} />
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <Label.Root for="edit-bio" class={labelClass}>Bio</Label.Root>
+          <textarea id="edit-bio" bind:value={editBio} rows={3} maxlength={500} class={`${field} resize-none`}
+          ></textarea>
+          <p class="self-end text-xs text-muted-foreground">{editBio.length}/500</p>
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <Label.Root for="edit-email" class={labelClass}>Login email</Label.Root>
+          <input
+            id="edit-email"
+            type="email"
+            bind:value={editEmail}
+            maxlength={254}
+            autocomplete="off"
+            spellcheck={false}
+            class={field}
+          />
+          <p class="text-xs text-muted-foreground">
+            Private — used for sign-in and account recovery. Changing it requires the new address to be verified.
+          </p>
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <Label.Root for="edit-publicEmail" class={labelClass}>Public email</Label.Root>
+          <input
+            id="edit-publicEmail"
+            type="email"
+            bind:value={editPublicEmail}
+            maxlength={254}
+            placeholder="you@example.com"
+            autocomplete="off"
+            spellcheck={false}
+            class={field}
+          />
+          <p class="text-xs text-muted-foreground">Optional — shown on the profile. Leave blank to hide it.</p>
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <Label.Root class={labelClass}>Tags</Label.Root>
+          <TagInput
+            bind:tags={editTags}
+            max={MAX_PROFILE_TAGS}
+            hint="Topics they post about — shown on the profile and federated to other servers."
+          />
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <Label.Root class={labelClass}>Links</Label.Root>
+          <ProfileLinksEditor bind:links={editLinks} />
+        </div>
+        <div class="flex flex-col gap-1.5">
+          <Label.Root class={labelClass}>Custom section</Label.Root>
+          <CustomSectionEditor bind:value={editCustomSection} maxLength={MAX_CUSTOM_SECTION_LEN} />
+        </div>
+        {#if editError}<p class="text-sm text-destructive">{editError}</p>{/if}
+      </div>
+
+      <div class="mt-6 flex justify-end gap-2">
+        <Dialog.Close
+          class="inline-flex h-10 items-center justify-center rounded-input px-4 text-sm font-medium text-foreground hover:bg-muted active:scale-[0.98]"
+        >
+          Cancel
+        </Dialog.Close>
+        <Button variant="solid" disabled={!editDirty || editBusy} onclick={saveEdit}>
+          {editBusy ? "Saving…" : "Save changes"}
         </Button>
       </div>
     </Dialog.Content>

--- a/apps/frontend/src/lib/types.ts
+++ b/apps/frontend/src/lib/types.ts
@@ -480,11 +480,15 @@ export type AdminInstance = {
 
 // ── moderation (admin only) ──
 // A row in the admin user table. Exposes the moderation-relevant private fields
-// (login email, verification + suspension state) — admin surfaces only.
+// (login email, verification + suspension state) plus the editable profile
+// fields — admin surfaces only.
 export type AdminUser = {
   id: string;
   username: string;
   displayName: string;
+  bio: string;
+  publicEmail: string;
+  customSection: string;
   avatarUrl: string | null;
   isAdmin: boolean;
   email: string;
@@ -530,11 +534,14 @@ export type Report = {
 };
 
 // Full admin detail for one account: the table row plus post/follow counts,
-// the latest posts and the reports filed against the account or its posts.
+// the latest posts, the profile tags/links backing the edit form, and the
+// reports filed against the account or its posts.
 export type AdminUserDetail = {
   user: AdminUser;
   postCounts: { draft: number; scheduled: number; published: number };
   followCounts: { followers: number; following: number };
   recentPosts: { id: string; title: string | null; slug: string | null; status: string; createdAt: string }[];
   reports: Report[];
+  tags: Tag[];
+  links: ProfileLink[];
 };

--- a/apps/frontend/src/routes/admin/+page.svelte
+++ b/apps/frontend/src/routes/admin/+page.svelte
@@ -66,7 +66,7 @@
     <section class="rounded-card border border-border bg-background p-6">
       <h2 class="text-lg font-semibold tracking-tight text-foreground">Users</h2>
       <p class="mt-1 text-sm text-muted-foreground">
-        Every local account on this instance. Expand a row for detail; suspend, delete, or change the admin role.
+        Every local account on this instance. Expand a row for detail; edit, suspend, delete, or change the admin role.
       </p>
       <div class="mt-5">
         <AdminUsers selfId={data.user.id} />


### PR DESCRIPTION
## Symptom
Moderators had no way to fix an abusive profile (display name, bio, links) or a mistyped login email short of asking the owner to do it.

## Root cause
No admin write path existed for profile fields or the login email — `services/moderation.ts` only covered suspend, delete, role, and verification flags.

## Fix
- New `PATCH /api/admin/users/:id` (all fields optional). Profile fields delegate to `usersService.updateProfile`, so validation, tag/link caps, and the federated actor update stay in one place; the admin Users table gets an Edit dialog seeded from the user detail.
- A login-email change is normalized, uniqueness-checked, stored with `emailVerified: false`, and the credential `accountId` is synced. The standard Better Auth verification link goes to the new address; a new `send_account_email_changed` notice goes to the previous address. A case-only fix canonicalises silently with no mail round-trip.
- Rejected alternatives: a pending-email column (schema change for a rare operation) and reusing Better Auth's self-service change-email (session-bound, wrong actor for an admin action).

## Verified
- Backend: `oxlint` clean, `vitest` 29 files / 307 tests pass, `oxfmt` clean. (Deno-based `greenly` type-check unavailable in this environment — no Deno binary.)
- Frontend: `svelte-check` 0 errors (includes the backend↔frontend serializer contract), `oxlint` clean, `vitest` 8 files / 34 tests pass.
- Not run: integration suite (needs a throwaway Postgres) and CI.

## Deploy notes
Plain `docker compose up -d` is enough — no migration, no restart-gated change.