### PR TITLE
feat(admin): search deleted accounts, clearable searches, live countdown

### DIFF
--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -217,25 +217,37 @@ function deletedBeforeCursor(cursor: Cursor | null) {
   return or(lt(users.deletedAt, ts), and(eq(users.deletedAt, ts), lt(users.id, cursor.id)));
 }
 
-export function listDeleted(cursor: Cursor | null = null, limit = DELETED_USERS_PAGE_SIZE) {
+// Shared match for the restore list: handle / name / email substring, same
+// escaping as the live table.
+function deletedConditions(query = ""): (SQL | undefined)[] {
+  const conditions: (SQL | undefined)[] = [sql`${users.deletedAt} is not null`];
+  if (query.trim()) {
+    const term = `%${query.replace(/[%_\\]/g, "\\$&")}%`;
+    conditions.push(or(ilike(users.username, term), ilike(users.displayName, term), ilike(users.email, term)));
+  }
+  return conditions;
+}
+
+export function listDeleted(query = "", cursor: Cursor | null = null, limit = DELETED_USERS_PAGE_SIZE) {
   const capped = Math.min(Math.max(Math.trunc(limit) || DELETED_USERS_PAGE_SIZE, 1), DELETED_USERS_MAX_PAGE_SIZE);
   const deleter = alias(users, "deleter");
   return db
     .select({ user: users, deletedByUsername: deleter.username })
     .from(users)
     .leftJoin(deleter, eq(users.deletedBy, deleter.id))
-    .where(and(sql`${users.deletedAt} is not null`, deletedBeforeCursor(cursor)))
+    .where(and(...deletedConditions(query), deletedBeforeCursor(cursor)))
     .orderBy(desc(users.deletedAt), desc(users.id))
     .limit(capped + 1);
 }
 
 // How many deleted accounts are awaiting restore or expiry — the restore
-// list's header count.
-export async function countDeleted(): Promise<number> {
+// list's header count. Takes the same search filter, so the header can show
+// "N of M" while searching.
+export async function countDeleted(query = ""): Promise<number> {
   const [row] = await db
     .select({ n: sql<number>`count(*)::int` })
     .from(users)
-    .where(sql`${users.deletedAt} is not null`);
+    .where(and(...deletedConditions(query)));
   return row?.n ?? 0;
 }
 

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -356,18 +356,22 @@ adminRoutes.post("/users/:id/restore", async (c) => {
 });
 
 // Recently deleted accounts awaiting restore or expiry, newest deletion
-// first. Keyset-paginated like the live table: `?cursor=` continues from the
-// previous page's `nextCursor`, `?limit=` sizes the page (1–100, default 50).
+// first. Optional handle / name / email filter (?q=), keyset-paginated like
+// the live table: `?cursor=` continues from the previous page's `nextCursor`,
+// `?limit=` sizes the page (1–100, default 50). `total` counts every deleted
+// account; `filteredTotal` matches the current search.
 adminRoutes.get("/users/deleted", async (c) => {
   requireAdmin(c);
+  const q = c.req.query("q") ?? "";
   const cursor = decodeCursor(c.req.query("cursor"));
   const limitRaw = Number.parseInt(c.req.query("limit") ?? "", 10);
   const limit = Number.isFinite(limitRaw) ? limitRaw : DELETED_USERS_PAGE_SIZE;
-  const [{ users, nextCursor }, total] = await Promise.all([
-    moderation.listDeletedUsers(cursor, limit),
+  const [{ users, nextCursor }, total, filteredTotal] = await Promise.all([
+    moderation.listDeletedUsers(cursor, limit, q),
     moderation.countDeletedUsers(),
+    moderation.countDeletedUsers(q),
   ]);
-  return c.json({ users: users.map(deletedUserView), nextCursor, total });
+  return c.json({ users: users.map(deletedUserView), nextCursor, total, filteredTotal });
 });
 
 // Permanently erase a deleted account before its window ends (frees the handle

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -277,12 +277,13 @@ export type DeletedUserRow = {
 export async function listDeletedUsers(
   cursor: Cursor | null = null,
   limit = usersRepo.DELETED_USERS_PAGE_SIZE,
+  query = "",
 ): Promise<{ users: DeletedUserRow[]; nextCursor: string | null }> {
   const capped = Math.min(
     Math.max(Math.trunc(limit) || usersRepo.DELETED_USERS_PAGE_SIZE, 1),
     usersRepo.DELETED_USERS_MAX_PAGE_SIZE,
   );
-  const rows = await usersRepo.listDeleted(cursor, capped);
+  const rows = await usersRepo.listDeleted(query, cursor, capped);
   const hasMore = rows.length > capped;
   const page = hasMore ? rows.slice(0, capped) : rows;
   const counts = await postsRepo.countLocalByAuthors(page.map((r) => r.user.id));
@@ -305,9 +306,10 @@ export async function listDeletedUsers(
 }
 
 // How many deleted accounts await restore or expiry — the restore list's
-// header count.
-export function countDeletedUsers(): Promise<number> {
-  return usersRepo.countDeleted();
+// header count. Takes the same search filter so the header can show "N of
+// M" while searching.
+export function countDeletedUsers(query = ""): Promise<number> {
+  return usersRepo.countDeleted(query);
 }
 
 // Permanently erases a deleted account before its window ends. The Delete was

--- a/apps/backend/tests/integration/admin_delete_user_test.ts
+++ b/apps/backend/tests/integration/admin_delete_user_test.ts
@@ -256,4 +256,11 @@ describe("deleted restore list pagination", () => {
     expect(new Set(ids).size).toBe(3);
     expect(await moderation.countDeletedUsers()).toBe(3);
   });
+
+  test("search matches handle, name, and login email", async () => {
+    const { users } = await moderation.listDeletedUsers(null, 50, "gone-b");
+    expect(users.map((r) => r.user.username)).toEqual(["gone-b"]);
+    expect(await moderation.countDeletedUsers("gone-c@example.test")).toBe(1);
+    expect(await moderation.countDeletedUsers("no-such-account")).toBe(0);
+  });
 });

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -188,13 +188,15 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
     setUserRole: (id: string, body: { makeAdmin: boolean; password: string }) =>
       api.post<{ ok: true }>(`/admin/users/${id}/role`, body),
     // Recently deleted accounts awaiting restore or expiry, newest deletion
-    // first. Keyset-paginated like the live table.
-    deletedUsers: (cursor?: string | null, limit?: number) => {
+    // first. Optional handle / name / email filter, keyset-paginated like
+    // the live table.
+    deletedUsers: (cursor?: string | null, limit?: number, q?: string) => {
       const params = new URLSearchParams();
+      if (q) params.set("q", q);
       if (cursor) params.set("cursor", cursor);
       if (limit) params.set("limit", String(limit));
       const qs = params.toString();
-      return api.get<{ users: DeletedUser[]; nextCursor: string | null; total: number }>(
+      return api.get<{ users: DeletedUser[]; nextCursor: string | null; total: number; filteredTotal: number }>(
         `/admin/users/deleted${qs ? `?${qs}` : ""}`,
       );
     },

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -54,11 +54,17 @@
   // deletion first, cursor-paginated like the live table.
   let deleted = $state<DeletedUser[]>([]);
   let deletedTotal = $state(0);
+  let deletedFilteredTotal = $state(0);
   let deletedNextCursor = $state<string | null>(null);
   let deletedLoading = $state(true);
   let deletedLoadingMore = $state(false);
   let deletedError = $state("");
+  let deletedQuery = $state("");
   let deletedSeq = 0;
+
+  // Ticking clock for the retention countdown (see onMount): a plain
+  // Date.now() call would freeze "N days left" at page-load time.
+  let now = $state(Date.now());
 
   // GitHub-style delete confirmation: type the account's username and re-enter
   // the admin's own password. Both travel with the request; the server
@@ -125,10 +131,15 @@
       deletedLoadingMore = true;
     }
     try {
-      const res = await endpoints().deletedUsers(reset ? null : deletedNextCursor);
+      const res = await endpoints().deletedUsers(
+        reset ? null : deletedNextCursor,
+        undefined,
+        deletedQuery.trim() || undefined,
+      );
       if (my !== deletedSeq) return;
       deleted = reset ? res.users : [...deleted, ...res.users.filter((d) => !deleted.some((x) => x.id === d.id))];
       deletedTotal = res.total;
+      deletedFilteredTotal = res.filteredTotal;
       deletedNextCursor = res.nextCursor;
     } catch (e) {
       if (my !== deletedSeq) return;
@@ -145,12 +156,36 @@
   onMount(() => {
     load();
     loadDeleted();
+    // The retention countdown reads this, so "N days left" rolls over while
+    // the tab sits open rather than freezing at load time.
+    const clock = setInterval(() => (now = Date.now()), 60_000);
+    return () => clearInterval(clock);
   });
 
   let searchTimer: ReturnType<typeof setTimeout>;
   function onSearch() {
     clearTimeout(searchTimer);
     searchTimer = setTimeout(() => load(true), 250);
+  }
+
+  function clearSearch() {
+    if (!query) return;
+    clearTimeout(searchTimer);
+    query = "";
+    load(true);
+  }
+
+  let deletedSearchTimer: ReturnType<typeof setTimeout>;
+  function onDeletedSearch() {
+    clearTimeout(deletedSearchTimer);
+    deletedSearchTimer = setTimeout(() => loadDeleted(true), 250);
+  }
+
+  function clearDeletedSearch() {
+    if (!deletedQuery) return;
+    clearTimeout(deletedSearchTimer);
+    deletedQuery = "";
+    loadDeleted(true);
   }
 
   async function toggleSuspend(u: AdminUser) {
@@ -680,7 +715,7 @@
 
   // Whole days until the retention window ends, for the "expires in N days" label.
   function daysLeft(iso: string): number {
-    return Math.max(0, Math.ceil((new Date(iso).getTime() - Date.now()) / 86_400_000));
+    return Math.max(0, Math.ceil((new Date(iso).getTime() - now) / 86_400_000));
   }
 
   const field =
@@ -766,8 +801,18 @@
       oninput={onSearch}
       placeholder="Search by handle, name, or email"
       aria-label="Search accounts by handle, name, or email"
-      class="w-full rounded-input border border-input bg-background py-2.5 pr-3.5 pl-9 text-sm shadow-btn outline-hidden placeholder:text-muted-foreground focus:border-foreground"
+      class="w-full rounded-input border border-input bg-background py-2.5 pr-9 pl-9 text-sm shadow-btn outline-hidden placeholder:text-muted-foreground focus:border-foreground"
     />
+    {#if query}
+      <button
+        type="button"
+        onclick={clearSearch}
+        aria-label="Clear search"
+        class="absolute top-1/2 right-2.5 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-input text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <Icon name="close" size={14} />
+      </button>
+    {/if}
   </div>
 
   <div class="flex flex-wrap gap-x-5 gap-y-3" role="group" aria-label="Filter accounts">
@@ -795,7 +840,9 @@
   {#if loading}
     <p class="py-8 text-center text-sm text-muted-foreground">Loading…</p>
   {:else if users.length === 0}
-    <p class="py-8 text-center text-sm text-muted-foreground">No accounts found.</p>
+    <p class="py-8 text-center text-sm text-muted-foreground">
+      {isFiltering ? "No accounts match." : "No accounts found."}
+    </p>
   {:else}
     <ul class="flex flex-col divide-y divide-border">
       {#each users as u (u.id)}
@@ -1003,6 +1050,11 @@
       <Icon name="clock" size={16} />
       {#if deletedLoading}
         <span>Loading recently deleted…</span>
+      {:else if deletedQuery.trim()}
+        <span>
+          {deletedFilteredTotal} of {deletedTotal}
+          {deletedTotal === 1 ? "account" : "accounts"} · showing {deleted.length}
+        </span>
       {:else}
         <span>
           Recently deleted ({deletedTotal}) — restorable until the retention window ends{deletedNextCursor
@@ -1012,11 +1064,37 @@
       {/if}
     </div>
 
+    <div class="relative mt-3">
+      <span class="pointer-events-none absolute top-1/2 left-3 -translate-y-1/2 text-muted-foreground">
+        <Icon name="search" size={16} />
+      </span>
+      <input
+        type="search"
+        bind:value={deletedQuery}
+        oninput={onDeletedSearch}
+        placeholder="Search deleted by handle, name, or email"
+        aria-label="Search deleted accounts by handle, name, or email"
+        class="w-full rounded-input border border-input bg-background py-2.5 pr-9 pl-9 text-sm shadow-btn outline-hidden placeholder:text-muted-foreground focus:border-foreground"
+      />
+      {#if deletedQuery}
+        <button
+          type="button"
+          onclick={clearDeletedSearch}
+          aria-label="Clear deleted search"
+          class="absolute top-1/2 right-2.5 inline-flex size-6 -translate-y-1/2 items-center justify-center rounded-input text-muted-foreground hover:bg-muted hover:text-foreground"
+        >
+          <Icon name="close" size={14} />
+        </button>
+      {/if}
+    </div>
+
     {#if deletedError}<p class="mt-2 text-sm text-destructive">{deletedError}</p>{/if}
 
     {#if !deletedLoading}
       {#if deleted.length === 0}
-        <p class="py-4 text-center text-sm text-muted-foreground">No deleted accounts.</p>
+        <p class="py-4 text-center text-sm text-muted-foreground">
+          {deletedQuery.trim() ? "No deleted accounts match." : "No deleted accounts."}
+        </p>
       {:else}
         <ul class="flex flex-col divide-y divide-border">
           {#each deleted as d (d.id)}
@@ -1058,7 +1136,7 @@
         {#if deletedNextCursor}
           <div class="mt-4 flex justify-center">
             <Button variant="outline" size="sm" disabled={deletedLoadingMore} onclick={() => loadDeleted(false)}>
-              {deletedLoadingMore ? "Loading…" : `Load more (${deleted.length} of ${deletedTotal})`}
+              {deletedLoadingMore ? "Loading…" : `Load more (${deleted.length} of ${deletedFilteredTotal})`}
             </Button>
           </div>
         {/if}

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -1376,3 +1376,11 @@
     </Dialog.Content>
   </Dialog.Portal>
 </Dialog.Root>
+
+<style>
+  /* The searches carry their own clear button (with empty-query handling),
+  so the browser-native one would double up in WebKit. */
+  input[type="search"]::-webkit-search-cancel-button {
+    display: none;
+  }
+</style>


### PR DESCRIPTION
## Symptom

Three papercuts in Admin → Users. The restore list was the only table with no search. Both search boxes had no clear action — filtering to zero results meant selecting and deleting text by hand. The 'N days left' retention countdown read `Date.now()` once, freezing if the tab sat open past midnight.

## Fix

- `GET /admin/users/deleted` takes `?q=` (handle/name/email, same escaping as the live table) and returns `filteredTotal`; the restore section gets a debounced search box with header counts and Load-more labels to match.
- Clear (×) buttons on both search boxes; clearing reloads the unfiltered list.
- A minute-ticking clock behind `daysLeft` so the countdown rolls over in an open tab.
- Empty states distinguish 'no data' from 'no match' in both lists.

## Verified

- `deno check` on touched backend files; `svelte-check` 0 errors; `vitest run src/` 307 passed; `oxlint` + `oxfmt` clean in both apps.
- New test: deleted-list search matches handle and email, misses cleanly.
- NOT run: `test:integration` (needs Postgres; `DATABASE_URL` unset here) — please let CI cover it.

## Deploy notes

Plain redeploy; no migrations, no config changes. Additive API changes on the deleted endpoint only.