### PR TITLE
feat(admin): paginate user table, search by email, fix load loop

### DIFF
--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -3,6 +3,7 @@ import { and, desc, eq, gte, ilike, lt, ne, or, type SQL, sql } from "drizzle-or
 import { alias } from "drizzle-orm/pg-core";
 import { db } from "@/db/client.ts";
 import { type ActorKeyPair, follows, type NewUser, sessions, users } from "@/db/schema.ts";
+import type { Cursor } from "@/lib/pagination.ts";
 
 // All user DB access lives here. Services/routes never touch `db` directly.
 
@@ -145,27 +146,59 @@ export type AdminUserFilter = {
 };
 
 // Live local accounts for the admin user table: newest first, optional handle /
-// name substring filter plus the triage filters. Deleted accounts are excluded
-// — they have their own restore list (listDeleted). Returns full rows (the
-// admin serializer picks fields).
-export function listForAdmin(query = "", filter: AdminUserFilter = {}, limit = 100) {
+// name / email substring filter plus the triage filters. Deleted accounts are
+// excluded — they have their own restore list (listDeleted). Keyset-paginated
+// over (created_at, id): pass the previous page's `nextCursor` to continue.
+// Fetches limit + 1 rows so the service can derive the next cursor without a
+// second query. Returns full rows (the admin serializer picks fields).
+export const ADMIN_USERS_PAGE_SIZE = 50;
+export const ADMIN_USERS_MAX_PAGE_SIZE = 100;
+
+function adminConditions(query = "", filter: AdminUserFilter = {}): (SQL | undefined)[] {
   const conditions: (SQL | undefined)[] = [sql`${users.deletedAt} is null`];
   if (query.trim()) {
     const term = `%${query.replace(/[%_\\]/g, "\\$&")}%`;
-    conditions.push(or(ilike(users.username, term), ilike(users.displayName, term)));
+    conditions.push(or(ilike(users.username, term), ilike(users.displayName, term), ilike(users.email, term)));
   }
   if (filter.suspended !== undefined) {
     conditions.push(filter.suspended ? sql`${users.suspendedAt} is not null` : sql`${users.suspendedAt} is null`);
   }
   if (filter.admin !== undefined) conditions.push(eq(users.isAdmin, filter.admin));
   if (filter.verified !== undefined) conditions.push(eq(users.emailVerified, filter.verified));
+  return conditions;
+}
+
+// Rows strictly older than the cursor in (created_at, id) order.
+function adminBeforeCursor(cursor: Cursor | null) {
+  if (!cursor) return undefined;
+  const ts = new Date(cursor.createdAt);
+  return or(lt(users.createdAt, ts), and(eq(users.createdAt, ts), lt(users.id, cursor.id)));
+}
+
+export function listForAdmin(
+  query = "",
+  filter: AdminUserFilter = {},
+  cursor: Cursor | null = null,
+  limit = ADMIN_USERS_PAGE_SIZE,
+) {
+  const capped = Math.min(Math.max(Math.trunc(limit) || ADMIN_USERS_PAGE_SIZE, 1), ADMIN_USERS_MAX_PAGE_SIZE);
   // `and()` drops undefined operands, so unset dimensions stay unfiltered.
   return db
     .select()
     .from(users)
-    .where(and(...conditions))
-    .orderBy(desc(users.createdAt))
-    .limit(limit);
+    .where(and(...adminConditions(query, filter), adminBeforeCursor(cursor)))
+    .orderBy(desc(users.createdAt), desc(users.id))
+    .limit(capped + 1);
+}
+
+// Filtered live-account count for the admin table header ("N of M accounts"
+// while searching). Uses the same conditions as listForAdmin, minus the cursor.
+export async function countFiltered(query = "", filter: AdminUserFilter = {}): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(users)
+    .where(and(...adminConditions(query, filter)));
+  return row?.n ?? 0;
 }
 
 // Recently deleted accounts, newest deletion first, with the deleting

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -2,7 +2,9 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { rotateSessionSecret, sessionSecretManaged } from "@/config.ts";
+import { ADMIN_USERS_PAGE_SIZE } from "@/db/repositories/users.ts";
 import { badRequest } from "@/lib/http.ts";
