### PR TITLE
Remove emoji-picker-element-data dependency

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -45,7 +45,6 @@
     "@testing-library/jest-dom": "7.0.1",
     "@testing-library/svelte": "5.4.2",
     "@types/node": "^26.4.1",
-    "emoji-picker-element-data": "1.8.0",
     "greenly": "1.1.6",
     "jsdom": "30.0.1",
     "oxfmt": "0.66.0",

--- a/apps/frontend/pnpm-lock.yaml
+++ b/apps/frontend/pnpm-lock.yaml
@@ -87,9 +87,6 @@ importers:
       '@types/node':
         specifier: ^26.4.1
         version: 26.4.1
-      emoji-picker-element-data:
-        specifier: 1.8.0
-        version: 1.8.0
       greenly:
         specifier: 1.1.6
         version: 1.1.6
@@ -1453,9 +1450,6 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
-
-  emoji-picker-element-data@1.8.0:
-    resolution: {integrity: sha512-VfRuRJNEDLS1JKlNS4olaqhjX5S1nnZ+ZHG73b/dV8QeZyi0yPruTPEE72EmF6XO3k/9hj3lybMIYMOYXb/57A==}
 
   emoji-picker-element@1.29.1:
     resolution: {integrity: sha512-TOiHzu9Dqib3x4MwcAi3wi3RdyT4SoeB4b15AvH1ks4SBwTl7DeebhZ0d3x6dNi4XfNU7IGRZ7NBQllj0RqwrQ==}
@@ -3194,8 +3188,6 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
-
-  emoji-picker-element-data@1.8.0: {}
 
   emoji-picker-element@1.29.1: {}
 


### PR DESCRIPTION
## Summary of Changes
Eliminate the dependency on `emoji-picker-element-data` to streamline the project and reduce unnecessary package usage.

## Fixed Issues

Closes #

## Checks

- [x] Backend checks / tests pass
- [x] Frontend builds and the affected UI was exercised

