### PR TITLE
feat(admin): moderate avatars and scope detail messages per row

### DIFF
--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -429,6 +429,24 @@ adminRoutes.patch("/users/:id", jsonBody(adminUpdateUserSchema), async (c) => {
   return c.json({ user: adminUserView(user) });
 });
 
+// Replace another account's avatar (raw image body; content-type identifies
+// the format). Same validation, quota and federation as the account's own
+// upload — the moderator override for an abusive photo.
+adminRoutes.post("/users/:id/avatar", async (c) => {
+  requireAdmin(c);
+  const contentType = (c.req.header("content-type") ?? "").split(";")[0].trim();
+  const bytes = new Uint8Array(await c.req.arrayBuffer());
+  const user = await moderation.setUserAvatar(c.req.param("id"), bytes, contentType);
+  return c.json({ user: adminUserView(user) });
+});
+
+// Clear another account's avatar so the profile falls back to initials.
+adminRoutes.delete("/users/:id/avatar", async (c) => {
+  requireAdmin(c);
+  const user = await moderation.removeUserAvatar(c.req.param("id"));
+  return c.json({ user: adminUserView(user) });
+});
+
 // Resend the verification email to an unverified account.
 adminRoutes.post("/users/:id/verification-email", async (c) => {
   requireAdmin(c);

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -360,6 +360,23 @@ export async function resendVerification(targetId: string): Promise<void> {
 
 // ── User details (admin edit) ────────────────────────────────────────────
 
+// Replaces another account's avatar. Reuses the account's own upload path
+// (services/users.ts) so type/size validation, quota and federation stay in
+// one place — the typical use is clearing an abusive photo, with an optional
+// neutral replacement.
+export async function setUserAvatar(targetId: string, bytes: Uint8Array, contentType: string) {
+  const target = await usersRepo.findById(targetId);
+  if (!target || target.deletedAt) throw notFound("Account not found.");
+  return usersService.setAvatar(targetId, bytes, contentType);
+}
+
+// Clears another account's avatar so the profile falls back to initials.
+export async function removeUserAvatar(targetId: string) {
+  const target = await usersRepo.findById(targetId);
+  if (!target || target.deletedAt) throw notFound("Account not found.");
+  return usersService.removeAvatar(targetId);
+}
+
 export type AdminUpdateUserInput = {
   displayName?: string;
   bio?: string;

--- a/apps/backend/tests/integration/admin_edit_user_test.ts
+++ b/apps/backend/tests/integration/admin_edit_user_test.ts
@@ -52,6 +52,14 @@ async function captureRejection(promise: Promise<unknown>): Promise<unknown> {
   return new Error("expected rejection, but the call succeeded");
 }
 
+// Leading bytes of a real PNG signature, zero-padded — enough to pass the
+// magic-byte check, mirroring uploads_test.ts.
+function pngBytes(size: number): Uint8Array {
+  const bytes = new Uint8Array(size);
+  bytes.set([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  return bytes;
+}
+
 async function credentialAccountId(userId: string): Promise<string | null> {
   const rows = await db.select().from(accounts).where(eq(accounts.userId, userId));
   return rows.find((r) => r.providerId === "credential")?.accountId ?? null;
@@ -185,5 +193,46 @@ describe("admin edit user", () => {
     expect(mail.text).toContain("@member");
     expect(mail.text).toContain("new@example.test");
     expect(mail.html).toContain("new@example.test");
+  });
+
+  test("avatar replace stores the photo and federates", async () => {
+    const user = await moderation.setUserAvatar(memberId, pngBytes(64), "image/png");
+    await flush();
+
+    expect(user.avatarUrl).toMatch(/^\/api\/uploads\/.+\.png$/);
+    expect((await usersRepo.findById(memberId))?.avatarUrl).toBe(user.avatarUrl);
+    expect(actorUpdates.some((u) => u.userId === memberId)).toBe(true);
+  });
+
+  test("avatar remove clears back to initials", async () => {
+    await moderation.setUserAvatar(memberId, pngBytes(64), "image/png");
+    const user = await moderation.removeUserAvatar(memberId);
+
+    expect(user.avatarUrl).toBeNull();
+    expect((await usersRepo.findById(memberId))?.avatarUrl).toBeNull();
+  });
+
+  test("avatar rejects wrong types and mismatched bytes", async () => {
+    const before = (await usersRepo.findById(memberId))?.avatarUrl;
+    const typeErr = await captureRejection(moderation.setUserAvatar(memberId, pngBytes(64), "image/bmp"));
+    expect(typeErr).toBeInstanceOf(HttpError);
+    expect((typeErr as HttpError).status).toBe(400);
+
+    const sniffErr = await captureRejection(
+      moderation.setUserAvatar(memberId, new TextEncoder().encode("not an image"), "image/png"),
+    );
+    expect(sniffErr).toBeInstanceOf(HttpError);
+    expect((sniffErr as HttpError).status).toBe(400);
+
+    expect((await usersRepo.findById(memberId))?.avatarUrl).toBe(before);
+  });
+
+  test("avatar on a deleted account 404s", async () => {
+    const goneId = (await mkUser("gone-avatar")).id;
+    await usersRepo.setDeleted(goneId, new Date(), memberId);
+    const setErr = await captureRejection(moderation.setUserAvatar(goneId, pngBytes(64), "image/png"));
+    expect((setErr as HttpError).status).toBe(404);
+    const removeErr = await captureRejection(moderation.removeUserAvatar(goneId));
+    expect((removeErr as HttpError).status).toBe(404);
   });
 });

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -175,6 +175,11 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
         email?: string;
       },
     ) => api.patch<{ user: AdminUser }>(`/admin/users/${id}`, body),
+    // Replace another account's avatar (moderator override for an abusive
+    // photo), or clear it back to initials.
+    uploadUserAvatarAsAdmin: (id: string, blob: Blob, contentType: string) =>
+      api.postRaw<{ user: AdminUser }>(`/admin/users/${id}/avatar`, blob, contentType),
+    removeUserAvatarAsAdmin: (id: string) => api.del<{ user: AdminUser }>(`/admin/users/${id}/avatar`),
     // Resend the verification email, or manually mark the address verified.
     resendVerification: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/verification-email`, {}),
     verifyEmail: (id: string) => api.post<{ ok: true }>(`/admin/users/${id}/verify`, {}),

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -9,6 +9,7 @@
   import Avatar from "$lib/components/ui/Avatar.svelte";
   import Button from "$lib/components/ui/Button.svelte";
   import { confirm } from "$lib/components/ui/confirm";
+  import { AVATAR_MAX_DIMENSION, prepareImage } from "$lib/editor/image";
   import { identifierToUrl, platformMeta, urlToIdentifier } from "$lib/profileLinks";
   import { MAX_PROFILE_TAGS } from "$lib/tags";
   import type { AdminUser, AdminUserDetail, DeletedUser, ProfileLink } from "$lib/types";
@@ -95,7 +96,12 @@
       total = res.total;
       filteredTotal = res.filteredTotal;
       nextCursor = res.nextCursor;
-      detailNotice = "";
+      // A fresh table resets per-row detail messages; appending more rows
+      // leaves whatever the admin is reading alone.
+      if (reset) {
+        detailNotices = {};
+        detailErrors = {};
+      }
     } catch (e) {
       if (my !== loadSeq) return;
       if (reset) users = [];
@@ -270,20 +276,45 @@
   let details = $state<Record<string, AdminUserDetail>>({});
   let detailLoadingId = $state<string | null>(null);
 
+  // Per-row detail messages, keyed by account id: expanding another row or
+  // paging the table must never steal or wipe what the admin is reading.
+  let detailNotices = $state<Record<string, string>>({});
+  let detailErrors = $state<Record<string, string>>({});
+
+  function clearDetailMsg(id: string) {
+    if (detailNotices[id] !== undefined) {
+      const { [id]: _, ...rest } = detailNotices;
+      detailNotices = rest;
+    }
+    if (detailErrors[id] !== undefined) {
+      const { [id]: _, ...rest } = detailErrors;
+      detailErrors = rest;
+    }
+  }
+
+  function setDetailNotice(id: string, msg: string) {
+    detailNotices = { ...detailNotices, [id]: msg };
+  }
+
+  function setDetailError(id: string, msg: string) {
+    detailErrors = { ...detailErrors, [id]: msg };
+  }
+
   async function toggleDetail(u: AdminUser) {
     if (expandedId === u.id) {
       expandedId = null;
       return;
     }
     expandedId = u.id;
-    detailNotice = "";
+    clearDetailMsg(u.id);
     if (details[u.id] || detailLoadingId === u.id) return;
     detailLoadingId = u.id;
     try {
       details[u.id] = await endpoints().adminUserDetail(u.id);
     } catch (e) {
-      error = e instanceof ApiError ? e.message : "Failed to load account detail.";
-      expandedId = null;
+      // Inline, panel stays open: collapsing would hide the failure and the
+      // row's toggle retries (nothing is cached).
+      setDetailError(u.id, e instanceof ApiError ? e.message : "Failed to load account detail.");
     } finally {
       detailLoadingId = null;
     }
@@ -293,16 +324,15 @@
   // act on. Resending just sends mail; marking verified overrides a security
   // gate, so it gets a confirmation dialog.
   let verifyBusyId = $state<string | null>(null);
-  let detailNotice = $state("");
 
   async function resendVerification(u: AdminUser) {
     verifyBusyId = u.id;
-    detailNotice = "";
+    clearDetailMsg(u.id);
     try {
       await endpoints().resendVerification(u.id);
-      detailNotice = "Verification email sent.";
+      setDetailNotice(u.id, "Verification email sent.");
     } catch (e) {
-      detailNotice = e instanceof ApiError ? e.message : "Sending failed.";
+      setDetailError(u.id, e instanceof ApiError ? e.message : "Sending failed.");
     } finally {
       verifyBusyId = null;
     }
@@ -317,7 +347,7 @@
     });
     if (!ok) return;
     verifyBusyId = u.id;
-    detailNotice = "";
+    clearDetailMsg(u.id);
     try {
       await endpoints().verifyEmail(u.id);
       // A verified account no longer matches the Verified "No" filter.
@@ -325,14 +355,13 @@
         users = users.filter((x) => x.id !== u.id);
         filteredTotal = Math.max(0, filteredTotal - 1);
         if (expandedId === u.id) expandedId = null;
-        detailNotice = "";
       } else {
         users = users.map((x) => (x.id === u.id ? { ...x, emailVerified: true } : x));
         if (details[u.id]) details[u.id] = { ...details[u.id], user: { ...details[u.id].user, emailVerified: true } };
-        detailNotice = "Email marked verified.";
+        setDetailNotice(u.id, "Email marked verified.");
       }
     } catch (e) {
-      detailNotice = e instanceof ApiError ? e.message : "Action failed.";
+      setDetailError(u.id, e instanceof ApiError ? e.message : "Action failed.");
     } finally {
       verifyBusyId = null;
     }
@@ -351,7 +380,7 @@
     });
     if (!ok) return;
     resolveBusyId = reportId;
-    detailNotice = "";
+    clearDetailMsg(u.id);
     try {
       await endpoints().resolveReport(reportId);
       if (details[u.id]) {
@@ -362,9 +391,9 @@
           ),
         };
       }
-      detailNotice = "Report resolved.";
+      setDetailNotice(u.id, "Report resolved.");
     } catch (e) {
-      detailNotice = e instanceof ApiError ? e.message : "Resolve failed.";
+      setDetailError(u.id, e instanceof ApiError ? e.message : "Resolve failed.");
     } finally {
       resolveBusyId = null;
     }
@@ -387,6 +416,81 @@
   let editError = $state("");
   let editBusy = $state(false);
 
+  // Avatar moderation: the dialog's photo section applies immediately (upload
+  // or clear), like Settings — it is not part of the dirty-tracked Save.
+  let editAvatarUrl = $state<string | null>(null);
+  let editAvatarBusy = $state(false);
+  let avatarInput = $state<HTMLInputElement | null>(null);
+  // Backend caps (services/users.ts) and the raw-pick sanity cap, mirroring
+  // the Settings form — the two apps don't share a constants module.
+  const AVATAR_MAX_BYTES = 2 * 1024 * 1024;
+  const AVATAR_RAW_MAX_BYTES = 25 * 1024 * 1024;
+
+  function applyAvatarToRow(user: AdminUser) {
+    users = users.map((x) => (x.id === user.id ? { ...x, ...user } : x));
+    if (details[user.id]) details[user.id] = { ...details[user.id], user: { ...details[user.id].user, ...user } };
+    editAvatarUrl = user.avatarUrl;
+  }
+
+  async function onAvatarPick(e: Event) {
+    const input = e.target as HTMLInputElement;
+    const picked = input.files?.[0] ?? null;
+    // Reset so re-picking the same file fires change again.
+    input.value = "";
+    if (!picked || !editTarget) return;
+    if (!picked.type.startsWith("image/")) {
+      editError = "Please choose an image file.";
+      return;
+    }
+    if (picked.size > AVATAR_RAW_MAX_BYTES) {
+      editError = "Image too large. Please choose a file under 25 MB.";
+      return;
+    }
+    const target = editTarget;
+    editAvatarBusy = true;
+    editError = "";
+    try {
+      // Downscale before upload so moderator replacements aren't shipped at
+      // full photo resolution (GIFs pass through untouched).
+      const { blob, type } = await prepareImage(picked, AVATAR_MAX_DIMENSION, AVATAR_MAX_BYTES);
+      if (blob.size > AVATAR_MAX_BYTES) {
+        editError =
+          type === "image/gif"
+            ? "That GIF is too large (max 2 MB). Try a smaller GIF, or use PNG/JPEG/WebP."
+            : "Image too large (max 2 MB) even after compression. Please choose a different photo.";
+        return;
+      }
+      const { user } = await endpoints().uploadUserAvatarAsAdmin(target.id, blob, type);
+      applyAvatarToRow(user);
+    } catch (err) {
+      editError = err instanceof ApiError ? err.message : "Photo upload failed.";
+    } finally {
+      editAvatarBusy = false;
+    }
+  }
+
+  async function removeEditAvatar() {
+    if (!editTarget || !editAvatarUrl) return;
+    const target = editTarget;
+    const ok = await confirm({
+      title: `Remove @${target.username}'s photo?`,
+      description: "Their profile reverts to initials. They can upload a new photo themselves at any time.",
+      confirmText: "Remove photo",
+      destructive: true,
+    });
+    if (!ok) return;
+    editAvatarBusy = true;
+    editError = "";
+    try {
+      const { user } = await endpoints().removeUserAvatarAsAdmin(target.id);
+      applyAvatarToRow(user);
+    } catch (err) {
+      editError = err instanceof ApiError ? err.message : "Photo removal failed.";
+    } finally {
+      editAvatarBusy = false;
+    }
+  }
+
   async function openEdit(u: AdminUser) {
     editTarget = u;
     editError = "";
@@ -403,6 +507,7 @@
     }
     const d = details[u.id];
     const row = d?.user ?? u;