+import { decodeCursor } from "@/lib/pagination.ts";
 import { jsonBody } from "@/lib/validate.ts";
 import { requireAdmin } from "@/routes/middleware.ts";
 import { adminUserDetailView, adminUserView, deletedUserView } from "@/routes/serializers.ts";
@@ -298,21 +300,28 @@ function flag(v: string | undefined): boolean | undefined {
   return v === "true" ? true : v === "false" ? false : undefined;
 }
 
-// The admin user table, with an optional handle / name filter (?q=) and
-// triage filters (?suspended=&admin=&verified=true|false).
-// `total` is the unfiltered local-account count for the header.
+// The admin user table, with an optional handle / name / email filter (?q=)
+// and triage filters (?suspended=&admin=&verified=true|false). Keyset-paginated
+// over (created_at, id): `?cursor=` continues from the previous page's
+// `nextCursor`, `?limit=` sizes the page (1–100, default 50). `total` is the
+// unfiltered local-account count; `filteredTotal` matches the current filter.
 adminRoutes.get("/users", async (c) => {
   requireAdmin(c);
+  const q = c.req.query("q") ?? "";
   const filter = {
     suspended: flag(c.req.query("suspended")),
     admin: flag(c.req.query("admin")),
     verified: flag(c.req.query("verified")),
   };
-  const [rows, total] = await Promise.all([
-    moderation.listUsers(c.req.query("q") ?? "", filter),
+  const cursor = decodeCursor(c.req.query("cursor"));
+  const limitRaw = Number.parseInt(c.req.query("limit") ?? "", 10);
+  const limit = Number.isFinite(limitRaw) ? limitRaw : ADMIN_USERS_PAGE_SIZE;
+  const [{ users, nextCursor }, total, filteredTotal] = await Promise.all([
+    moderation.listUsers(q, filter, cursor, limit),
     moderation.countUsers(),
+    moderation.countFilteredUsers(q, filter),
   ]);
-  return c.json({ users: rows.map(adminUserView), total });
+  return c.json({ users: users.map(adminUserView), nextCursor, total, filteredTotal });
 });
 
 const suspendSchema = z.object({ suspend: z.boolean() });

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -16,6 +16,7 @@ import type { AdminUserFilter } from "@/db/repositories/users.ts";
 import type { BlockedDomain } from "@/db/schema.ts";
 import { hostMatchesDomain, normalizeDomain } from "@/lib/domain.ts";
 import { badRequest, forbidden, notFound, unauthorized } from "@/lib/http.ts";
+import { type Cursor, encodeCursor } from "@/lib/pagination.ts";
 import { queue } from "@/queue/queue.ts";
 import {
   notifyAdminGranted,
@@ -91,11 +92,33 @@ export async function resolveReport(adminId: string, reportId: string, resolutio
 
 // ── Users (admin) ──────────────────────────────────────────────────────────
 
-export function listUsers(
+// One page of the admin user table, newest first. The cursor is opaque —
+// pass back the previous page's `nextCursor`, or null for the first page.
+// `limit` is clamped to the repository's page bounds.
+export async function listUsers(
   query = "",
   filter: AdminUserFilter = {},
-): Promise<Awaited<ReturnType<typeof usersRepo.listForAdmin>>> {
-  return usersRepo.listForAdmin(query, filter);
+  cursor: Cursor | null = null,
+  limit = usersRepo.ADMIN_USERS_PAGE_SIZE,
+): Promise<{ users: Awaited<ReturnType<typeof usersRepo.listForAdmin>>; nextCursor: string | null }> {
+  const capped = Math.min(
+    Math.max(Math.trunc(limit) || usersRepo.ADMIN_USERS_PAGE_SIZE, 1),
+    usersRepo.ADMIN_USERS_MAX_PAGE_SIZE,
+  );
+  const rows = await usersRepo.listForAdmin(query, filter, cursor, capped);
+  const hasMore = rows.length > capped;
+  const page = hasMore ? rows.slice(0, capped) : rows;
+  const last = page.at(-1);
+  return {
+    users: page,
+    nextCursor: hasMore && last ? encodeCursor({ createdAt: last.createdAt.toISOString(), id: last.id }) : null,
+  };
+}
+
+// Live accounts matching the current table filter — the "N of M" header while
+// searching or paging. Equal to `countUsers()` when unfiltered.
+export function countFilteredUsers(query = "", filter: AdminUserFilter = {}): Promise<number> {
+  return usersRepo.countFiltered(query, filter);
 }
 
 // Total local accounts, unfiltered — the admin user table's header count.

--- a/apps/backend/tests/integration/admin_filters_verify_test.ts
+++ b/apps/backend/tests/integration/admin_filters_verify_test.ts
@@ -9,6 +9,7 @@
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import * as usersRepo from "@/db/repositories/users.ts";
 import { HttpError } from "@/lib/http.ts";
+import { decodeCursor } from "@/lib/pagination.ts";
 import { registerHandler } from "@/queue/queue.ts";
 import * as moderation from "@/services/moderation.ts";
 import { closeDb, mkUser, resetDb } from "./harness.ts";
@@ -40,6 +41,16 @@ function usernames(rows: readonly { username: string }[]): string[] {
   return rows.map((r) => r.username).toSorted();
 }
 
+async function page(
+  query = "",
+  filter: Parameters<typeof moderation.listUsers>[1] = {},
+  cursor: Parameters<typeof moderation.listUsers>[2] = null,
+  limit: Parameters<typeof moderation.listUsers>[3] = 50,
+) {
+  const { users } = await moderation.listUsers(query, filter, cursor, limit);
+  return users;
+}
+
 afterAll(async () => {
   await closeDb();
 });
@@ -56,28 +67,53 @@ describe("admin user filters", () => {
   });
 
   test("no filter lists everyone live", async () => {
-    expect(usernames(await moderation.listUsers())).toEqual(["alpha", "beta", "delta", "gamma"]);
+    expect(usernames(await page())).toEqual(["alpha", "beta", "delta", "gamma"]);
   });
 
   test("suspended filter splits both ways", async () => {
-    expect(usernames(await moderation.listUsers("", { suspended: true }))).toEqual(["beta"]);
-    expect(usernames(await moderation.listUsers("", { suspended: false }))).toEqual(["alpha", "delta", "gamma"]);
+    expect(usernames(await page("", { suspended: true }))).toEqual(["beta"]);
+    expect(usernames(await page("", { suspended: false }))).toEqual(["alpha", "delta", "gamma"]);
   });
 
   test("admin filter splits both ways", async () => {
-    expect(usernames(await moderation.listUsers("", { admin: true }))).toEqual(["gamma"]);
-    expect(usernames(await moderation.listUsers("", { admin: false }))).toEqual(["alpha", "beta", "delta"]);
+    expect(usernames(await page("", { admin: true }))).toEqual(["gamma"]);
+    expect(usernames(await page("", { admin: false }))).toEqual(["alpha", "beta", "delta"]);
   });
 
   test("verified filter splits both ways", async () => {
-    expect(usernames(await moderation.listUsers("", { verified: true }))).toEqual(["delta"]);
-    expect(usernames(await moderation.listUsers("", { verified: false }))).toEqual(["alpha", "beta", "gamma"]);
+    expect(usernames(await page("", { verified: true }))).toEqual(["delta"]);
+    expect(usernames(await page("", { verified: false }))).toEqual(["alpha", "beta", "gamma"]);
   });
 
   test("filters combine with each other and with the search query", async () => {
-    expect(usernames(await moderation.listUsers("", { admin: false, verified: false }))).toEqual(["alpha", "beta"]);
-    expect(usernames(await moderation.listUsers("a", { verified: false }))).toEqual(["alpha", "beta", "gamma"]);
-    expect(usernames(await moderation.listUsers("amm", { admin: true }))).toEqual(["gamma"]);
+    expect(usernames(await page("", { admin: false, verified: false }))).toEqual(["alpha", "beta"]);
+    expect(usernames(await page("a", { verified: false }))).toEqual(["alpha", "beta", "gamma"]);
+    expect(usernames(await page("amm", { admin: true }))).toEqual(["gamma"]);
+  });
+
+  test("search matches the login email too", async () => {
+    expect(usernames(await page("beta@example.test"))).toEqual(["beta"]);
+    expect(usernames(await page("ALPHA@EXAMPLE.TEST"))).toEqual(["alpha"]);
+  });
+
+  test("filtered count matches the listing", async () => {
+    expect(await moderation.countFilteredUsers("", { suspended: true })).toBe(1);
+    expect(await moderation.countFilteredUsers("a", { verified: false })).toBe(3);
+    expect(await moderation.countUsers()).toBe(4);
+  });
+
+  test("cursor pagination walks the whole table without overlap", async () => {
+    const first = await moderation.listUsers("", {}, null, 2);
+    expect(first.users).toHaveLength(2);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await moderation.listUsers("", {}, decodeCursor(first.nextCursor), 2);
+    expect(second.users).toHaveLength(2);
+    expect(second.nextCursor).toBeNull();
+
+    const seen = usernames([...first.users, ...second.users]);
+    expect(seen).toEqual(["alpha", "beta", "delta", "gamma"]);
+    expect(new Set([...first.users, ...second.users].map((u) => u.id)).size).toBe(4);
   });
 });
 

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -133,14 +133,22 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     checkPort25: () => api.get<{ ok: boolean; detail: string }>("/admin/email/port25"),
 
     // admin moderation
-    adminUsers: (q?: string, filters?: { suspendedOnly?: boolean; adminsOnly?: boolean; unverifiedOnly?: boolean }) => {
+    adminUsers: (
+      q?: string,
+      filters?: { suspendedOnly?: boolean; adminsOnly?: boolean; unverifiedOnly?: boolean },
+      page?: { cursor?: string | null; limit?: number },
+    ) => {
       const params = new URLSearchParams();
       if (q) params.set("q", q);
       if (filters?.suspendedOnly) params.set("suspended", "true");
       if (filters?.adminsOnly) params.set("admin", "true");
       if (filters?.unverifiedOnly) params.set("verified", "false");
+      if (page?.cursor) params.set("cursor", page.cursor);
+      if (page?.limit) params.set("limit", String(page.limit));
       const qs = params.toString();
-      return api.get<{ users: AdminUser[]; total: number }>(`/admin/users${qs ? `?${qs}` : ""}`);
+      return api.get<{ users: AdminUser[]; nextCursor: string | null; total: number; filteredTotal: number }>(
+        `/admin/users${qs ? `?${qs}` : ""}`,
+      );
     },
     suspendUser: (id: string, suspend: boolean) => api.post<{ ok: true }>(`/admin/users/${id}/suspend`, { suspend }),
     // Delete a local account. GitHub-style: the exact username plus the acting

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -12,7 +12,8 @@
   import { identifierToUrl, platformMeta, urlToIdentifier } from "$lib/profileLinks";
   import { MAX_PROFILE_TAGS } from "$lib/tags";
   import type { AdminUser, AdminUserDetail, DeletedUser, ProfileLink } from "$lib/types";
-  import { Dialog, Label } from "bits-ui";
+  import { Dialog, DropdownMenu, Label } from "bits-ui";
+  import { onMount } from "svelte";
 
   // The signed-in admin's own id, so the row for self can hide every action
   // (the server also forbids them).
@@ -20,10 +21,16 @@
 
   let users = $state<AdminUser[]>([]);
   let total = $state(0);
+  let filteredTotal = $state(0);
+  let nextCursor = $state<string | null>(null);
   let loading = $state(true);
+  let loadingMore = $state(false);
   let error = $state("");
   let query = $state("");
   let busyId = $state<string | null>(null);
+  // Monotonic request id: only the latest list response may write state, so a
+  // slow search can never overwrite a newer one.
+  let loadSeq = 0;
 
   // Triage filters: each shows only matching accounts while on.
   let fSuspended = $state(false);
@@ -44,25 +51,47 @@
   let deleteError = $state("");
   let deleteBusy = $state(false);
 
-  async function load() {
-    loading = true;
-    error = "";
+  // Cursor-paginated table load. `reset` fetches the first page (new search or
+  // filter change); otherwise appends the next page. Stale responses are
+  // dropped via `loadSeq`, and the detail cache is kept — mutations update it
+  // in place, so an expansion survives a reload.
+  function filterParams() {
+    return {
+      suspendedOnly: fSuspended || undefined,
+      adminsOnly: fAdmins || undefined,
+      unverifiedOnly: fUnverified || undefined,
+    };
+  }
+
+  async function load(reset = true) {
+    const my = ++loadSeq;
+    if (reset) {
+      loading = true;
+      nextCursor = null;
+      error = "";
+    } else {
+      if (!nextCursor || loadingMore) return;
+      loadingMore = true;
+    }
     try {
-      const res = await endpoints().adminUsers(query.trim() || undefined, {
-        suspendedOnly: fSuspended || undefined,
-        adminsOnly: fAdmins || undefined,
-        unverifiedOnly: fUnverified || undefined,
+      const res = await endpoints().adminUsers(query.trim() || undefined, filterParams(), {
+        cursor: reset ? null : nextCursor,
       });
-      users = res.users;
+      if (my !== loadSeq) return;
+      users = reset ? res.users : [...users, ...res.users.filter((u) => !users.some((x) => x.id === u.id))];
       total = res.total;
-      // Mutations may have changed what a detail shows; drop the cache so an
-      // expansion always refetches.
-      details = {};
+      filteredTotal = res.filteredTotal;
+      nextCursor = res.nextCursor;
       detailNotice = "";
     } catch (e) {
+      if (my !== loadSeq) return;
+      if (reset) users = [];
       error = e instanceof ApiError ? e.message : "Failed to load users.";
     } finally {
-      loading = false;
+      if (my === loadSeq) {
+        loading = false;
+        loadingMore = false;
+      }
     }
   }
 
@@ -78,7 +107,7 @@
     }
   }
 
-  $effect(() => {
+  onMount(() => {
     load();
     loadDeleted();
   });
@@ -86,7 +115,7 @@
   let searchTimer: ReturnType<typeof setTimeout>;
   function onSearch() {
     clearTimeout(searchTimer);
-    searchTimer = setTimeout(load, 250);
+    searchTimer = setTimeout(() => load(true), 250);
   }
 
   async function toggleSuspend(u: AdminUser) {
@@ -103,9 +132,15 @@
     busyId = u.id;
     try {
       await endpoints().suspendUser(u.id, suspend);
-      // Replace the row immutably rather than mutating the loop item in place,
-      // so the badge and button reliably re-render with the new state.
-      users = users.map((x) => (x.id === u.id ? { ...x, suspended: suspend } : x));
+      // A reinstated account no longer matches the Suspended-only filter, so it
+      // leaves the listing; otherwise update the row in place.
+      if (fSuspended && !suspend) {
+        users = users.filter((x) => x.id !== u.id);
+        filteredTotal = Math.max(0, filteredTotal - 1);
+        if (expandedId === u.id) expandedId = null;
+      } else {
+        users = users.map((x) => (x.id === u.id ? { ...x, suspended: suspend } : x));
+      }
     } catch (e) {
       error = e instanceof ApiError ? e.message : "Action failed.";
     } finally {
@@ -137,7 +172,15 @@
         username: deleteUsername.trim(),
         password: deletePassword,
       });
-      users = users.filter((x) => x.id !== deleteTarget!.id);
+      const goneId = deleteTarget.id;
+      users = users.filter((x) => x.id !== goneId);
+      total = Math.max(0, total - 1);
+      filteredTotal = Math.max(0, filteredTotal - 1);
+      if (expandedId === goneId) expandedId = null;
+      if (details[goneId]) {
+        const { [goneId]: _, ...rest } = details;
+        details = rest;
+      }
       deleteTarget = null;
       await loadDeleted();
     } catch (e) {
@@ -174,7 +217,14 @@
     try {
       await endpoints().setUserRole(roleTarget.id, { makeAdmin, password: rolePassword });
       const id = roleTarget.id;
-      users = users.map((x) => (x.id === id ? { ...x, isAdmin: makeAdmin } : x));
+      // A demoted account no longer matches the Admins-only filter.
+      if (fAdmins && !makeAdmin) {
+        users = users.filter((x) => x.id !== id);
+        filteredTotal = Math.max(0, filteredTotal - 1);
+        if (expandedId === id) expandedId = null;
+      } else {
+        users = users.map((x) => (x.id === id ? { ...x, isAdmin: makeAdmin } : x));
+      }
       roleTarget = null;
     } catch (e) {
       roleError = e instanceof ApiError ? e.message : "Role change failed.";
@@ -184,8 +234,8 @@
   }
 
   // Expandable per-account detail: counts, latest posts and reports against
-  // the account or its posts. Loaded lazily on expand and cached until the
-  // next table reload.
+  // the account or its posts. Loaded lazily on expand and cached; mutations
+  // update the cache in place, and reloads keep it.
   let expandedId = $state<string | null>(null);
   let details = $state<Record<string, AdminUserDetail>>({});
   let detailLoadingId = $state<string | null>(null);
@@ -240,9 +290,17 @@
     detailNotice = "";
     try {
       await endpoints().verifyEmail(u.id);
-      users = users.map((x) => (x.id === u.id ? { ...x, emailVerified: true } : x));
-      if (details[u.id]) details[u.id] = { ...details[u.id], user: { ...details[u.id].user, emailVerified: true } };
-      detailNotice = "Email marked verified.";
+      // A verified account no longer matches the Unverified-only filter.
+      if (fUnverified) {
+        users = users.filter((x) => x.id !== u.id);
+        filteredTotal = Math.max(0, filteredTotal - 1);
+        if (expandedId === u.id) expandedId = null;
+        detailNotice = "";
+      } else {
+        users = users.map((x) => (x.id === u.id ? { ...x, emailVerified: true } : x));
+        if (details[u.id]) details[u.id] = { ...details[u.id], user: { ...details[u.id].user, emailVerified: true } };
+        detailNotice = "Email marked verified.";
+      }
     } catch (e) {
       detailNotice = e instanceof ApiError ? e.message : "Action failed.";
     } finally {
@@ -456,6 +514,11 @@
   const field =
     "rounded-input border border-input bg-background shadow-btn px-3.5 py-2.5 text-sm outline-hidden placeholder:text-muted-foreground focus:border-foreground";
   const labelClass = "text-sm font-medium leading-none";
+  const menuItemClass =
+    "flex h-10 cursor-pointer items-center gap-2 rounded-button px-3 text-sm font-medium text-foreground select-none data-highlighted:bg-muted focus-visible:outline-hidden";
+  const destructiveItemClass = menuItemClass.replace("text-foreground", "text-destructive");
+
+  const isFiltering = $derived(query.trim() !== "" || fSuspended || fAdmins || fUnverified);
 </script>
 
 <div class="flex flex-col gap-4">
@@ -463,10 +526,16 @@
     <Icon name="users" size={16} />
     {#if loading}
       <span>Loading accounts…</span>
-    {:else if query.trim() || fSuspended || fAdmins || fUnverified}
-      <span>{users.length} of {total} {total === 1 ? "account" : "accounts"}</span>
+    {:else if isFiltering}
+      <span>
+        {filteredTotal} of {total}
+        {total === 1 ? "account" : "accounts"} · showing {users.length}
+      </span>
     {:else}
-      <span>{total} {total === 1 ? "account" : "accounts"} total</span>
+      <span>
+        {total}
+        {total === 1 ? "account" : "accounts"} total{nextCursor ? ` · showing ${users.length}` : ""}
+      </span>
     {/if}
   </div>
 
@@ -475,9 +544,11 @@
       <Icon name="search" size={16} />
     </span>
     <input
+      type="search"
       bind:value={query}
       oninput={onSearch}
-      placeholder="Search by handle or name"
+      placeholder="Search by handle, name, or email"
+      aria-label="Search accounts by handle, name, or email"
       class="w-full rounded-input border border-input bg-background py-2.5 pr-3.5 pl-9 text-sm shadow-btn outline-hidden placeholder:text-muted-foreground focus:border-foreground"
     />
   </div>
@@ -562,7 +633,7 @@
               </p>
             </div>
             {#if u.id !== selfId}
-              <div class="flex shrink-0 flex-wrap items-center justify-end gap-2">
+              <div class="flex shrink-0 items-center gap-2">
                 {#if !u.isAdmin}
                   <Button
                     variant={u.suspended ? "outline" : "destructive"}
@@ -573,19 +644,43 @@
                     <Icon name={u.suspended ? "check" : "shieldOff"} size={15} />
                     {u.suspended ? "Reinstate" : "Suspend"}
                   </Button>
-                  <Button variant="outline" size="sm" disabled={busyId === u.id} onclick={() => openDelete(u)}>
-                    <Icon name="trash" size={15} />
-                    Delete
-                  </Button>
                 {/if}
-                <Button variant="outline" size="sm" disabled={busyId === u.id} onclick={() => openEdit(u)}>
-                  <Icon name="edit" size={15} />
-                  Edit
-                </Button>
-                <Button variant="outline" size="sm" disabled={busyId === u.id} onclick={() => openRole(u)}>
-                  <Icon name="admin" size={15} />
-                  {u.isAdmin ? "Remove admin" : "Make admin"}
-                </Button>
+                <DropdownMenu.Root>
+                  <DropdownMenu.Trigger disabled={busyId === u.id}>
+                    {#snippet child({ props })}
+                      <Button
+                        {...props}
+                        variant="outline"
+                        size="sm"
+                        aria-label={`More actions for @${u.username}`}
+                        class="px-2!"
+                      >
+                        <Icon name="more" size={16} />
+                      </Button>
+                    {/snippet}
+                  </DropdownMenu.Trigger>
+                  <DropdownMenu.Portal>
+                    <DropdownMenu.Content
+                      align="end"
+                      sideOffset={6}
+                      class="z-50 w-52 rounded-card border border-border bg-background p-1 shadow-popover focus-visible:outline-hidden"
+                    >
+                      <DropdownMenu.Item onSelect={() => openEdit(u)} class={menuItemClass}>
+                        <Icon name="edit" size={16} /> Edit profile…
+                      </DropdownMenu.Item>
+                      <DropdownMenu.Item onSelect={() => openRole(u)} class={menuItemClass}>
+                        <Icon name="admin" size={16} />
+                        {u.isAdmin ? "Remove admin…" : "Make admin…"}
+                      </DropdownMenu.Item>
+                      {#if !u.isAdmin}
+                        <DropdownMenu.Separator class="my-1 h-px bg-border" />
+                        <DropdownMenu.Item onSelect={() => openDelete(u)} class={destructiveItemClass}>
+                          <Icon name="trash" size={16} /> Delete…
+                        </DropdownMenu.Item>
+                      {/if}
+                    </DropdownMenu.Content>
+                  </DropdownMenu.Portal>
+                </DropdownMenu.Root>
               </div>
             {/if}
           </div>
@@ -679,6 +774,13 @@
         </li>
       {/each}
     </ul>
+    {#if nextCursor}
+      <div class="mt-4 flex justify-center">
+        <Button variant="outline" size="sm" disabled={loadingMore} onclick={() => load(false)}>
+          {loadingMore ? "Loading…" : `Load more (${users.length} of ${filteredTotal})`}
+        </Button>
+      </div>
+    {/if}
   {/if}
 
   <div class="mt-4 border-t border-border pt-4">


### PR DESCRIPTION
## Symptom

The Admin → Users table silently capped at 100 rows with no pager, so large instances could not reach older accounts. Search matched handle/display name only, missing the login email admins usually look up by. Typing in search fired overlapping fetches with no ordering guard.

## Root cause

- `listForAdmin` used a fixed `LIMIT 100` with no cursor (`apps/backend/src/db/repositories/users.ts`).
- The search predicate covered `username | displayName` only.
- `AdminUsers.svelte` loaded the table from a bare $\effect that re-ran on every reactive read, defeating the 250ms search debounce; responses had no sequence guard, so a slow request could overwrite a newer one.

## Fix

- Keyset-paginate `GET /admin/users` over `(created_at, id)` (same convention as the feeds): `?cursor=&limit=` (1–100, default 50), response gains `nextCursor` + `filteredTotal`.
- Search also matches `email` (escaped `%_\` as before); added `countFiltered` reusing the same conditions.
- Frontend loads explicitly (`onMount` + search/filter handlers) with a monotonic request id, appends pages via Load more with id-dedup, keeps the detail cache across reloads, and condenses per-row Edit/Role/Delete into a bits-ui DropdownMenu (Suspend stays primary).
- Mutations keep filtered views consistent (reinstated/demoted/verified/deleted rows leave the listing when they no longer match).

## Verified

- `deno check` on touched backend files; `svelte-check` 0 errors; `vitest run src/` 307 passed; `oxlint` + `oxfmt` clean in both apps.
- Extended `admin_filters_verify_test.ts` (email search, filtered counts, cursor walk without overlap).
- NOT run: `test:integration` (needs Postgres; `DATABASE_URL` unset here) — please let CI cover it.

## Deploy notes

Plain redeploy; no migrations, no config changes. API shape change on `GET /admin/users` only (additive fields + new optional params).