### PR TITLE
fix(frontend): default feed language filter to show-only

### DIFF
--- a/apps/frontend/src/lib/prefs.svelte.ts
+++ b/apps/frontend/src/lib/prefs.svelte.ts
@@ -23,9 +23,9 @@ function initialFeed(): FeedTab | null {
 }
 
 function initialLangMode(): FeedLangMode {
-  if (!browser) return "hide";
+  if (!browser) return "show";
   const v = localStorage.getItem(LANG_MODE_KEY);
-  return v === "show" ? "show" : "hide";
+  return v === "hide" ? "hide" : "show";
 }
 
 function initialLangs(): string[] {


### PR DESCRIPTION
The Feed languages toggle defaulted to Hide these, so an empty filter read as an exclusion list. Default to Show only these instead; an explicit Hide choice is still respected.

Verified: code inspection only, no tests run.