+    editAvatarUrl = row.avatarUrl ?? null;
     editDisplayName = row.displayName;
     editBio = row.bio ?? "";
     editEmail = row.email;
@@ -523,9 +628,12 @@
         };
       }
       editTarget = null;
-      detailNotice = emailChanged
-        ? "Saved. Login email updated — a verification link was sent to the new address and the previous address was notified."
-        : "Saved.";
+      setDetailNotice(
+        target.id,
+        emailChanged
+          ? "Saved. Login email updated — a verification link was sent to the new address and the previous address was notified."
+          : "Saved.",
+      );
       if (expandedId !== target.id) expandedId = target.id;
     } catch (e) {
       editError = e instanceof ApiError ? e.message : "Save failed.";
@@ -781,6 +889,8 @@
             <div class="mt-3 ml-10 rounded-card border border-border bg-background-alt p-4">
               {#if detailLoadingId === u.id}
                 <p class="text-sm text-muted-foreground">Loading detail…</p>
+              {:else if detailErrors[u.id] && !details[u.id]}
+                <p class="text-sm text-destructive">{detailErrors[u.id]}</p>
               {:else if details[u.id]}
                 {@const d = details[u.id]}
                 <div class="flex flex-wrap gap-x-5 gap-y-1 text-sm text-muted-foreground">
@@ -814,7 +924,8 @@
                     {/if}
                   </span>
                 </div>
-                {#if detailNotice}<p class="mt-1 text-xs text-muted-foreground">{detailNotice}</p>{/if}
+                {#if detailNotices[u.id]}<p class="mt-1 text-xs text-muted-foreground">{detailNotices[u.id]}</p>{/if}
+                {#if detailErrors[u.id]}<p class="mt-1 text-xs text-destructive">{detailErrors[u.id]}</p>{/if}
                 <h4 class="mt-4 text-sm font-semibold text-foreground">Latest posts</h4>
                 {#if d.recentPosts.length === 0}
                   <p class="mt-1 text-sm text-muted-foreground">No posts yet.</p>
@@ -1083,6 +1194,39 @@
       </Dialog.Description>
 
       <div class="mt-5 flex flex-col gap-4">
+        <div class="flex items-center gap-4">
+          <Avatar name={editTarget?.displayName ?? ""} src={editAvatarUrl ?? undefined} size={56} />
+          <div class="flex flex-col gap-1.5">
+            <div class="flex flex-wrap gap-2">
+              <Button variant="outline" size="sm" disabled={editAvatarBusy} onclick={() => avatarInput?.click()}>
+                <Icon name="camera" size={15} /> Change photo
+              </Button>
+              {#if editAvatarUrl}
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  disabled={editAvatarBusy}
+                  onclick={removeEditAvatar}
+                  class="text-muted-foreground hover:text-destructive"
+                >
+                  <Icon name="trash" size={15} />
+                  {editAvatarBusy ? "Removing…" : "Remove"}
+                </Button>
+              {/if}
+            </div>
+            <p class="text-xs text-muted-foreground">
+              Applies immediately — not part of Save. PNG, JPEG, WebP or GIF · large photos are resized automatically
+            </p>
+          </div>
+          <input
+            bind:this={avatarInput}
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/gif"
+            class="hidden"
+            onchange={onAvatarPick}
+            aria-label="Upload a new profile photo"
+          />
+        </div>
         <div class="flex flex-col gap-1.5">
           <Label.Root for="edit-displayName" class={labelClass}>Display name</Label.Root>
           <input id="edit-displayName" bind:value={editDisplayName} maxlength={60} class={field} />


### PR DESCRIPTION
## Symptom

Two gaps in Admin → Users. First, admins could edit every profile field except the photo — an abusive avatar had no recourse short of suspending the account. Second, one row's detail failure or action notice surfaced globally: a failed detail load raised the table banner and collapsed the panel, and any notice was wiped by paging or expanding another row.

## Fix

- `POST /admin/users/:id/avatar` (raw image body) and `DELETE /admin/users/:id/avatar`, both delegating to the account's own `setAvatar`/`removeAvatar` in `services/users.ts` so type/size validation, quota, and actor-update federation stay in one place. 404 on missing/deleted accounts.
- Edit dialog gains a photo section mirroring Settings (preview, Change/Remove, client downscale via `prepareImage`, same 2 MB / 25 MB caps). Applies immediately, not part of Save; table row and detail cache update in place.
- Detail notices/errors keyed by account id. A failed detail load renders inline with the panel left open (re-expanding retries, nothing cached); table reloads only clear messages on reset, not on Load more.

## Verified

- `deno check` on touched backend files; `svelte-check` 0 errors; `vitest run src/` 307 passed; `oxlint` + `oxfmt` clean in both apps.
- New tests in `admin_edit_user_test.ts`: replace stores + federates, remove clears, wrong type / mismatched bytes rejected without changes, deleted account 404s.
- NOT run: `test:integration` (needs Postgres; `DATABASE_URL` unset here) — please let CI cover it.

## Deploy notes

Plain redeploy; no migrations, no config changes. Two new admin API routes.