### PR TITLE
feat(admin): tri-state user filters and deleted-list pagination

### DIFF
--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -203,16 +203,40 @@ export async function countFiltered(query = "", filter: AdminUserFilter = {}): P
 
 // Recently deleted accounts, newest deletion first, with the deleting
 // moderator's username (null when unknown). The admin restore list — the
-// "backup" a deletion keeps for the retention window.
-export function listDeleted(limit = 100) {
+// "backup" a deletion keeps for the retention window. Keyset-paginated over
+// (deleted_at, id): pass the previous page's `nextCursor` to continue.
+// Fetches limit + 1 rows so the service can derive the next cursor without a
+// second query.
+export const DELETED_USERS_PAGE_SIZE = 50;
+export const DELETED_USERS_MAX_PAGE_SIZE = 100;
+
+// Rows strictly older than the cursor in (deleted_at, id) order.
+function deletedBeforeCursor(cursor: Cursor | null) {
+  if (!cursor) return undefined;
+  const ts = new Date(cursor.createdAt);
+  return or(lt(users.deletedAt, ts), and(eq(users.deletedAt, ts), lt(users.id, cursor.id)));
+}
+
+export function listDeleted(cursor: Cursor | null = null, limit = DELETED_USERS_PAGE_SIZE) {
+  const capped = Math.min(Math.max(Math.trunc(limit) || DELETED_USERS_PAGE_SIZE, 1), DELETED_USERS_MAX_PAGE_SIZE);
   const deleter = alias(users, "deleter");
   return db
     .select({ user: users, deletedByUsername: deleter.username })
     .from(users)
     .leftJoin(deleter, eq(users.deletedBy, deleter.id))
-    .where(sql`${users.deletedAt} is not null`)
-    .orderBy(desc(users.deletedAt))
-    .limit(limit);
+    .where(and(sql`${users.deletedAt} is not null`, deletedBeforeCursor(cursor)))
+    .orderBy(desc(users.deletedAt), desc(users.id))
+    .limit(capped + 1);
+}
+
+// How many deleted accounts are awaiting restore or expiry — the restore
+// list's header count.
+export async function countDeleted(): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(users)
+    .where(sql`${users.deletedAt} is not null`);
+  return row?.n ?? 0;
 }
 
 // Ids of deleted accounts whose retention window ended before `cutoff` — the

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -2,7 +2,7 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { rotateSessionSecret, sessionSecretManaged } from "@/config.ts";
-import { ADMIN_USERS_PAGE_SIZE } from "@/db/repositories/users.ts";
+import { ADMIN_USERS_PAGE_SIZE, DELETED_USERS_PAGE_SIZE } from "@/db/repositories/users.ts";
 import { badRequest } from "@/lib/http.ts";
 import { decodeCursor } from "@/lib/pagination.ts";
 import { jsonBody } from "@/lib/validate.ts";
@@ -355,11 +355,19 @@ adminRoutes.post("/users/:id/restore", async (c) => {
   return c.json({ ok: true });
 });
 
