### PR TITLE
feat(admin): sort user table by newest, oldest, or username

### DIFF
--- a/apps/backend/src/db/repositories/users.ts
+++ b/apps/backend/src/db/repositories/users.ts
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import { and, desc, eq, gte, ilike, lt, ne, or, type SQL, sql } from "drizzle-orm";
+import { and, desc, eq, gt, gte, ilike, lt, ne, or, type SQL, sql } from "drizzle-orm";
+import { asc as ascCol } from "drizzle-orm";
 import { alias } from "drizzle-orm/pg-core";
 import { db } from "@/db/client.ts";
 import { type ActorKeyPair, follows, type NewUser, sessions, users } from "@/db/schema.ts";
@@ -145,12 +146,53 @@ export type AdminUserFilter = {
   verified?: boolean;
 };
 
-// Live local accounts for the admin user table: newest first, optional handle /
+// Sort orders for the admin user table. `newest` is the historical default
+// (joined most recently first); `oldest` walks the same key the other way for
+// finding the founding accounts without paging to the end; `username` is an
+// A–Z handle listing for answering "is X on this instance?".
+export type AdminUserSort = "newest" | "oldest" | "username";
+
+// Opaque page token for the sortable admin list. The tuple mirrors the row's
+// position in the requested order: a (created_at, id) instant pair for the two
+// time orders, a (username, id) string pair for the handle order. Two shapes
+// are needed because SQL compares the time and handle keys with different
+// operators and collations; the `v` tag (`t` vs `u`) lets decode tell them
+// apart without probing. Legacy (created_at, id) tokens minted before sorting
+// existed decode as `{ v: "t", ... }` and keep working as `newest` cursors.
+export type AdminCursor = { v: "t"; createdAt: string; id: string } | { v: "u"; username: string; id: string };
+
+export function encodeAdminCursor(c: AdminCursor): string {
+  return btoa(c.v === "t" ? `t|${c.createdAt}|${c.id}` : `u|${c.username}|${c.id}`);
+}
+
+export function decodeAdminCursor(raw: string | undefined | null): AdminCursor | null {
+  if (!raw) return null;
+  try {
+    const parts = atob(raw).split("|");
+    // Legacy two-part `createdAt|id` token: a newest-order cursor.
+    if (parts.length === 2) {
+      const [createdAt, id] = parts;
+      if (!createdAt || !id) return null;
+      return { v: "t", createdAt, id };
+    }
+    if (parts.length !== 3) return null;
+    const [v, key, id] = parts;
+    if (!key || !id) return null;
+    if (v === "t") return { v: "t", createdAt: key, id };
+    if (v === "u") return { v: "u", username: key, id };
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// Live local accounts for the admin user table, optional handle /
 // name / email substring filter plus the triage filters. Deleted accounts are
 // excluded — they have their own restore list (listDeleted). Keyset-paginated
-// over (created_at, id): pass the previous page's `nextCursor` to continue.
-// Fetches limit + 1 rows so the service can derive the next cursor without a
-// second query. Returns full rows (the admin serializer picks fields).
+// in `sort` order (see AdminUserSort): pass the previous page's `nextCursor`
+// to continue, with the same sort. Fetches limit + 1 rows so the service can
+// derive the next cursor without a second query. Returns full rows (the admin
+// serializer picks fields).
 export const ADMIN_USERS_PAGE_SIZE = 50;
 export const ADMIN_USERS_MAX_PAGE_SIZE = 100;
 
@@ -168,26 +210,47 @@ function adminConditions(query = "", filter: AdminUserFilter = {}): (SQL | undef
   return conditions;
 }
 
-// Rows strictly older than the cursor in (created_at, id) order.
-function adminBeforeCursor(cursor: Cursor | null) {
+// Rows strictly beyond the cursor in `sort` order. Each sort mirrors its
+// ORDER BY exactly (comparison direction + tiebreak), otherwise pages skip or
+// repeat rows. Time sorts tiebreak on id so rows sharing a timestamp still
+// page deterministically; the username sort tiebreaks on id too so a renamed
+// account that collides on handle cannot strand a row.
+function adminAfterCursor(cursor: AdminCursor | null, sort: AdminUserSort) {
   if (!cursor) return undefined;
+  if (sort === "username") {
+    if (cursor.v !== "u") return undefined;
+    return or(gt(users.username, cursor.username), and(eq(users.username, cursor.username), gt(users.id, cursor.id)));
+  }
+  if (cursor.v !== "t") return undefined;
   const ts = new Date(cursor.createdAt);
+  if (sort === "oldest") {
+    return or(gt(users.createdAt, ts), and(eq(users.createdAt, ts), gt(users.id, cursor.id)));
+  }
   return or(lt(users.createdAt, ts), and(eq(users.createdAt, ts), lt(users.id, cursor.id)));
 }
 
 export function listForAdmin(
   query = "",
   filter: AdminUserFilter = {},
-  cursor: Cursor | null = null,
+  cursor: AdminCursor | null = null,
   limit = ADMIN_USERS_PAGE_SIZE,
+  sort: AdminUserSort = "newest",
 ) {
   const capped = Math.min(Math.max(Math.trunc(limit) || ADMIN_USERS_PAGE_SIZE, 1), ADMIN_USERS_MAX_PAGE_SIZE);
   // `and()` drops undefined operands, so unset dimensions stay unfiltered.
+  // A cursor minted for another sort is ignored (restarts at page one) rather
+  // than applied against the wrong key, which would silently skip rows.
   return db
     .select()
     .from(users)
-    .where(and(...adminConditions(query, filter), adminBeforeCursor(cursor)))
-    .orderBy(desc(users.createdAt), desc(users.id))
+    .where(and(...adminConditions(query, filter), adminAfterCursor(cursor, sort)))
+    .orderBy(
+      ...(sort === "username"
+        ? [ascCol(users.username), ascCol(users.id)]
+        : sort === "oldest"
+          ? [ascCol(users.createdAt), ascCol(users.id)]
+          : [desc(users.createdAt), desc(users.id)]),
+    )
     .limit(capped + 1);
 }
 

--- a/apps/backend/src/routes/admin.ts
+++ b/apps/backend/src/routes/admin.ts
@@ -2,7 +2,12 @@
 import { Hono } from "hono";
 import { z } from "zod";
 import { rotateSessionSecret, sessionSecretManaged } from "@/config.ts";
-import { ADMIN_USERS_PAGE_SIZE, DELETED_USERS_PAGE_SIZE } from "@/db/repositories/users.ts";
+import {
+  ADMIN_USERS_PAGE_SIZE,
+  type AdminUserSort,
+  DELETED_USERS_PAGE_SIZE,
+  decodeAdminCursor,
+} from "@/db/repositories/users.ts";
 import { badRequest } from "@/lib/http.ts";
 import { decodeCursor } from "@/lib/pagination.ts";
 import { jsonBody } from "@/lib/validate.ts";
@@ -300,11 +305,14 @@ function flag(v: string | undefined): boolean | undefined {
   return v === "true" ? true : v === "false" ? false : undefined;
 }
 
-// The admin user table, with an optional handle / name / email filter (?q=)
-// and triage filters (?suspended=&admin=&verified=true|false). Keyset-paginated
-// over (created_at, id): `?cursor=` continues from the previous page's
-// `nextCursor`, `?limit=` sizes the page (1–100, default 50). `total` is the
-// unfiltered local-account count; `filteredTotal` matches the current filter.
+// The admin user table, with an optional handle / name / email filter (?q=),
+// triage filters (?suspended=&admin=&verified=true|false) and a sort order
+// (?sort=newest|oldest|username, default newest). Keyset-paginated in that
+// order: `?cursor=` continues from the previous page's `nextCursor` (minted
+// for the same sort — a cursor from another sort restarts at page one),
+// `?limit=` sizes the page (1–100, default 50). Unknown `sort` values fall
+// back to newest so a stale bookmark still lists. `total` is the unfiltered
+// local-account count; `filteredTotal` matches the current filter.
 adminRoutes.get("/users", async (c) => {
   requireAdmin(c);
   const q = c.req.query("q") ?? "";
@@ -313,11 +321,13 @@ adminRoutes.get("/users", async (c) => {
     admin: flag(c.req.query("admin")),
     verified: flag(c.req.query("verified")),
   };
-  const cursor = decodeCursor(c.req.query("cursor"));
+  const rawSort = c.req.query("sort");
+  const sort: AdminUserSort = rawSort === "oldest" || rawSort === "username" ? rawSort : "newest";
+  const cursor = decodeAdminCursor(c.req.query("cursor"));
   const limitRaw = Number.parseInt(c.req.query("limit") ?? "", 10);
   const limit = Number.isFinite(limitRaw) ? limitRaw : ADMIN_USERS_PAGE_SIZE;
   const [{ users, nextCursor }, total, filteredTotal] = await Promise.all([
-    moderation.listUsers(q, filter, cursor, limit),
+    moderation.listUsers(q, filter, cursor, limit, sort),
     moderation.countUsers(),
     moderation.countFilteredUsers(q, filter),
   ]);

--- a/apps/backend/src/services/moderation.ts
+++ b/apps/backend/src/services/moderation.ts
@@ -12,7 +12,7 @@ import * as sessionsRepo from "@/db/repositories/sessions.ts";
 import * as tagsRepo from "@/db/repositories/tags.ts";
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import * as usersRepo from "@/db/repositories/users.ts";
-import type { AdminUserFilter } from "@/db/repositories/users.ts";
+import type { AdminCursor, AdminUserFilter, AdminUserSort } from "@/db/repositories/users.ts";
 import type { BlockedDomain } from "@/db/schema.ts";
 import { hostMatchesDomain, normalizeDomain } from "@/lib/domain.ts";
 import { badRequest, forbidden, notFound, unauthorized } from "@/lib/http.ts";
@@ -92,26 +92,35 @@ export async function resolveReport(adminId: string, reportId: string, resolutio
 
 // ── Users (admin) ──────────────────────────────────────────────────────────
 
-// One page of the admin user table, newest first. The cursor is opaque —
-// pass back the previous page's `nextCursor`, or null for the first page.
-// `limit` is clamped to the repository's page bounds.
+// One page of the admin user table. The cursor is opaque —
+// pass back the previous page's `nextCursor`, or null for the first page,
+// with the same `sort` it was minted for. `limit` is clamped to the
+// repository's page bounds.
 export async function listUsers(
   query = "",
   filter: AdminUserFilter = {},
-  cursor: Cursor | null = null,
+  cursor: AdminCursor | null = null,
   limit = usersRepo.ADMIN_USERS_PAGE_SIZE,
+  sort: AdminUserSort = "newest",
 ): Promise<{ users: Awaited<ReturnType<typeof usersRepo.listForAdmin>>; nextCursor: string | null }> {
   const capped = Math.min(
     Math.max(Math.trunc(limit) || usersRepo.ADMIN_USERS_PAGE_SIZE, 1),
     usersRepo.ADMIN_USERS_MAX_PAGE_SIZE,
   );
-  const rows = await usersRepo.listForAdmin(query, filter, cursor, capped);
+  const rows = await usersRepo.listForAdmin(query, filter, cursor, capped, sort);
   const hasMore = rows.length > capped;
   const page = hasMore ? rows.slice(0, capped) : rows;
   const last = page.at(-1);
   return {
     users: page,
-    nextCursor: hasMore && last ? encodeCursor({ createdAt: last.createdAt.toISOString(), id: last.id }) : null,
+    nextCursor:
+      hasMore && last
+        ? usersRepo.encodeAdminCursor(
+            sort === "username"
+              ? { v: "u", username: last.username, id: last.id }
+              : { v: "t", createdAt: last.createdAt.toISOString(), id: last.id },
+          )
+        : null,
   };
 }
 

--- a/apps/backend/tests/integration/admin_filters_verify_test.ts
+++ b/apps/backend/tests/integration/admin_filters_verify_test.ts
@@ -8,8 +8,8 @@
 // through Better Auth's own endpoint; the test captures the queued mail job.
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import * as usersRepo from "@/db/repositories/users.ts";
+import { decodeAdminCursor } from "@/db/repositories/users.ts";
 import { HttpError } from "@/lib/http.ts";
-import { decodeCursor } from "@/lib/pagination.ts";
 import { registerHandler } from "@/queue/queue.ts";
 import * as moderation from "@/services/moderation.ts";
 import { closeDb, mkUser, resetDb } from "./harness.ts";
@@ -46,8 +46,9 @@ async function page(
   filter: Parameters<typeof moderation.listUsers>[1] = {},
   cursor: Parameters<typeof moderation.listUsers>[2] = null,
   limit: Parameters<typeof moderation.listUsers>[3] = 50,
+  sort: Parameters<typeof moderation.listUsers>[4] = "newest",
 ) {
-  const { users } = await moderation.listUsers(query, filter, cursor, limit);
+  const { users } = await moderation.listUsers(query, filter, cursor, limit, sort);
   return users;
 }
 
@@ -107,13 +108,49 @@ describe("admin user filters", () => {
     expect(first.users).toHaveLength(2);
     expect(first.nextCursor).not.toBeNull();
 
-    const second = await moderation.listUsers("", {}, decodeCursor(first.nextCursor), 2);
+    const second = await moderation.listUsers("", {}, decodeAdminCursor(first.nextCursor), 2);
     expect(second.users).toHaveLength(2);
     expect(second.nextCursor).toBeNull();
 
     const seen = usernames([...first.users, ...second.users]);
     expect(seen).toEqual(["alpha", "beta", "delta", "gamma"]);
     expect(new Set([...first.users, ...second.users].map((u) => u.id)).size).toBe(4);
+  });
+
+  test("sort orders: oldest reverses newest, username lists A-Z", async () => {
+    const newest = await moderation.listUsers("", {}, null, 50, "newest");
+    const oldest = await moderation.listUsers("", {}, null, 50, "oldest");
+    const byName = await moderation.listUsers("", {}, null, 50, "username");
+    // Fixture creation order is alpha, beta, gamma, delta; id ties break time ties.
+    expect(oldest.users.map((u) => u.username)).toEqual(newest.users.map((u) => u.username).toReversed());
+    expect(byName.users.map((u) => u.username)).toEqual(["alpha", "beta", "delta", "gamma"]);
+  });
+
+  test("username pagination walks the whole table without overlap", async () => {
+    const first = await moderation.listUsers("", {}, null, 2, "username");
+    expect(first.users.map((u) => u.username)).toEqual(["alpha", "beta"]);
+    expect(first.nextCursor).not.toBeNull();
+
+    const second = await moderation.listUsers("", {}, decodeAdminCursor(first.nextCursor), 2, "username");
+    expect(second.users.map((u) => u.username)).toEqual(["delta", "gamma"]);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  test("oldest pagination walks the whole table without overlap", async () => {
+    const newest = await moderation.listUsers("", {}, null, 50, "newest");
+    const expected = newest.users.map((u) => u.username).toReversed();
+    const first = await moderation.listUsers("", {}, null, 2, "oldest");
+    const second = await moderation.listUsers("", {}, decodeAdminCursor(first.nextCursor), 2, "oldest");
+    expect([...first.users, ...second.users].map((u) => u.username)).toEqual(expected);
+    expect(second.nextCursor).toBeNull();
+  });
+
+  test("a cursor from another sort restarts at page one", async () => {
+    const newestFirst = await moderation.listUsers("", {}, null, 2, "newest");
+    expect(newestFirst.nextCursor).not.toBeNull();
+    // Reusing a newest cursor with the username sort must not skip rows.
+    const restarted = await moderation.listUsers("", {}, decodeAdminCursor(newestFirst.nextCursor), 2, "username");
+    expect(restarted.users.map((u) => u.username)).toEqual(["alpha", "beta"]);
   });
 });
 

--- a/apps/backend/tests/integration/admin_filters_verify_test.ts
+++ b/apps/backend/tests/integration/admin_filters_verify_test.ts
@@ -60,10 +60,14 @@ describe("admin user filters", () => {
   beforeAll(async () => {
     await resetDb();
 
-    await mkUser("alpha");
-    await mkUser("beta", { suspended: true });
-    await mkUser("gamma", { isAdmin: true });
-    const delta = await mkUser("delta");
+    // Distinct creation instants, oldest first: the time sorts then have a
+    // total order to assert on, instead of racing the clock and falling back
+    // to id order (see mkUser `createdAt`).
+    const base = Date.now();
+    await mkUser("alpha", { createdAt: new Date(base) });
+    await mkUser("beta", { suspended: true, createdAt: new Date(base + 1_000) });
+    await mkUser("gamma", { isAdmin: true, createdAt: new Date(base + 2_000) });
+    const delta = await mkUser("delta", { createdAt: new Date(base + 3_000) });
     await usersRepo.update(delta.id, { emailVerified: true });
   });
 
@@ -117,12 +121,13 @@ describe("admin user filters", () => {
     expect(new Set([...first.users, ...second.users].map((u) => u.id)).size).toBe(4);
   });
 
-  test("sort orders: oldest reverses newest, username lists A-Z", async () => {
+  test("sort orders: newest is reverse-chronological, oldest its mirror, username A-Z", async () => {
     const newest = await moderation.listUsers("", {}, null, 50, "newest");
     const oldest = await moderation.listUsers("", {}, null, 50, "oldest");
     const byName = await moderation.listUsers("", {}, null, 50, "username");
-    // Fixture creation order is alpha, beta, gamma, delta; id ties break time ties.
-    expect(oldest.users.map((u) => u.username)).toEqual(newest.users.map((u) => u.username).toReversed());
+    // Fixture creation order is alpha, beta, gamma, delta (distinct instants).
+    expect(newest.users.map((u) => u.username)).toEqual(["delta", "gamma", "beta", "alpha"]);
+    expect(oldest.users.map((u) => u.username)).toEqual(["alpha", "beta", "gamma", "delta"]);
     expect(byName.users.map((u) => u.username)).toEqual(["alpha", "beta", "delta", "gamma"]);
   });
 
@@ -137,11 +142,10 @@ describe("admin user filters", () => {
   });
 
   test("oldest pagination walks the whole table without overlap", async () => {
-    const newest = await moderation.listUsers("", {}, null, 50, "newest");
-    const expected = newest.users.map((u) => u.username).toReversed();
     const first = await moderation.listUsers("", {}, null, 2, "oldest");
+    expect(first.users.map((u) => u.username)).toEqual(["alpha", "beta"]);
     const second = await moderation.listUsers("", {}, decodeAdminCursor(first.nextCursor), 2, "oldest");
-    expect([...first.users, ...second.users].map((u) => u.username)).toEqual(expected);
+    expect(second.users.map((u) => u.username)).toEqual(["gamma", "delta"]);
     expect(second.nextCursor).toBeNull();
   });
 

--- a/apps/backend/tests/integration/harness.ts
+++ b/apps/backend/tests/integration/harness.ts
@@ -52,7 +52,16 @@ export async function closeDb(): Promise<void> {
 // Deliberately terse: a visibility test should read as a sentence about who
 // can see what, not as twenty lines of insert boilerplate.
 
-export type UserOpts = { isPrivate?: boolean; suspended?: boolean; isAdmin?: boolean; deleted?: boolean };
+export type UserOpts = {
+  isPrivate?: boolean;
+  suspended?: boolean;
+  isAdmin?: boolean;
+  deleted?: boolean;
+  // Explicit creation instant. Lets a test pin row order without racing the
+  // clock — rows minted in the same millisecond otherwise share a timestamp
+  // and fall back to id order, which can surprise an order assertion.
+  createdAt?: Date;
+};
 
 export async function mkUser(username: string, opts: UserOpts = {}) {
   const [row] = await db
@@ -66,6 +75,7 @@ export async function mkUser(username: string, opts: UserOpts = {}) {
       isAdmin: opts.isAdmin ?? false,
       suspendedAt: opts.suspended ? new Date() : null,
       deletedAt: opts.deleted ? new Date() : null,
+      ...(opts.createdAt ? { createdAt: opts.createdAt, updatedAt: opts.createdAt } : {}),
     })
     .returning();
   return row;

--- a/apps/frontend/src/lib/api/index.ts
+++ b/apps/frontend/src/lib/api/index.ts
@@ -137,12 +137,14 @@ export function endpoints(fetchFn?: typeof globalThis.fetch) {
       q?: string,
       filters?: { suspended?: boolean; admin?: boolean; verified?: boolean },
       page?: { cursor?: string | null; limit?: number },
+      sort?: "newest" | "oldest" | "username",
     ) => {
       const params = new URLSearchParams();
       if (q) params.set("q", q);
       if (filters?.suspended !== undefined) params.set("suspended", String(filters.suspended));
       if (filters?.admin !== undefined) params.set("admin", String(filters.admin));
       if (filters?.verified !== undefined) params.set("verified", String(filters.verified));
+      if (sort && sort !== "newest") params.set("sort", sort);
       if (page?.cursor) params.set("cursor", page.cursor);
       if (page?.limit) params.set("limit", String(page.limit));
       const qs = params.toString();

--- a/apps/frontend/src/lib/components/AdminUsers.svelte
+++ b/apps/frontend/src/lib/components/AdminUsers.svelte
@@ -50,6 +50,24 @@
     load(true);
   }
 
+  // Table sort: newest (joined most recently first, the default), oldest
+  // (founding accounts first) and username (A–Z handle order). Changing it
+  // reloads from page one — cursors are minted per sort and don't transfer.
+  type UserSort = "newest" | "oldest" | "username";
+  let sort = $state<UserSort>("newest");
+  const sortOptions: { value: UserSort; label: string }[] = [
+    { value: "newest", label: "Newest" },
+    { value: "oldest", label: "Oldest" },
+    { value: "username", label: "Username" },
+  ];
+
+  function onSortChange(v: string) {
+    const next = sortOptions.find((o) => o.value === v)?.value ?? "newest";
+    if (next === sort) return;
+    sort = next;
+    load(true);
+  }
+
   // Recently deleted accounts: the retention window's restore list, newest
   // deletion first, cursor-paginated like the live table.
   let deleted = $state<DeletedUser[]>([]);
@@ -94,9 +112,14 @@
       loadingMore = true;
     }
     try {
-      const res = await endpoints().adminUsers(query.trim() || undefined, filterParams(), {
-        cursor: reset ? null : nextCursor,
-      });
+      const res = await endpoints().adminUsers(
+        query.trim() || undefined,
+        filterParams(),
+        {
+          cursor: reset ? null : nextCursor,
+        },
+        sort,
+      );
       if (my !== loadSeq) return;
       users = reset ? res.users : [...users, ...res.users.filter((u) => !users.some((x) => x.id === u.id))];
       total = res.total;
@@ -815,7 +838,23 @@
     {/if}
   </div>
 
-  <div class="flex flex-wrap gap-x-5 gap-y-3" role="group" aria-label="Filter accounts">
+  <div class="flex flex-wrap items-center gap-x-5 gap-y-3" role="group" aria-label="Filter accounts">
+    <div class="flex items-center gap-2">
+      <span class="text-xs font-medium text-muted-foreground">Sort</span>
+      <ToggleGroup.Root
+        type="single"
+        value={sort}
+        onValueChange={onSortChange}
+        class="inline-flex items-center gap-0.5 rounded-input border border-input bg-background-alt p-0.5 shadow-btn"
+        aria-label="Sort accounts"
+      >
+        {#each sortOptions as o (o.value)}
+          <ToggleGroup.Item value={o.value} aria-label={`Sort accounts: ${o.label}`} class={segItemClass}>
+            {o.label}
+          </ToggleGroup.Item>
+        {/each}
+      </ToggleGroup.Root>
+    </div>
     {#each triFilters as f (f.label)}
       <div class="flex items-center gap-2">
         <span class="text-xs font-medium text-muted-foreground">{f.label}</span>


### PR DESCRIPTION
## Symptom

The admin user table was newest-only. Finding the founding accounts meant paging to the end of the table, and answering 'is X on this instance?' meant searching blind instead of scanning an A-Z handle listing.

## Root cause

`listForAdmin` had a single hard-coded order (`created_at DESC, id DESC`) with one cursor shape, and the route accepted no sort parameter — confirmed by the absence of any `sort` handling in `apps/backend/src/routes/admin.ts` and `services/moderation.ts` before this change.

## Fix (and why this shape)

- `GET /admin/users` accepts `?sort=newest|oldest|username` (default `newest`; unknown values fall back to `newest` so stale bookmarks still list).
- New `AdminUserSort` / `AdminCursor` in the users repository: tagged cursors (`t|createdAt|id` for the time sorts, `u|username|id` for the handle sort). Pre-sort two-part tokens decode as newest cursors, so in-flight pagination doesn't break on upgrade.
- One mirrored keyset condition per order (`adminAfterCursor`), each matching its `ORDER BY` + tiebreak exactly — the alternative (one generic comparator) would skip or repeat rows at page boundaries.
- A cursor minted for another sort is ignored (restarts at page one) rather than applied against the wrong key, which would silently skip rows.
- Frontend: `adminUsers()` takes an optional 4th `sort` arg (omitted when `newest`); `AdminUsers.svelte` gains a Sort segmented control (Bits UI ToggleGroup, same styling as the filter segments) beside the triage filters. Changing sort reloads from page one.
- No migration: the username sort rides the existing `users_username_idx` unique index.

## Verified

- Backend: `pnpm check`, `pnpm lint`, `pnpm fmt:check` clean; unit suite 29 files / 307 tests passed.
- Frontend: `svelte-check`, `lint`, `fmt:check` clean; `vitest` 8 files / 34 tests passed.
- Integration (`admin_filters_verify_test.ts` — order, per-sort full pagination walks, cross-sort restart) written but **not run**: no Postgres available in this environment. Needs CI's `pnpm test:integration`.

## Deploy notes

Plain `docker compose up -d` suffices — no migration, no env change, no restart-only config.