-// Recently deleted accounts awaiting restore or expiry, newest deletion first.
+// Recently deleted accounts awaiting restore or expiry, newest deletion
+// first. Keyset-paginated like the live table: `?cursor=` continues from the
+// previous page's `nextCursor`, `?limit=` sizes the page (1–100, default 50).
 adminRoutes.get("/users/deleted", async (c) => {
   requireAdmin(c);
-  const rows = await moderation.listDeletedUsers();
-  return c.json({ users: rows.map(deletedUserView) });
+  const cursor = decodeCursor(c.req.query("cursor"));
+  const limitRaw = Number.parseInt(c.req.query("limit") ?? "", 10);
+  const limit = Number.isFinite(limitRaw) ? limitRaw : DELETED_USERS_PAGE_SIZE;
+  const [{ users, nextCursor }, total] = await Promise.all([
+    moderation.listDeletedUsers(cursor, limit),
+    moderation.countDeletedUsers(),
+  ]);
+  return c.json({ users: users.map(deletedUserView), nextCursor, total });
 });
 
 // Permanently erase a deleted account before its window ends (frees the handle

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -265,23 +265,49 @@ export async function restoreUser(targetId: string): Promise<void> {
 
 // Recently deleted accounts with the deleting moderator's username, each
 // account's kept post count, and when its retention window ends — the admin
-// restore list.
-export async function listDeletedUsers(): Promise<
-  {
-    user: NonNullable<Awaited<ReturnType<typeof usersRepo.findById>>>;
-    deletedByUsername: string | null;
-    postCount: number;
-    expiresAt: Date;
-  }[]
-> {
-  const rows = await usersRepo.listDeleted();
-  const counts = await postsRepo.countLocalByAuthors(rows.map((r) => r.user.id));
-  return rows.map((r) => ({
+// restore list. Keyset-paginated like the live table: pass back the previous
+// page's `nextCursor`, or null for the first page.
+export type DeletedUserRow = {
+  user: NonNullable<Awaited<ReturnType<typeof usersRepo.findById>>>;
+  deletedByUsername: string | null;
+  postCount: number;
+  expiresAt: Date;
+};
+
+export async function listDeletedUsers(
+  cursor: Cursor | null = null,
+  limit = usersRepo.DELETED_USERS_PAGE_SIZE,
+): Promise<{ users: DeletedUserRow[]; nextCursor: string | null }> {
+  const capped = Math.min(
+    Math.max(Math.trunc(limit) || usersRepo.DELETED_USERS_PAGE_SIZE, 1),
+    usersRepo.DELETED_USERS_MAX_PAGE_SIZE,
+  );
+  const rows = await usersRepo.listDeleted(cursor, capped);
+  const hasMore = rows.length > capped;
+  const page = hasMore ? rows.slice(0, capped) : rows;
+  const counts = await postsRepo.countLocalByAuthors(page.map((r) => r.user.id));
+  const users = page.map((r) => ({
     ...r,
     postCount: counts.get(r.user.id) ?? 0,
     // `deletedAt` is non-null: listDeleted only returns deleted accounts.
     expiresAt: deletionExpiresAt(r.user.deletedAt!),
   }));
+  const last = page.at(-1);
+  // The cursor is opaque: the deletion timestamp rides in the `createdAt`
+  // slot, since this listing orders by deleted_at rather than created_at.
+  return {
+    users,
+    nextCursor:
+      hasMore && last?.user.deletedAt
+        ? encodeCursor({ createdAt: last.user.deletedAt.toISOString(), id: last.user.id })
+        : null,
+  };
+}
+
+// How many deleted accounts await restore or expiry — the restore list's
+// header count.
+export function countDeletedUsers(): Promise<number> {
+  return usersRepo.countDeleted();
 }
 
 // Permanently erases a deleted account before its window ends. The Delete was

--- a/apps/backend/tests/integration/admin_delete_user_test.ts
+++ b/apps/backend/tests/integration/admin_delete_user_test.ts
@@ -15,6 +15,7 @@ import * as postsRepo from "@/db/repositories/posts.ts";
 import * as usersRepo from "@/db/repositories/users.ts";
 import { accounts, sessions } from "@/db/schema.ts";
 import { HttpError } from "@/lib/http.ts";
+import { decodeCursor } from "@/lib/pagination.ts";
 import { registerHandler } from "@/queue/queue.ts";
 import { sweep as sweepDeletedUsers } from "@/services/deletedUsers.ts";
 import * as moderation from "@/services/moderation.ts";
@@ -160,7 +161,7 @@ describe("admin delete user", () => {
   });
 
   test("a deleted account shows up on the restore list with its metadata", async () => {
-    const deleted = await moderation.listDeletedUsers();
+    const { users: deleted } = await moderation.listDeletedUsers();
     expect(deleted).toHaveLength(1);
     expect(deleted[0].user.id).toBe(victimId);
     expect(deleted[0].deletedByUsername).toBe(adminName);
@@ -193,7 +194,7 @@ describe("admin delete user", () => {
     expect(row?.deletedBy).toBeNull();
 
     expect((await usersRepo.listForAdmin()).some((u) => u.id === victimId)).toBe(true);
-    expect(await moderation.listDeletedUsers()).toHaveLength(0);
+    expect((await moderation.listDeletedUsers()).users).toHaveLength(0);
     expect(includesPost(await globalPosts(), victimPostId)).toBe(true);
   });
 
@@ -209,7 +210,7 @@ describe("admin delete user", () => {
 
     expect(await usersRepo.findById(victimId)).toBeUndefined();
     expect(await postsRepo.findById(victimPostId)).toBeNull();
-    expect(await moderation.listDeletedUsers()).toHaveLength(0);
+    expect((await moderation.listDeletedUsers()).users).toHaveLength(0);
   });
 
   test("expiry purge only takes accounts past the retention window", async () => {
@@ -225,5 +226,34 @@ describe("admin delete user", () => {
 
     // The sweeper service surfaces the same pass without throwing.
     await expect(sweepDeletedUsers()).resolves.toBe(0);
+  });
+});
+
+describe("deleted restore list pagination", () => {
+  beforeAll(async () => {
+    await resetDb();
+
+    const admin = await mkUser("root2", { isAdmin: true });
+    await mkCredential(admin.id, ADMIN_PASSWORD);
+    // Deleted one after another so deleted_at ties (same millisecond) also
+    // exercise the id tiebreak in the keyset.
+    for (const name of ["gone-a", "gone-b", "gone-c"]) {
+      const u = await mkUser(name);
+      await moderation.deleteUser(admin.id, u.id, { username: name, password: ADMIN_PASSWORD });
+    }
+  });
+
+  test("pages cover every deleted account without overlap", async () => {
+    const first = await moderation.listDeletedUsers(null, 2);
+    expect(first.users).toHaveLength(2);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await moderation.listDeletedUsers(decodeCursor(first.nextCursor), 2);
+    expect(second.users).toHaveLength(1);
+    expect(second.nextCursor).toBeNull();
+
+    const ids = [...first.users, ...second.users].map((r) => r.user.id);
+    expect(new Set(ids).size).toBe(3);
+    expect(await moderation.countDeletedUsers()).toBe(3);
   });
 });

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -135,14 +135,14 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     // admin moderation
     adminUsers: (
       q?: string,
-      filters?: { suspendedOnly?: boolean; adminsOnly?: boolean; unverifiedOnly?: boolean },
+      filters?: { suspended?: boolean; admin?: boolean; verified?: boolean },
       page?: { cursor?: string | null; limit?: number },
     ) => {
       const params = new URLSearchParams();
       if (q) params.set("q", q);
-      if (filters?.suspendedOnly) params.set("suspended", "true");
-      if (filters?.adminsOnly) params.set("admin", "true");
-      if (filters?.unverifiedOnly) params.set("verified", "false");
+      if (filters?.suspended !== undefined) params.set("suspended", String(filters.suspended));
+      if (filters?.admin !== undefined) params.set("admin", String(filters.admin));
+      if (filters?.verified !== undefined) params.set("verified", String(filters.verified));
       if (page?.cursor) params.set("cursor", page.cursor);
       if (page?.limit) params.set("limit", String(page.limit));
       const qs = params.toString();
@@ -182,8 +182,17 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     // with the request — the server re-verifies it.
     setUserRole: (id: string, body: { makeAdmin: boolean; password: string }) =>
       api.post<{ ok: true }>(`/admin/users/${id}/role`, body),
-    // Recently deleted accounts awaiting restore or expiry.
-    deletedUsers: () => api.get<{ users: DeletedUser[] }>("/admin/users/deleted"),
+    // Recently deleted accounts awaiting restore or expiry, newest deletion
+    // first. Keyset-paginated like the live table.
+    deletedUsers: (cursor?: string | null, limit?: number) => {
+      const params = new URLSearchParams();
+      if (cursor) params.set("cursor", cursor);
+      if (limit) params.set("limit", String(limit));
+      const qs = params.toString();
+      return api.get<{ users: DeletedUser[]; nextCursor: string | null; total: number }>(
+        `/admin/users/deleted${qs ? `?${qs}` : ""}`,
+      );
+    },
     // Permanently erase a deleted account before its window ends.
     purgeDeletedUser: (id: string) => api.del<{ ok: true }>(`/admin/users/deleted/${id}`),
     adminRemovePost: (id: string) => api.del<{ ok: true }>(`/admin/posts/${id}`),

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -12,7 +12,7 @@
   import { identifierToUrl, platformMeta, urlToIdentifier } from "$lib/profileLinks";
   import { MAX_PROFILE_TAGS } from "$lib/tags";
   import type { AdminUser, AdminUserDetail, DeletedUser, ProfileLink } from "$lib/types";
-  import { Dialog, DropdownMenu, Label } from "bits-ui";
+  import { Dialog, DropdownMenu, Label, ToggleGroup } from "bits-ui";
   import { onMount } from "svelte";
 
   // The signed-in admin's own id, so the row for self can hide every action
@@ -32,15 +32,33 @@
   // slow search can never overwrite a newer one.
   let loadSeq = 0;
 
-  // Triage filters: each shows only matching accounts while on.
-  let fSuspended = $state(false);
-  let fAdmins = $state(false);
-  let fUnverified = $state(false);
+  // Triage filters, tri-state: `undefined` shows all accounts, `true` only
+  // matching ones, `false` only the rest. The backend speaks the same shape.
+  type TriFilter = boolean | undefined;
+  let fSuspended = $state<TriFilter>(undefined);
+  let fAdmins = $state<TriFilter>(undefined);
+  let fVerified = $state<TriFilter>(undefined);
 
-  // Recently deleted accounts: the retention window's restore list.
+  function triValue(v: TriFilter): string {
+    return v === undefined ? "all" : v ? "yes" : "no";
+  }
+
+  function onTriChange(set: (v: TriFilter) => void, raw: string) {
+    // Single-select deselects to "" when the active option is clicked — that
+    // also means "all".
+    set(raw === "all" || raw === "" ? undefined : raw === "yes");
+    load(true);
+  }
+
+  // Recently deleted accounts: the retention window's restore list, newest
+  // deletion first, cursor-paginated like the live table.
   let deleted = $state<DeletedUser[]>([]);
+  let deletedTotal = $state(0);
+  let deletedNextCursor = $state<string | null>(null);
   let deletedLoading = $state(true);
+  let deletedLoadingMore = $state(false);
   let deletedError = $state("");
+  let deletedSeq = 0;
 
   // GitHub-style delete confirmation: type the account's username and re-enter
   // the admin's own password. Both travel with the request; the server
@@ -56,11 +74,7 @@
   // dropped via `loadSeq`, and the detail cache is kept — mutations update it
   // in place, so an expansion survives a reload.
   function filterParams() {
-    return {
-      suspendedOnly: fSuspended || undefined,
-      adminsOnly: fAdmins || undefined,
-      unverifiedOnly: fUnverified || undefined,
-    };
+    return { suspended: fSuspended, admin: fAdmins, verified: fVerified };
   }
 
   async function load(reset = true) {
@@ -95,15 +109,31 @@
     }
   }
 
-  async function loadDeleted() {
-    deletedLoading = true;
-    deletedError = "";
+  async function loadDeleted(reset = true) {
+    const my = ++deletedSeq;
+    if (reset) {
+      deletedLoading = true;
+      deletedNextCursor = null;
+      deletedError = "";
+    } else {
+      if (!deletedNextCursor || deletedLoadingMore) return;
+      deletedLoadingMore = true;
+    }
     try {
-      deleted = (await endpoints().deletedUsers()).users;
+      const res = await endpoints().deletedUsers(reset ? null : deletedNextCursor);
+      if (my !== deletedSeq) return;
+      deleted = reset ? res.users : [...deleted, ...res.users.filter((d) => !deleted.some((x) => x.id === d.id))];
+      deletedTotal = res.total;
+      deletedNextCursor = res.nextCursor;
     } catch (e) {
+      if (my !== deletedSeq) return;
+      if (reset) deleted = [];
       deletedError = e instanceof ApiError ? e.message : "Failed to load deleted accounts.";
     } finally {
-      deletedLoading = false;
+      if (my === deletedSeq) {
+        deletedLoading = false;
+        deletedLoadingMore = false;
+      }
     }
   }
 
@@ -132,9 +162,9 @@
     busyId = u.id;
     try {
       await endpoints().suspendUser(u.id, suspend);
-      // A reinstated account no longer matches the Suspended-only filter, so it
-      // leaves the listing; otherwise update the row in place.
-      if (fSuspended && !suspend) {
+      // The account leaves the listing when it no longer matches an active
+      // Suspended filter (reinstated under "Yes", suspended under "No").
+      if ((fSuspended === true && !suspend) || (fSuspended === false && suspend)) {
         users = users.filter((x) => x.id !== u.id);
         filteredTotal = Math.max(0, filteredTotal - 1);
         if (expandedId === u.id) expandedId = null;
@@ -217,8 +247,9 @@
     try {
       await endpoints().setUserRole(roleTarget.id, { makeAdmin, password: rolePassword });
       const id = roleTarget.id;
-      // A demoted account no longer matches the Admins-only filter.
-      if (fAdmins && !makeAdmin) {
+      // The account leaves the listing when it no longer matches an active
+      // Admin filter (demoted under "Yes", promoted under "No").
+      if ((fAdmins === true && !makeAdmin) || (fAdmins === false && makeAdmin)) {
         users = users.filter((x) => x.id !== id);
         filteredTotal = Math.max(0, filteredTotal - 1);
         if (expandedId === id) expandedId = null;
@@ -290,8 +321,8 @@
     detailNotice = "";
     try {
       await endpoints().verifyEmail(u.id);
-      // A verified account no longer matches the Unverified-only filter.
-      if (fUnverified) {
+      // A verified account no longer matches the Verified "No" filter.
+      if (fVerified === false) {
         users = users.filter((x) => x.id !== u.id);
         filteredTotal = Math.max(0, filteredTotal - 1);
         if (expandedId === u.id) expandedId = null;
@@ -478,6 +509,7 @@
     try {
       await endpoints().restoreUser(d.id);
       deleted = deleted.filter((x) => x.id !== d.id);
+      deletedTotal = Math.max(0, deletedTotal - 1);
       await load();
     } catch (e) {
       error = e instanceof ApiError ? e.message : "Restore failed.";
@@ -499,6 +531,7 @@
     try {
       await endpoints().purgeDeletedUser(d.id);
       deleted = deleted.filter((x) => x.id !== d.id);
+      deletedTotal = Math.max(0, deletedTotal - 1);
     } catch (e) {
       deletedError = e instanceof ApiError ? e.message : "Erase failed.";
     } finally {
@@ -518,7 +551,24 @@
     "flex h-10 cursor-pointer items-center gap-2 rounded-button px-3 text-sm font-medium text-foreground select-none data-highlighted:bg-muted focus-visible:outline-hidden";
   const destructiveItemClass = menuItemClass.replace("text-foreground", "text-destructive");
 
-  const isFiltering = $derived(query.trim() !== "" || fSuspended || fAdmins || fUnverified);
+  const isFiltering = $derived(
+    query.trim() !== "" || fSuspended !== undefined || fAdmins !== undefined || fVerified !== undefined,
+  );
+
+  // Tri-state filter segments (All / Yes / No), rendered from one config so
+  // the three dimensions stay visually identical.
+  const triOptions = [
+    { value: "all", label: "All" },
+    { value: "yes", label: "Yes" },
+    { value: "no", label: "No" },
+  ];
+  const triFilters = $derived([
+    { label: "Suspended", value: triValue(fSuspended), set: (v: TriFilter) => (fSuspended = v) },
+    { label: "Admin", value: triValue(fAdmins), set: (v: TriFilter) => (fAdmins = v) },
+    { label: "Verified", value: triValue(fVerified), set: (v: TriFilter) => (fVerified = v) },
+  ]);
+  const segItemClass =
+    "h-7 rounded-button px-2.5 text-xs font-medium text-muted-foreground data-[state=on]:bg-background data-[state=on]:text-foreground data-[state=on]:shadow-mini focus-visible:outline-hidden";
 </script>
 
 <div class="flex flex-col gap-4">
@@ -553,40 +603,24 @@
     />
   </div>
 
-  <div class="flex flex-wrap gap-2" role="group" aria-label="Filter accounts">
-    <Button
-      variant={fSuspended ? "solid" : "outline"}
-      size="sm"
-      aria-pressed={fSuspended}
-      onclick={() => {
-        fSuspended = !fSuspended;
-        load();
-      }}
-    >
-      Suspended
-    </Button>
-    <Button
-      variant={fAdmins ? "solid" : "outline"}
-      size="sm"
-      aria-pressed={fAdmins}
-      onclick={() => {
-        fAdmins = !fAdmins;
-        load();
-      }}
-    >
-      Admins
-    </Button>
-    <Button
-      variant={fUnverified ? "solid" : "outline"}
-      size="sm"
-      aria-pressed={fUnverified}
-      onclick={() => {
-        fUnverified = !fUnverified;
-        load();
-      }}
-    >
-      Unverified
-    </Button>
+  <div class="flex flex-wrap gap-x-5 gap-y-3" role="group" aria-label="Filter accounts">
+    {#each triFilters as f (f.label)}
+      <div class="flex items-center gap-2">
+        <span class="text-xs font-medium text-muted-foreground">{f.label}</span>
+        <ToggleGroup.Root
+          type="single"
+          value={f.value}
+          onValueChange={(v) => onTriChange(f.set, v)}
+          class="inline-flex items-center gap-0.5 rounded-input border border-input bg-background-alt p-0.5 shadow-btn"
+        >
+          {#each triOptions as o (o.value)}
+            <ToggleGroup.Item value={o.value} aria-label={`${f.label}: ${o.label}`} class={segItemClass}>
+              {o.label}
+            </ToggleGroup.Item>
+          {/each}
+        </ToggleGroup.Root>
+      </div>
+    {/each}
   </div>
 
   {#if error}<p class="text-sm text-destructive">{error}</p>{/if}
@@ -790,7 +824,9 @@
         <span>Loading recently deleted…</span>
       {:else}
         <span>
-          Recently deleted{deleted.length > 0 ? ` (${deleted.length})` : ""} — restorable until the retention window ends
+          Recently deleted ({deletedTotal}) — restorable until the retention window ends{deletedNextCursor
+            ? ` · showing ${deleted.length}`
+            : ""}
         </span>
       {/if}
     </div>
@@ -838,6 +874,13 @@
             </li>
           {/each}
         </ul>
+        {#if deletedNextCursor}
+          <div class="mt-4 flex justify-center">
+            <Button variant="outline" size="sm" disabled={deletedLoadingMore} onclick={() => loadDeleted(false)}>
+              {deletedLoadingMore ? "Loading…" : `Load more (${deleted.length} of ${deletedTotal})`}
+            </Button>
+          </div>
+        {/if}
       {/if}
     {/if}
   </div>


### PR DESCRIPTION
## Symptom

The Users filter pills could only narrow to matching accounts (suspended-only, admins-only, unverified-only) — never to the complement — even though the backend filter dimensions are tri-state. The Recently-deleted restore list still had the silent 100-row cap the live table just lost.

## Root cause

- The frontend only ever sent `suspended=true` / `admin=true` / `verified=false`; `false` was unreachable (`AdminUsers.svelte` bool flags + `|| undefined` mapping).
- `listDeleted` used a fixed `LIMIT 100` with no cursor (`db/repositories/users.ts`).

## Fix

- Tri-state filters: Suspended / Admin / Verified each get an All/Yes/No segmented control (bits-ui `ToggleGroup` single-select); the API client forwards all three states; row actions leave the listing whenever they stop matching either direction.
- `GET /admin/users/deleted` is keyset-paginated over `(deleted_at, id)`: `?cursor=&limit=` (1–100, default 50), response gains `nextCursor` + `total`. The cursor is opaque (deletion timestamp in the timestamp slot).
- Restore list pages in the UI with the same Load-more + request-guard pattern as the live table; restore/purge/delete keep its count consistent locally.

## Verified

- `deno check` on touched backend files; `svelte-check` 0 errors; `vitest run src/` 307 passed; `oxlint` + `oxfmt` clean in both apps.
- New pagination test in `admin_delete_user_test.ts` (3 deleted accounts, limit 2: full coverage, no overlap, count matches).
- NOT run: `test:integration` (needs Postgres; `DATABASE_URL` unset here) — please let CI cover it.

## Deploy notes

Plain redeploy; no migrations, no config changes. Additive API changes only (`GET /admin/users/deleted` gains optional params and fields; `GET /admin/users` filter params unchanged in meaning).